### PR TITLE
Restructured  the way the live cursor location information is harvested and rendered

### DIFF
--- a/pkg/gql/ChannelValue.py
+++ b/pkg/gql/ChannelValue.py
@@ -25,7 +25,11 @@ class ChannelValue(graphene.ObjectType):
         """
         # extract the value
         value = context["rep"]
-        # and render
+        # if it's a string
+        if isinstance(value, str):
+            # leave it alone
+            return value
+        # otherwise, render it and return it
         return f"{value:10.4g}"
 
 

--- a/pkg/readers/isce2/interferogram/Dataset.py
+++ b/pkg/readers/isce2/interferogram/Dataset.py
@@ -65,6 +65,9 @@ class Dataset(
         """
         Build a family of value representations at the given {pixel}
         """
+        # build the cursor rep
+        yield "cursor", [(f"{pixel}", "pixels")]
+
         # get my data type
         cell = self.cell
         # my channels

--- a/pkg/readers/isce2/interferogram/Dataset.py
+++ b/pkg/readers/isce2/interferogram/Dataset.py
@@ -66,7 +66,7 @@ class Dataset(
         Build a family of value representations at the given {pixel}
         """
         # build the cursor rep
-        yield "cursor", [(f"{pixel}", "pixels")]
+        yield "cursor", [(f"{pixel}", "pixel")]
 
         # get my data type
         cell = self.cell

--- a/pkg/readers/isce2/unwrapped/Dataset.py
+++ b/pkg/readers/isce2/unwrapped/Dataset.py
@@ -65,6 +65,9 @@ class Dataset(
         """
         Build a family of value representations at the given {pixel}
         """
+        # build the cursor rep
+        yield "cursor", [(f"{pixel}", "pixels")]
+
         # get the pixel value
         _, _, amplitude, phase = self.profile(points=[pixel])[0]
 

--- a/pkg/readers/isce2/unwrapped/Dataset.py
+++ b/pkg/readers/isce2/unwrapped/Dataset.py
@@ -66,7 +66,7 @@ class Dataset(
         Build a family of value representations at the given {pixel}
         """
         # build the cursor rep
-        yield "cursor", [(f"{pixel}", "pixels")]
+        yield "cursor", [(f"{pixel}", "pixel")]
 
         # get the pixel value
         _, _, amplitude, phase = self.profile(points=[pixel])[0]

--- a/pkg/readers/native/datasets/GDALBand.py
+++ b/pkg/readers/native/datasets/GDALBand.py
@@ -70,6 +70,9 @@ class GDALBand(
         # and the value of the {pixel}
         _, _, value = self.profile(points=[pixel])[0]
 
+        # build the cursor rep
+        yield "cursor", [(f"{pixel}", "pixels")]
+
         # go through the channels marked as special by my data type
         for name in cell.summary:
             # get the corresponding channel

--- a/pkg/readers/native/datasets/GDALBand.py
+++ b/pkg/readers/native/datasets/GDALBand.py
@@ -71,7 +71,7 @@ class GDALBand(
         _, _, value = self.profile(points=[pixel])[0]
 
         # build the cursor rep
-        yield "cursor", [(f"{pixel}", "pixels")]
+        yield "cursor", [(f"{pixel}", "pixel")]
 
         # go through the channels marked as special by my data type
         for name in cell.summary:

--- a/pkg/readers/native/datasets/MemoryMap.py
+++ b/pkg/readers/native/datasets/MemoryMap.py
@@ -72,7 +72,7 @@ class MemoryMap(
         _, _, value = self.profile(points=[pixel])[0]
 
         # build the cursor rep
-        yield "cursor", [(f"{pixel}", "pixels")]
+        yield "cursor", [(f"{pixel}", "pixel")]
 
         # go through the channels marked as special by my data type
         for name in cell.summary:

--- a/pkg/readers/native/datasets/MemoryMap.py
+++ b/pkg/readers/native/datasets/MemoryMap.py
@@ -71,6 +71,9 @@ class MemoryMap(
         # and the value of the {pixel}
         _, _, value = self.profile(points=[pixel])[0]
 
+        # build the cursor rep
+        yield "cursor", [(f"{pixel}", "pixels")]
+
         # go through the channels marked as special by my data type
         for name in cell.summary:
             # get the corresponding channel

--- a/pkg/readers/nisar/products/Product.py
+++ b/pkg/readers/nisar/products/Product.py
@@ -64,6 +64,9 @@ class Product(
         """
         Build a family of value representations at the given {pixel}
         """
+        # generate cursor information
+        yield from self.cursor(pixel=pixel)
+
         # get my data type
         cell = self.cell
         # my channels
@@ -94,6 +97,15 @@ class Product(
         )
         # and return it
         return profile
+
+    def cursor(self, pixel):
+        """
+        Render information about the cursor position
+        """
+        # build the cursor rep
+        yield "cursor", [(f"{pixel}", "pixel")]
+        # all done
+        return
 
     def render(self, channel, zoom, origin, shape):
         """

--- a/ux/client/views/viz/controls/measure/path/button.js
+++ b/ux/client/views/viz/controls/measure/path/button.js
@@ -29,8 +29,7 @@ export const Button = ({ size = 12, behaviors, children, ...rest }) => {
 }
 
 
-const Mark = styled.span`
-    display: inline-block;
+const Mark = styled.div`
     width: 2.0rem;
     text-align: end;
 `

--- a/ux/client/views/viz/controls/measure/path/coordinate.js
+++ b/ux/client/views/viz/controls/measure/path/coordinate.js
@@ -89,7 +89,7 @@ const Base = styled.input`
     outline: none;
     cursor: pointer;
     font-family: inconsolata;
-    font-size: 100%;
+    font-size: 110%;
     width: 3.0rem;
     text-align: end;
     background-color: hsl(0deg, 0%, 7%);

--- a/ux/client/views/viz/controls/measure/path/delete.js
+++ b/ux/client/views/viz/controls/measure/path/delete.js
@@ -37,7 +37,7 @@ export const Delete = ({ idx }) => {
 
     // render
     return (
-        <Button size={10} behaviors={behaviors}>
+        <Button size={12} behaviors={behaviors}>
             <X />
         </Button>
     )

--- a/ux/client/views/viz/controls/measure/path/point.js
+++ b/ux/client/views/viz/controls/measure/path/point.js
@@ -42,8 +42,12 @@ export const Point = ({ idx, point, last }) => {
 
 // the container
 const Box = styled.div`
+    display: flex;
+    align-items: end;
     font-family: inconsolata;
-    padding: 0.2rem 0.0rem;
+    height: 1.2em;
+    margin: 0em;
+    padding: 0.125rem 0.0rem;
 `
 
 

--- a/ux/client/views/viz/controls/measure/peek/channel.js
+++ b/ux/client/views/viz/controls/measure/peek/channel.js
@@ -38,7 +38,7 @@ const Entry = styled.div`
     display: flex;
     align-items: end;
     height: 1.2em;
-    margin: 0.0rem 0.0rem 0.0rem 0.0rem;
+    margin: 0.0rm;
     padding: 0.0rem 0.0rem 0.25rem 0.0rem;
 `
 

--- a/ux/client/views/viz/controls/measure/peek/channel.js
+++ b/ux/client/views/viz/controls/measure/peek/channel.js
@@ -35,40 +35,36 @@ export const Channel = ({ channel, reps }) => {
 
 // the container
 const Entry = styled.div`
+    display: flex;
+    align-items: end;
+    height: 1.2em;
+    margin: 0.0rem 0.0rem 0.0rem 0.0rem;
+    padding: 0.0rem 0.0rem 0.25rem 0.0rem;
 `
 
-const Label = styled.span`
-    display: inline-block;
+const Label = styled.div`
     font-family: rubik-light;
     width: 4.0rem;
     text-align: end;
     text-transform: uppercase;
-    padding: 0.0rem 0.0rem 0.25rem 0.0rem;
-    margin: 0.0rem 0.0rem 0.1rem 0.0rem;
     cursor: default;
 `
 
-const Value = styled.span`
-    display: inline-block;
+const Value = styled.div`
     font-family: inconsolata;
-    cursor: default;
-    width: 3.25rem;
+    font-size: 110%;
+    width: 6.0rem;
     text-align: end;
-    padding: 0.0rem;
     overflow: clip;
-    padding: 0.0rem 0.0rem 0.0rem 0.5rem;
     cursor: default;
 `
 
 // the state control
-const Button = styled.button`
+const Button = styled.div`
     & {
         cursor: pointer;
         font-family: rubik-light;
         text-align: start;
-        color: inherit;
-        background-color: transparent;
-        border: 0 transparent;
         margin: 0.0rem;
         padding: 0.0rem 0.0rem 0.0rem 0.5rem;
     }

--- a/ux/client/views/viz/controls/measure/peek/peek.js
+++ b/ux/client/views/viz/controls/measure/peek/peek.js
@@ -84,10 +84,6 @@ const Panel = () => {
             <Header>
                 {/* the label */}
                 <Title>peek</Title>
-                {/* the mouse coordinates */}
-                <Coordinate>{pixel[0]}</Coordinate>
-                x
-                <Coordinate>{pixel[1]}</Coordinate>
             </Header>
             {/* the reps */}
             {value.map(({ channel, reps }) => (
@@ -116,12 +112,6 @@ const Title = styled.span`
     margin: 0.0rem 0.0rem 0.1rem 0.0rem;
     cursor: default;
     color: hsl(0deg, 0%, 75%);
-`
-
-const Coordinate = styled.span`
-    font-family: inconsolata;
-    cursor: default;
-    padding: 0.0rem 0.25rem;
 `
 
 

--- a/ux/client/views/viz/controls/sync/body.js
+++ b/ux/client/views/viz/controls/sync/body.js
@@ -12,7 +12,6 @@ import styled from 'styled-components'
 // hooks
 import { useViews } from '../../viz/useViews'
 // components
-import { Cell } from './cell'
 import { Dataset } from './dataset'
 import { Channel } from './channel'
 import { Offset } from './offset'

--- a/ux/client/views/viz/controls/sync/body.js
+++ b/ux/client/views/viz/controls/sync/body.js
@@ -56,15 +56,5 @@ const Viewport = styled.tr`
     vertical-align: middle;
 `
 
-// the dataset
-const ActiveDataset = styled(Cell)`
-    text-align: left;
-    overflow: auto;
-`
-
-const SelectedDataset = styled(ActiveDataset)`
-    color: hsl(28deg, 90%, 55%);
-`
-
 
 // end of file

--- a/ux/client/views/viz/controls/sync/body.js
+++ b/ux/client/views/viz/controls/sync/body.js
@@ -26,7 +26,7 @@ export const Body = () => {
     // render
     return (
         <Container>
-            {views.map(({ dataset, channel }, viewport) => {
+            {views.map(({ dataset }, viewport) => {
                 // render
                 return (
                     <Viewport key={`${dataset.name}:${viewport}`}>

--- a/ux/client/views/viz/controls/sync/channel.js
+++ b/ux/client/views/viz/controls/sync/channel.js
@@ -12,7 +12,7 @@ import React from 'react'
 import { useSynced } from '../../viz/useSynced'
 import { useSyncAspect } from '../../viz/useSyncAspect'
 // components
-import { Cell } from './cell'
+import { Control } from './control'
 import { Toggle } from './toggle'
 
 // the channel sync control
@@ -23,12 +23,12 @@ export const Channel = ({ viewport }) => {
     const { toggle, force } = useSyncAspect()
     // render
     return (
-        <Cell>
+        <Control>
             <Toggle
                 state={synced[viewport].channel}
                 toggle={toggle(viewport, "channel")}
                 force={force(viewport, "channel")} />
-        </Cell>
+        </Control>
     )
 }
 

--- a/ux/client/views/viz/controls/sync/control.js
+++ b/ux/client/views/viz/controls/sync/control.js
@@ -1,0 +1,20 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2024 all rights reserved
+
+
+// externals
+import styled from 'styled-components'
+
+// local
+// components
+import { Cell } from './cell'
+
+
+// cells with controls
+export const Control = styled(Cell)`
+    width: 3.0em;
+`
+
+// end of file

--- a/ux/client/views/viz/controls/sync/coordinate.js
+++ b/ux/client/views/viz/controls/sync/coordinate.js
@@ -52,13 +52,10 @@ export const Coordinate = ({ className, point, axis, adjust }) => {
 // the base entry
 const Base = styled.input`
     display: inline-block;
-    font-size: 110%;
     appearance: textfield;
     outline: none;
     cursor: pointer;
-    font-family: inconsolata;
-    font-size: 100%;
-    width: 2.5em;
+    width: 4.0em;
     background-color: hsl(0deg, 0%, 7%);
     padding: 0.0rem;
     border: 0 transparent;

--- a/ux/client/views/viz/controls/sync/dataset.js
+++ b/ux/client/views/viz/controls/sync/dataset.js
@@ -60,6 +60,8 @@ export const Dataset = ({ viewport, children }) => {
 
 // the styles
 const ActiveDataset = styled(Cell)`
+    font-family: inconsolata;
+    font-size: 110%;
     text-align: left;
     overflow: auto;
     cursor: pointer;

--- a/ux/client/views/viz/controls/sync/offset.js
+++ b/ux/client/views/viz/controls/sync/offset.js
@@ -38,7 +38,10 @@ export const Offset = ({ viewport }) => {
 }
 
 const Housing = styled(Cell)`
-    min-width: 6em;
+    font-family: inconsolata;
+    font-size: 110%;
+    width: 7.5em;
+    min-width: 7.5em;
 `
 
 const Line = styled(Coordinate)`

--- a/ux/client/views/viz/controls/sync/path.js
+++ b/ux/client/views/viz/controls/sync/path.js
@@ -12,7 +12,7 @@ import React from 'react'
 import { useSynced } from '../../viz/useSynced'
 import { useSyncAspect } from '../../viz/useSyncAspect'
 // components
-import { Cell } from './cell'
+import { Control } from './control'
 import { Toggle } from './toggle'
 
 // the path sync control
@@ -23,12 +23,12 @@ export const Path = ({ viewport }) => {
     const { toggle, force } = useSyncAspect()
     // render
     return (
-        <Cell>
+        <Control>
             <Toggle
                 state={synced[viewport].path}
                 toggle={toggle(viewport, "path")}
                 force={force(viewport, "path")} />
-        </Cell>
+        </Control>
     )
 }
 

--- a/ux/client/views/viz/controls/sync/scroll.js
+++ b/ux/client/views/viz/controls/sync/scroll.js
@@ -12,7 +12,7 @@ import React from 'react'
 import { useSynced } from '../../viz/useSynced'
 import { useSyncAspect } from '../../viz/useSyncAspect'
 // components
-import { Cell } from './cell'
+import { Control } from './control'
 import { Toggle } from './toggle'
 
 // the scroll sync control
@@ -23,12 +23,12 @@ export const Scroll = ({ viewport }) => {
     const { toggle, force } = useSyncAspect()
     // render
     return (
-        <Cell>
+        <Control>
             <Toggle
                 state={synced[viewport].scroll}
                 toggle={toggle(viewport, "scroll")}
                 force={force(viewport, "scroll")} />
-        </Cell>
+        </Control>
     )
 }
 

--- a/ux/client/views/viz/controls/sync/sync.js
+++ b/ux/client/views/viz/controls/sync/sync.js
@@ -34,7 +34,6 @@ export const Sync = () => {
 const Housing = styled.table`
     margin: 1.0em auto ;
     padding: 1.0em 0.0em ;
-    font-family: inconsolata;
     color: hsl(0deg, 0%, 50%);
     margin: 0.0rem 0.5rem 0.5rem 0.5rem;
 `

--- a/ux/client/views/viz/controls/sync/zoom.js
+++ b/ux/client/views/viz/controls/sync/zoom.js
@@ -12,7 +12,7 @@ import React from 'react'
 import { useSynced } from '../../viz/useSynced'
 import { useSyncAspect } from '../../viz/useSyncAspect'
 // components
-import { Cell } from './cell'
+import { Control } from './control'
 import { Toggle } from './toggle'
 
 // the zoom sync control
@@ -23,12 +23,12 @@ export const Zoom = ({ viewport }) => {
     const { toggle, force } = useSyncAspect()
     // render
     return (
-        <Cell>
+        <Control>
             <Toggle
                 state={synced[viewport].zoom}
                 toggle={toggle(viewport, "zoom")}
                 force={force(viewport, "zoom")} />
-        </Cell>
+        </Control>
     )
 }
 


### PR DESCRIPTION
Datasets can now report arbitrary information about the cursor location on `peek`. The client renders it just like the other channels, with a clickable description that allows the user to cycle though the available information. As an example, this capability can now be used to let geocoded datasets report geographic information about the cursor location. At this point, only pixel locations are reported, pending a survey of what is possible for each dataset type.

In addition, this PR contains a few improvements to the functionality and style of the `measure` and `sync` controls, and addresses a few relevant issues that were in its neighborhood.
