### PR TITLE
The app is now more accessible from the command line

### DIFF
--- a/bin/qed
+++ b/bin/qed
@@ -19,11 +19,22 @@ journal.firewall("qed.ux.dispatch").fatal = False
 # get the package
 import qed
 
-# build an app instance
-app = qed.shells.qed(name="qed.app")
-# and run it
-status = app.run()
-# pass its exit status on to the shell
+# attempt to
+try:
+    # build an app instance
+    app = qed.shells.qed(name="qed.app")
+    # and invoke it
+    status = app.run()
+# if something goes wrong while configuring the application and its parts
+except qed.shells.qed.ConfigurationError:
+    # the error must have been reported already; bail
+    raise SystemExit(1)
+# if the application reports an error through the journal
+except journal.ApplicationError:
+    # we already have a report; bail
+    raise SystemExit(1)
+
+# if all goes well, pass the app exit status on to the shell
 raise SystemExit(status)
 
 

--- a/pkg/datatypes/Char.py
+++ b/pkg/datatypes/Char.py
@@ -14,5 +14,8 @@ class Char(Integer, family="qed.datatypes.Char"):
     The specification for one byte integers
     """
 
+    # size
+    bytes = 1
+
 
 # end of file

--- a/pkg/datatypes/ComplexDouble.py
+++ b/pkg/datatypes/ComplexDouble.py
@@ -15,5 +15,8 @@ class ComplexDouble(Complex, family="qed.datatypes.complex128"):
     floating point numbers
     """
 
+    # size
+    bytes = 16
+
 
 # end of file

--- a/pkg/datatypes/ComplexFloat.py
+++ b/pkg/datatypes/ComplexFloat.py
@@ -15,5 +15,8 @@ class ComplexFloat(Complex, family="qed.datatypes.complex64"):
     floating point numbers
     """
 
+    # size
+    bytes = 8
+
 
 # end of file

--- a/pkg/datatypes/Double.py
+++ b/pkg/datatypes/Double.py
@@ -14,5 +14,8 @@ class Double(Real, family="qed.datatypes.real64"):
     The specification for double precision floating point numbers
     """
 
+    # size
+    bytes = 8
+
 
 # end of file

--- a/pkg/datatypes/Float.py
+++ b/pkg/datatypes/Float.py
@@ -14,5 +14,8 @@ class Float(Real, family="qed.datatypes.real32"):
     The specification for single precision floating point numbers
     """
 
+    # size
+    bytes = 4
+
 
 # end of file

--- a/pkg/datatypes/Int16.py
+++ b/pkg/datatypes/Int16.py
@@ -14,5 +14,8 @@ class Int16(Integer, family="qed.datatypes.int16"):
     The specification for two byte integers
     """
 
+    # size
+    bytes = 2
+
 
 # end of file

--- a/pkg/datatypes/Int32.py
+++ b/pkg/datatypes/Int32.py
@@ -14,5 +14,8 @@ class Int32(Integer, family="qed.datatypes.int32"):
     The specification for four byte integers
     """
 
+    # size
+    bytes = 4
+
 
 # end of file

--- a/pkg/datatypes/Int64.py
+++ b/pkg/datatypes/Int64.py
@@ -14,5 +14,8 @@ class Int64(Integer, family="qed.datatypes.int64"):
     The specification for eight byte integers
     """
 
+    # size
+    bytes = 8
+
 
 # end of file

--- a/pkg/datatypes/Int8.py
+++ b/pkg/datatypes/Int8.py
@@ -14,5 +14,8 @@ class Int8(Integer, family="qed.datatypes.int8"):
     The specification for one byte integers
     """
 
+    # size
+    bytes = 1
+
 
 # end of file

--- a/pkg/datatypes/Int8.py
+++ b/pkg/datatypes/Int8.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2024 all rights reserved
+
+
+# my base class
+from .Integer import Integer
+
+
+# a 16 bit integer
+class Int8(Integer, family="qed.datatypes.int8"):
+    """
+    The specification for one byte integers
+    """
+
+
+# end of file

--- a/pkg/datatypes/UInt16.py
+++ b/pkg/datatypes/UInt16.py
@@ -14,5 +14,8 @@ class UInt16(Integer, family="qed.datatypes.uint16"):
     The specification for two byte unsigned integers
     """
 
+    # size
+    bytes = 2
+
 
 # end of file

--- a/pkg/datatypes/UInt32.py
+++ b/pkg/datatypes/UInt32.py
@@ -14,5 +14,8 @@ class UInt32(Integer, family="qed.datatypes.uint32"):
     The specification for four byte unsigned integers
     """
 
+    # size
+    bytes = 4
+
 
 # end of file

--- a/pkg/datatypes/UInt64.py
+++ b/pkg/datatypes/UInt64.py
@@ -14,5 +14,8 @@ class UInt64(Integer, family="qed.datatypes.uint64"):
     The specification for eight byte unsigned integers
     """
 
+    # size
+    bytes = 8
+
 
 # end of file

--- a/pkg/datatypes/UInt8.py
+++ b/pkg/datatypes/UInt8.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2024 all rights reserved
+
+
+# my base class
+from .Integer import Integer
+
+
+# a 16 bit unsigned integer
+class UInt8(Integer, family="qed.datatypes.uint8"):
+    """
+    The specification for one byte unsigned integers
+    """
+
+
+# end of file

--- a/pkg/datatypes/UInt8.py
+++ b/pkg/datatypes/UInt8.py
@@ -14,5 +14,8 @@ class UInt8(Integer, family="qed.datatypes.uint8"):
     The specification for one byte unsigned integers
     """
 
+    # size
+    bytes = 1
+
 
 # end of file

--- a/pkg/datatypes/__init__.py
+++ b/pkg/datatypes/__init__.py
@@ -9,24 +9,28 @@
 from .Char import Char as char
 
 # integers
+from .Int8 import Int8 as int8
 from .Int16 import Int16 as int16
 from .Int32 import Int32 as int32
 from .Int64 import Int64 as int64
+from .UInt8 import UInt8 as uint8
 from .UInt16 import UInt16 as uint16
 from .UInt32 import UInt32 as uint32
 from .UInt64 import UInt64 as uint64
 
 # real numbers
-from .Float import Float as float32
-from .Double import Double as float64
+from .Float import Float as float
+from .Double import Double as double
 
 # complex numbers
 from .ComplexFloat import ComplexFloat as complex64
 from .ComplexDouble import ComplexDouble as complex128
 
 # aliases
-real32 = float32
-real64 = float64
+float32 = float
+float64 = double
+real32 = float
+real64 = double
 
 # gdal
 # NYI: cint16, cint32

--- a/pkg/exceptions.py
+++ b/pkg/exceptions.py
@@ -15,23 +15,4 @@ class QEDError(PyreError):
     """
 
 
-# component configuration errors
-class ConfigurationError(QEDError):
-    """
-    Exception raised when qed components detect inconsistencies in their configurations
-    """
-
-    # public data
-    description = "configuration error: {0.reason}"
-
-    # meta-methods
-    def __init__(self, reason, **kwds):
-        # chain up
-        super().__init__(**kwds)
-        # save the error info
-        self.reason = reason
-        # all done
-        return
-
-
 # end of file

--- a/pkg/gql/ConnectReader.py
+++ b/pkg/gql/ConnectReader.py
@@ -54,22 +54,10 @@ class ConnectReader(graphene.Mutation):
         if cell:
             # add it to the pile
             args["cell"] = cell
-
-        # make a channel
-        channel = journal.info("qed.gql.connect")
-        channel.line(f"{reader=}")
-        channel.line(f"{name=}")
-        channel.line(f"{uri=}")
-        channel.line(f"{lines=}, {samples=}")
-        channel.line(f"{cell=}")
-        channel.log()
-
         # resolve the {reader} into a factory
         factory = qed.protocols.reader.pyre_resolveSpecification(spec=reader)
-        channel.log(f"{factory=}")
         # instantiate
         source = factory(**args)
-        channel.log(f"{source=}")
         # get the panel
         panel = info.context["panel"]
         # add the new source to the panel

--- a/pkg/protocols/Datatype.py
+++ b/pkg/protocols/Datatype.py
@@ -6,8 +6,10 @@
 
 # externals
 import sys
+
 # support
 import qed
+
 # my superclass
 from .Specification import Specification
 
@@ -18,7 +20,6 @@ class Datatype(Specification, family="qed.datatypes"):
     The datatype metadata
     """
 
-
     # public data
     byteswap = qed.properties.bool()
     byteswap.doc = "control whether byte swapping is necessary"
@@ -28,7 +29,6 @@ class Datatype(Specification, family="qed.datatypes"):
 
     tile = qed.properties.tuple(schema=qed.properties.int())
     tile.doc = "the preferred shape of dataset subsets"
-
 
     # value processing hooks
     # the byte order is indicated by a single character prefix that must be stripped before
@@ -51,15 +51,15 @@ class Datatype(Specification, family="qed.datatypes"):
         # chain up
         return super().pyre_convert(value=value, **kwds)
 
-
     @classmethod
     def pyre_instantiate(cls, spec, component, name, locator):
         """
         Invoke the {component} constructor to build a new instance
         """
         # chain up to build the {datatype} instance
-        instance = super().pyre_instantiate(spec=spec,
-                                           component=component, name=name, locator=locator)
+        instance = super().pyre_instantiate(
+            spec=spec, component=component, name=name, locator=locator
+        )
 
         # if the {spec} is a string
         if isinstance(spec, str):
@@ -71,36 +71,41 @@ class Datatype(Specification, family="qed.datatypes"):
         # return
         return instance
 
-
     # implementation details
     # the type alias table
     aliases = {
         # bytes
         "c": "qed.datatypes.char",
         "char": "qed.datatypes.char",
-
-        # integer types
+        # signed integers
+        "i1": "qed.datatypes.int8",
+        "int8": "qed.datatypes.int8",
         "i2": "qed.datatypes.int16",
         "int16": "qed.datatypes.int16",
-
         "i4": "qed.datatypes.int32",
         "int32": "qed.datatypes.int32",
-
         "i8": "qed.datatypes.int64",
         "int64": "qed.datatypes.int64",
-
+        # unsigned integers
+        "u1": "qed.datatypes.uint8",
+        "uint8": "qed.datatypes.uint8",
+        "u2": "qed.datatypes.uint16",
+        "uint16": "qed.datatypes.uint16",
+        "u4": "qed.datatypes.uint32",
+        "uint32": "qed.datatypes.uint32",
+        "u8": "qed.datatypes.uint64",
+        "uint64": "qed.datatypes.uint64",
         # single precision numbers
         "r4": "qed.datatypes.real32",
-        "real32": "qed.datatypes.real32",
-
+        "real32": "qed.datatypes.float",
+        "float32": "qed.datatypes.float",
         # double precision numbers
-        "r8": "qed.datatypes.real64",
-        "real64": "qed.datatypes.real64",
-
+        "r8": "qed.datatypes.double",
+        "real64": "qed.datatypes.double",
+        "float64": "qed.datatypes.double",
         # single precision complex numbers
         "c8": "qed.datatypes.complex64",
         "complex64": "qed.datatypes.complex64",
-
         # double precision complex numbers
         "c16": "qed.datatypes.complex128",
         "complex128": "qed.datatypes.complex128",

--- a/pkg/readers/isce2/SLC.py
+++ b/pkg/readers/isce2/SLC.py
@@ -7,6 +7,9 @@
 # support
 import qed
 
+# access to the metadata parser
+from . import xml
+
 # superclass
 from .. import native
 
@@ -21,6 +24,34 @@ class SLC(native.flat, family="qed.readers.isce2.slc"):
     cell = qed.protocols.datatype()
     cell.default = "complex64"
     cell.doc = "the type of the dataset payload"
+
+    # framework hooks
+    def pyre_configured(self):
+        """
+        Hook invoked after the reader configuration is complete
+        """
+        # get the current value of my shape
+        shape = list(self.shape) if self.shape else [0, 0]
+        # if it's trivial
+        if not shape or shape[0] == 0 or shape[1] == 0:
+            # look for an auxiliary file with metadata and extract the available information
+            metadata = xml.metadata(self.uri)
+            # if it knows the number of lines
+            if metadata.height:
+                # set it
+                shape[0] = metadata.height
+            # if it knows the number of samples
+            if metadata.width:
+                # set it
+                shape[1] = metadata.width
+            # if the shape is now fully resolved
+            if shape[0] and shape[1]:
+                # set it
+                self.shape = tuple(shape)
+        # and chain up
+        yield from super().pyre_configured()
+        # all done
+        return
 
 
 # end of file

--- a/pkg/readers/isce2/__init__.py
+++ b/pkg/readers/isce2/__init__.py
@@ -4,14 +4,14 @@
 # (c) 1998-2024 all rights reserved
 
 
+# the metadata parser
+from .xml import metadata, parse
+
 # publish the readers
 from .Auto import Auto as auto
 from .SLC import SLC as slc
 from .interferogram import int
 from .unwrapped import unw
-
-# the metadata parser
-from .xml import metadata, parse
 
 # reader aliases
 rslc = slc

--- a/pkg/readers/isce2/interferogram/Reader.py
+++ b/pkg/readers/isce2/interferogram/Reader.py
@@ -121,6 +121,7 @@ class Reader(
                 # generate a list of possible shapes
                 channel.line(f"while attempting to load '{self.uri.address}'")
                 channel.line(f"missing shape information; here are some possibilities")
+                channel.line(f"as lines x samples")
                 channel.indent()
                 # generate some options
                 for lines, samples in qed.libqed.factor(
@@ -129,6 +130,9 @@ class Reader(
                     # and show them
                     channel.line(f"{lines} x {samples}")
                 channel.outdent()
+                channel.line(
+                    f"please use '--lines' or '--samples' to provide the dataset shape"
+                )
                 # flush
                 channel.log()
 

--- a/pkg/readers/isce2/interferogram/Reader.py
+++ b/pkg/readers/isce2/interferogram/Reader.py
@@ -5,7 +5,12 @@
 
 
 # support
+import math
 import qed
+import journal
+
+# metadata parser
+from .. import xml
 
 # my dataset
 from .Dataset import Dataset
@@ -70,6 +75,65 @@ class Reader(
         # add the dataset to the pile
         self.datasets.append(dataset)
 
+        # all done
+        return
+
+    # framework hooks
+    def pyre_configured(self):
+        """
+        Hook invoked after the reader configuration is complete
+        """
+        # get the current value of my shape
+        shape = list(self.shape) if self.shape else [0, 0]
+        # if it's trivial
+        if not shape or shape[0] == 0 or shape[1] == 0:
+            # look for an auxiliary file with metadata and extract the available information
+            metadata = xml.metadata(self.uri)
+            # if it knows the number of lines
+            if metadata.height:
+                # set it
+                shape[0] = metadata.height
+            # if it knows the number of samples
+            if metadata.width:
+                # set it
+                shape[1] = metadata.width
+            # if the width is missing but we know the height
+            if shape[1] == 0 and shape[0]:
+                # set it from the file size
+                shape[1] = metadata.bytes / shape[0] / self.cell.bytes
+            # if the height is missing but we know the width
+            if shape[0] == 0 and shape[1]:
+                # set it from the file size
+                shape[0] = metadata.bytes / shape[1] / self.cell.bytes
+            # if the shape is now fully resolved
+            if (
+                shape[0]
+                and shape[1]
+                and shape[0] == math.floor(shape[0])
+                and shape[1] == math.floor(shape[1])
+            ):
+                # set it
+                self.shape = tuple(shape)
+            # if not
+            else:
+                # make a channel
+                channel = journal.warning("qed.readers.unw")
+                # generate a list of possible shapes
+                channel.line(f"while attempting to load '{self.uri.address}'")
+                channel.line(f"missing shape information; here are some possibilities")
+                channel.indent()
+                # generate some options
+                for lines, samples in qed.libqed.factor(
+                    product=metadata.bytes // self.cell.bytes, aspect=10
+                ):
+                    # and show them
+                    channel.line(f"{lines} x {samples}")
+                channel.outdent()
+                # flush
+                channel.log()
+
+        # chain up
+        yield from super().pyre_configured()
         # all done
         return
 

--- a/pkg/readers/isce2/unwrapped/Reader.py
+++ b/pkg/readers/isce2/unwrapped/Reader.py
@@ -5,7 +5,12 @@
 
 
 # support
+import math
 import qed
+import journal
+
+# metadata parser
+from .. import xml
 
 # dataset
 from .Dataset import Dataset
@@ -71,6 +76,65 @@ class Reader(
         # add the dataset to the pile
         self.datasets.append(dataset)
 
+        # all done
+        return
+
+    # framework hooks
+    def pyre_configured(self):
+        """
+        Hook invoked after the reader configuration is complete
+        """
+        # get the current value of my shape
+        shape = list(self.shape) if self.shape else [0, 0]
+        # if it's trivial
+        if not shape or shape[0] == 0 or shape[1] == 0:
+            # look for an auxiliary file with metadata and extract the available information
+            metadata = xml.metadata(self.uri)
+            # if it knows the number of lines
+            if metadata.height:
+                # set it
+                shape[0] = metadata.height
+            # if it knows the number of samples
+            if metadata.width:
+                # set it
+                shape[1] = metadata.width
+            # if the width is missing but we know the height
+            if shape[1] == 0 and shape[0]:
+                # set it from the file size
+                shape[1] = metadata.bytes / shape[0] / (2 * self.cell.bytes)
+            # if the height is missing but we know the width
+            if shape[0] == 0 and shape[1]:
+                # set it from the file size
+                shape[0] = metadata.bytes / shape[1] / (2 * self.cell.bytes)
+            # if the shape is now fully resolved
+            if (
+                shape[0]
+                and shape[1]
+                and shape[0] == math.floor(shape[0])
+                and shape[1] == math.floor(shape[1])
+            ):
+                # set it
+                self.shape = tuple(shape)
+            # if not
+            else:
+                # make a channel
+                channel = journal.warning("qed.readers.unw")
+                # generate a list of possible shapes
+                channel.line(f"while attempting to load '{self.uri.address}'")
+                channel.line(f"missing shape information; here are some possibilities")
+                channel.indent()
+                # generate some options
+                for lines, samples in qed.libqed.factor(
+                    product=metadata.bytes // (2 * self.cell.bytes), aspect=10
+                ):
+                    # and show them
+                    channel.line(f"{lines} x {samples}")
+                channel.outdent()
+                # flush
+                channel.log()
+
+        # chain up
+        yield from super().pyre_configured()
         # all done
         return
 

--- a/pkg/readers/isce2/unwrapped/Reader.py
+++ b/pkg/readers/isce2/unwrapped/Reader.py
@@ -122,6 +122,7 @@ class Reader(
                 # generate a list of possible shapes
                 channel.line(f"while attempting to load '{self.uri.address}'")
                 channel.line(f"missing shape information; here are some possibilities")
+                channel.line(f"as lines x samples")
                 channel.indent()
                 # generate some options
                 for lines, samples in qed.libqed.factor(
@@ -130,6 +131,9 @@ class Reader(
                     # and show them
                     channel.line(f"{lines} x {samples}")
                 channel.outdent()
+                channel.line(
+                    f"please use '--lines' or '--samples' to provide the dataset shape"
+                )
                 # flush
                 channel.log()
 

--- a/pkg/readers/native/Flat.py
+++ b/pkg/readers/native/Flat.py
@@ -5,7 +5,9 @@
 
 
 # support
+import math
 import qed
+import journal
 
 
 # a reader of flat binary files
@@ -45,11 +47,20 @@ class Flat(
         # stop the discovery timer
         discovery.stop()
 
+        # get my cell
+        cell = self.cell
+        # and my shape
+        shape = self.shape
+        # i need both to continue
+        if not cell or not shape:
+            # so bail, if they are not fully configured
+            return
+
         # unpack my state into a dataset configuration
         config = {
             "uri": self.uri,
-            "shape": self.shape,
-            "cell": self.cell,
+            "shape": shape,
+            "cell": cell,
             "tile": self.cell.tile,
         }
 
@@ -67,6 +78,81 @@ class Flat(
         # add the dataset to the pile
         self.datasets.append(dataset)
 
+        # all done
+        return
+
+    # framework hooks
+    def pyre_configured(self):
+        """
+        Hook invoked after the reader configuration is complete
+        """
+        # get my uri
+        uri = self.uri
+        # convert its address into a path
+        path = qed.primitives.path(uri.address)
+        # get the file size
+        filesize = path.stat().st_size
+        # get my cell
+        cell = self.cell
+        # if i don't have
+        if not cell:
+            # make a channel
+            channel = journal.error("qed.readers.native.flat")
+            # complain
+            channel.line(f"could not load a dataset from '{uri.address}'")
+            channel.line(f"missing data type specification")
+            channel.line(f"please provide a value for '--cell'")
+            # flush
+            channel.log()
+            # just in case errors aren't fatal
+            yield f"missing cell specification for '{uri.address}'"
+            # and bail
+            return
+        # get the current value of my shape
+        shape = list(self.shape) if self.shape else [0, 0]
+        # if it's trivial
+        if not shape or shape[0] == 0 or shape[1] == 0:
+            # if the width is missing but we know the height
+            if shape[1] == 0 and shape[0]:
+                # set it from the file size
+                shape[1] = filesize / shape[0] / cell.bytes
+            # if the height is missing but we know the width
+            if shape[0] == 0 and shape[1]:
+                # set it from the file size
+                shape[0] = filesize / shape[1] / cell.bytes
+            # if the shape is now fully resolved
+            if (
+                shape[0]
+                and shape[1]
+                and shape[0] == math.floor(shape[0])
+                and shape[1] == math.floor(shape[1])
+            ):
+                # set it
+                self.shape = tuple(shape)
+            # if not
+            else:
+                # make a channel
+                channel = journal.warning("qed.readers.unw")
+                # generate a list of possible shapes
+                channel.line(f"while attempting to load '{self.uri.address}'")
+                channel.line(f"missing shape information; here are some possibilities")
+                channel.line(f"as lines x samples")
+                channel.indent()
+                # generate some options
+                for lines, samples in qed.libqed.factor(
+                    product=filesize // cell.bytes, aspect=10
+                ):
+                    # and show them
+                    channel.line(f"{lines} x {samples}")
+                channel.outdent()
+                channel.line(
+                    f"please use '--lines' or '--samples' to provide the dataset shape"
+                )
+                # flush
+                channel.log()
+
+        # chain up
+        yield from super().pyre_configured()
         # all done
         return
 

--- a/pkg/shells/Plexus.py
+++ b/pkg/shells/Plexus.py
@@ -347,6 +347,10 @@ class Plexus(pyre.plexus, family="qed.shells.plexus"):
         argv = tuple(
             command.command for command in self.pyre_configurator.consumeCommands()
         )
+        # if there are no command line arguments
+        if not argv:
+            # nothing to do here
+            return
         # get all  the documented actions
         actions = self.pyre_action.pyre_documentedActions(plexus=self)
         # collect their names


### PR DESCRIPTION
There is now a way to register datasets entirely from the command line. `qed` requires four pieces of information:

- the product type so that it can invoke the correct reader; specified using `--reader`
- the pixel data type; specified using `--cell`
- the shape of the dataset; specified using `--shape`
- the name of one or more files to open; the chosen reader must be able to open all the files

The reader is specified with the `reader` command line argument, or its `r` alias. Certain readers, such NISAR, GDAL, and ISCE2 under the right circumstances, are able to determine the rest of the necessary information from the data product itself. The command

```
qed -r=nisar.rslc rslc.h5
```

opens `rslc.h5` with the NISAR RSLC reader and registers the datasets it contains. Similarly,

```
qed -r=native.gdal dem.tiff
```

will load `dem.tiff` using GDAL as the reader. Similar considerations apply to ISCE2 datasets that have an XML companion file. The three ISCE2 readers, `isce2.slc`, `isce2.int`, and `isce2.unw`, can parse the companion file and extract pixel type and shape information.

The pixel type specification can happen in two slightly different ways. The `cell` command line argument accepts a value directly using the standard mnemonics:

- signed integers: `char`, `int8`, `int16`, `int32`, and `int64`
- unsigned integers: `uint8`, `uint16`, `uint32`, and `uint64`
- floats: `float` and `double`, as well as `float32`, `float64`, `real32`, and `real64`
- complex numbers: `complex64` and `complex128`, as well as `cfloat32` and `cfloat64`
 
Alternatively, one can use a set of flags to set the pixel type directly:

- signed integers: `int8`, `i1`, or `integer*1`; `int16`, `i2`, or `integer*2`; `int32`, `i4`, or `integer*4`; and `int64`, `i8`, or `integer*8`
- unsigned integers: `uint8`, `u1`, `byte` or `b1`; `uint16`, `u2`, or `b2`; `uint32`, or `u4`; and `uint64` or `u8`
- floats: `float`, `r4`, or `real*32`; and `double`, `r8`, or `real*8`
- complex numbers: `complex64` or `c8`; and `complex128` or `c16`

where the less obvious aliases are borrowed from `mdx`. So the commands

```
qed -r=native.flat -cell=complex128 c16.dat
```

and

```
qed -r=native.flat -c16 c16.dat
```
  
both open the file `c16.dat` using the `native.flat` reader and specify that the image pixels are double precision complex values.

The image shape can be specified using the `shape` command line argument that takes a pair of values separated by a comma. The command

```
qed -r=native.flat -c16 -shape=(1160,1400) c16.dat
```

tells the `native.flat` reader to expect an image whose height is 1160 lines and whose width is 1400 samples. Alternatively, one can specify the lines and samples separately:

- height: `lines`, `rows`, `l`
- width: `samples`, `columns`, `cols`, `s`

One can mix and match these, as the regular `pyre` priority rules for configuration events are applied. If the command line does not provide enough information for the shape to be determined, `qed` will issue a warning and suggest plausible values for the shape. 

