### PR TITLE
Adds support for EarthAccess data archives

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,30 @@
         "python",
         "html"
     ],
-    "python.analysis.typeCheckingMode": "basic"
+    "python.analysis.typeCheckingMode": "basic",
+    "files.associations": {
+        "*.def": "makefile",
+        "*.h": "cpp",
+        "*.icc": "cpp",
+        "*.js": "javascriptreact",
+        "*.mm": "makefile",
+        "__hash_table": "cpp",
+        "__split_buffer": "cpp",
+        "__tree": "cpp",
+        "array": "cpp",
+        "bitset": "cpp",
+        "deque": "cpp",
+        "initializer_list": "cpp",
+        "list": "cpp",
+        "map": "cpp",
+        "queue": "cpp",
+        "set": "cpp",
+        "stack": "cpp",
+        "string": "cpp",
+        "string_view": "cpp",
+        "unordered_map": "cpp",
+        "unordered_set": "cpp",
+        "valarray": "cpp",
+        "vector": "cpp"
+    }
 }

--- a/pkg/archives/Archive.py
+++ b/pkg/archives/Archive.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2025 all rights reserved
+
+
+# support
+import qed
+import journal
+
+
+# a local data archive
+class Archive(
+    qed.component, family="qed.archives.base", implements=qed.protocols.archive
+):
+    """
+    The base data archive
+    """
+
+    # user configurable state
+    uri = qed.properties.uri()
+    uri.default = qed.primitives.uri(scheme="file", address=qed.primitives.path.cwd())
+    uri.doc = "the location of the archive"
+
+    # constants
+    readers = ()
+
+    # interface
+    @qed.export
+    def contents(self, uri):
+        """
+        Retrieve my contents at {uri}, a location expected to belong within the archive document
+        space
+        """
+        # i got nothing
+        return []
+
+    # implementation details
+    # visitor support
+    def identify(self, visitor, **kwds):
+        """
+        Let {visitor} know i'm a base archive
+        """
+        # attempt to
+        try:
+            # ask {visitor} for it's base handler
+            handler = visitor.onArchive
+        # if it doesn't understand
+        except AttributeError:
+            # get my class
+            me = type(self)
+            # and my poorly formed visitor's
+            them = type(visitor)
+            # complain that it is not a real visitor
+            raise NotImplementedError(
+                f"class '{them.__module__}.{them.__name__}' "
+                f"is not a well formed visitor of '{me.__module__}.{me.__name__}"
+            )
+        # if all went well, invoke the hook
+        return handler(archive=self, **kwds)
+
+    # constants
+    tag = "<base>"
+    label = "<base>"
+
+
+# end of file

--- a/pkg/archives/EarthAccess.py
+++ b/pkg/archives/EarthAccess.py
@@ -25,6 +25,16 @@ class EarthAccess(
     # constants
     readers = ("nisar",)
 
+    # interface
+    @qed.export
+    def contents(self, uri):
+        """
+        Retrieve the archive contents at {uri}, a location expected to belong within the archive
+        document space
+        """
+        # nothing, for now
+        return []
+
     # hooks
     @classmethod
     def isSupported(cls):
@@ -39,7 +49,7 @@ class EarthAccess(
         except ImportError as error:
             # no dice
             return False
-        # otherwise, chances are good the runtime support is present
+        # otherwise, chances are good there is runtime support
         return True
 
     # constants

--- a/pkg/archives/EarthAccess.py
+++ b/pkg/archives/EarthAccess.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2025 all rights reserved
+
+
+# support
+import qed
+import journal
+
+
+# an earth access data archive
+class EarthAccess(
+    qed.component, family="qed.archives.earth", implements=qed.protocols.archive
+):
+    """
+    A data archive that consists of datasets available through earth access
+    """
+
+    # user configurable state
+    uri = qed.properties.uri()
+    uri.default = qed.primitives.uri(scheme="earth", address=())
+    uri.doc = "the archive identifier"
+
+    # constants
+    readers = ("nisar",)
+
+    # hooks
+    @classmethod
+    def isSupported(cls):
+        """
+        Check whether there is runtime support for this archive type
+        """
+        # attempt to
+        try:
+            # access the external packages we need
+            import earthaccess
+        # if anything goes wrong
+        except ImportError as error:
+            # no dice
+            return False
+        # otherwise, chances are good the runtime support is present
+        return True
+
+    # constants
+    tag = "earth"
+    label = "earth-access"
+
+
+# end of file

--- a/pkg/archives/EarthAccess.py
+++ b/pkg/archives/EarthAccess.py
@@ -22,6 +22,9 @@ class EarthAccess(
     uri.default = qed.primitives.uri(scheme="earth", address=())
     uri.doc = "the archive identifier"
 
+    filters = qed.properties.list(schema=qed.protocols.archiveFilter())
+    filters.doc = "the collection of search filters to apply when looking for datasets"
+
     # constants
     readers = ("nisar",)
 

--- a/pkg/archives/Filter.py
+++ b/pkg/archives/Filter.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2025 all rights reserved
+
+
+# support
+import qed
+import journal
+
+
+# the base filter for selecting archive contents
+class Filter(
+    qed.component,
+    family="qed.archives.filters.base",
+    implements=qed.protocols.archiveFilter,
+):
+    """
+    The base filter
+    """
+
+    # interface
+    @qed.export
+    def filter(self, archive, **kwds):
+        """
+        Apply the filter to a search
+        """
+        # ask the archive to identify itself and invoke my associated handler
+        return archive.identify(archive=self, **kwds)
+
+    # visitor support
+    def onArchive(self, visitor, **kwds):
+        """
+        Apply my filter to a generic archive
+        """
+        # i don't really know how to do anything, but make sure i'm iterable because that's what
+        # clients expect
+        return ()
+
+
+# end of file

--- a/pkg/archives/GeoBBox.py
+++ b/pkg/archives/GeoBBox.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2025 all rights reserved
+
+
+# support
+import qed
+import journal
+
+
+# a polygon on the surface of a sphere
+class GeoBBox(
+    qed.component,
+    family="qed.archives.filters.geoBBox",
+    implements=qed.protocols.archiveFilter,
+):
+    """
+    A filter for earthdata searches that identifies datasets that contain a specific point
+    """
+
+    # user-configurable state
+    ne = qed.properties.tuple(schema=qed.properties.float())
+    ne.doc = "the coordinates of the north east corner"
+
+    sw = qed.properties.tuple(schema=qed.properties.float())
+    sw.doc = "the coordinates of the south west corner"
+
+    # interface
+    @qed.export
+    def filter(self):
+        """
+        Apply the filter to a search
+        """
+        # all done
+        return
+
+
+# end of file

--- a/pkg/archives/GeoBBox.py
+++ b/pkg/archives/GeoBBox.py
@@ -8,13 +8,12 @@
 import qed
 import journal
 
+# superclass
+from .Filter import Filter
+
 
 # a polygon on the surface of a sphere
-class GeoBBox(
-    qed.component,
-    family="qed.archives.filters.geoBBox",
-    implements=qed.protocols.archiveFilter,
-):
+class GeoBBox(Filter, family="qed.archives.filters.geoBBox"):
     """
     A filter for earthdata searches that identifies datasets that contain a specific point
     """
@@ -26,12 +25,22 @@ class GeoBBox(
     sw = qed.properties.tuple(schema=qed.properties.float())
     sw.doc = "the coordinates of the south west corner"
 
-    # interface
-    @qed.export
-    def filter(self):
+    # implementation details
+    # visitor support
+    def onEarthAccess(self, **kwds):
         """
-        Apply the filter to a search
+        Generate the required representation so an {EarthAccess} archive can filter its contents
         """
+        # unpack my state
+        swLon, swLat = self.sw
+        neLon, neLat = self.ne
+        # produce the {earthaccess} keyword
+        yield (
+            # the name
+            "bounding_box",
+            # the contents
+            (swLon, swLat, neLon, neLat),
+        )
         # all done
         return
 

--- a/pkg/archives/GeoCircle.py
+++ b/pkg/archives/GeoCircle.py
@@ -8,13 +8,12 @@
 import qed
 import journal
 
+# superclass
+from .Filter import Filter
+
 
 # a point on the surface of a sphere
-class GeoCircle(
-    qed.component,
-    family="qed.archives.filters.geoCircle",
-    implements=qed.protocols.archiveFilter,
-):
+class GeoCircle(Filter, family="qed.archives.filters.geoCircle"):
     """
     A filter for earthdata searches that identifies datasets that contain a specific point
     """
@@ -29,12 +28,19 @@ class GeoCircle(
     latitude = qed.properties.float()
     latitude.doc = "the latitude of the center"
 
-    # interface
-    @qed.export
-    def filter(self):
+    # implementation details
+    # visitor support
+    def onEarthAccess(self, **kwds):
         """
-        Apply the filter to a search
+        Generate the required representation so an {EarthAccess} archive can filter its contents
         """
+        # produce the {earthaccess} keyword
+        yield (
+            # the name
+            "circle",
+            # the contents
+            (self.longitude, self.latitude, self.radius),
+        )
         # all done
         return
 

--- a/pkg/archives/GeoCircle.py
+++ b/pkg/archives/GeoCircle.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2025 all rights reserved
+
+
+# support
+import qed
+import journal
+
+
+# a point on the surface of a sphere
+class GeoCircle(
+    qed.component,
+    family="qed.archives.filters.geoCircle",
+    implements=qed.protocols.archiveFilter,
+):
+    """
+    A filter for earthdata searches that identifies datasets that contain a specific point
+    """
+
+    # user-configurable state
+    radius = qed.properties.float()
+    radius.doc = "the radius of the circle, in meters"
+
+    longitude = qed.properties.float()
+    longitude.doc = "the longitude of the center"
+
+    latitude = qed.properties.float()
+    latitude.doc = "the latitude of the center"
+
+    # interface
+    @qed.export
+    def filter(self):
+        """
+        Apply the filter to a search
+        """
+        # all done
+        return
+
+
+# end of file

--- a/pkg/archives/GeoLine.py
+++ b/pkg/archives/GeoLine.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2025 all rights reserved
+
+
+# support
+import qed
+import journal
+
+
+# a collection of connected line segment on the surface of a sphere
+class GeoLine(
+    qed.component,
+    family="qed.archives.filters.geoLine",
+    implements=qed.protocols.archiveFilter,
+):
+    """
+    A filter for earthdata searches that identifies datasets that contain a specific line
+    """
+
+    # user-configurable state
+    vertices = qed.properties.list(
+        schema=qed.properties.tuple(schema=qed.properties.float())
+    )
+    vertices.doc = (
+        "the collection of (lon, lat) vertices that make up the line segments"
+    )
+
+    # interface
+    @qed.export
+    def filter(self):
+        """
+        Apply the filter to a search
+        """
+        # all done
+        return
+
+    # implementation details
+    @classmethod
+    def parseVertices(cls, payload):
+        """
+        Apply the schema of my {vertices} to {payload}, a list of dicts
+        """
+        # go through the payload
+        for vertex in payload:
+            # get the longitude
+            lon = float(vertex["longitude"])
+            # and the latitude
+            lat = float(vertex["latitude"])
+            # pack and ship
+            yield (lon, lat)
+        # all done
+        return
+
+
+# end of file

--- a/pkg/archives/GeoLine.py
+++ b/pkg/archives/GeoLine.py
@@ -8,13 +8,12 @@
 import qed
 import journal
 
+# superclass
+from .Filter import Filter
+
 
 # a collection of connected line segment on the surface of a sphere
-class GeoLine(
-    qed.component,
-    family="qed.archives.filters.geoLine",
-    implements=qed.protocols.archiveFilter,
-):
+class GeoLine(Filter, family="qed.archives.filters.geoLine"):
     """
     A filter for earthdata searches that identifies datasets that contain a specific line
     """
@@ -27,16 +26,35 @@ class GeoLine(
         "the collection of (lon, lat) vertices that make up the line segments"
     )
 
-    # interface
-    @qed.export
-    def filter(self):
+    # implementation details
+    # visitor support
+    def onEarthAccess(self, **kwds):
         """
-        Apply the filter to a search
+        Generate the required representation so an {EarthAccess} archive can filter its contents
         """
+        # get my vertices
+        vertices = self.vertices
+        # if there is only one
+        if len(vertices) == 1:
+            # pretend i'm a point
+            yield (
+                # the name
+                "point",
+                # the payload
+                vertices[0],
+            )
+            # all done
+            return
+        # otherwise, produce the {earthaccess} keyword
+        yield (
+            # the name
+            "line",
+            # the contents
+            vertices,
+        )
         # all done
         return
 
-    # implementation details
     @classmethod
     def parseVertices(cls, payload):
         """

--- a/pkg/archives/GeoPoint.py
+++ b/pkg/archives/GeoPoint.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2025 all rights reserved
+
+
+# support
+import qed
+import journal
+
+
+# a point on the surface of a sphere
+class GeoPoint(
+    qed.component,
+    family="qed.archives.filters.geoPoint",
+    implements=qed.protocols.archiveFilter,
+):
+    """
+    A filter for earthdata searches that identifies datasets that contain a specific point
+    """
+
+    # user-configurable state
+    longitude = qed.properties.float()
+    longitude.doc = "the longitude of the point"
+
+    latitude = qed.properties.float()
+    latitude.doc = "the latitude of the point"
+
+    # interface
+    @qed.export
+    def filter(self):
+        """
+        Apply the filter to a search
+        """
+        # all done
+        return
+
+
+# end of file

--- a/pkg/archives/GeoPoint.py
+++ b/pkg/archives/GeoPoint.py
@@ -8,13 +8,12 @@
 import qed
 import journal
 
+# superclass
+from .Filter import Filter
+
 
 # a point on the surface of a sphere
-class GeoPoint(
-    qed.component,
-    family="qed.archives.filters.geoPoint",
-    implements=qed.protocols.archiveFilter,
-):
+class GeoPoint(Filter, family="qed.archives.filters.geoPoint"):
     """
     A filter for earthdata searches that identifies datasets that contain a specific point
     """
@@ -26,12 +25,19 @@ class GeoPoint(
     latitude = qed.properties.float()
     latitude.doc = "the latitude of the point"
 
-    # interface
-    @qed.export
-    def filter(self):
+    # implementation details
+    # visitor support
+    def onEarthAccess(self, **kwds):
         """
-        Apply the filter to a search
+        Generate the required representation so an {EarthAccess} archive can filter its contents
         """
+        # produce the {earthaccess} keyword
+        yield (
+            # the name
+            "point",
+            # the contents
+            (self.longitude, self.latitude),
+        )
         # all done
         return
 

--- a/pkg/archives/GeoPolygon.py
+++ b/pkg/archives/GeoPolygon.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2025 all rights reserved
+
+
+# support
+import qed
+import journal
+
+
+# a polygon on the surface of a sphere
+class GeoPolygon(
+    qed.component,
+    family="qed.archives.filters.geoPolygon",
+    implements=qed.protocols.archiveFilter,
+):
+    """
+    A filter for earthdata searches that identifies datasets that contain a specific point
+    """
+
+    # user-configurable state
+    vertices = qed.properties.list(
+        schema=qed.properties.tuple(schema=qed.properties.float())
+    )
+    vertices.doc = "the collection of (lon, lat) vertices that make up the polygon"
+
+    # interface
+    @qed.export
+    def filter(self):
+        """
+        Apply the filter to a search
+        """
+        # all done
+        return
+
+    # implementation details
+    @classmethod
+    def parseVertices(cls, payload):
+        """
+        Apply the schema of my {vertices} to {payload}, a list of dicts
+        """
+        # go through the payload
+        for vertex in payload:
+            # get the longitude
+            lon = float(vertex["longitude"])
+            # and the latitude
+            lat = float(vertex["latitude"])
+            # pack and ship
+            yield (lon, lat)
+        # all done
+        return
+
+
+# end of file

--- a/pkg/archives/Local.py
+++ b/pkg/archives/Local.py
@@ -74,5 +74,18 @@ class Local(
         # all done
         return
 
+    # hooks
+    @classmethod
+    def isSupported(cls):
+        """
+        Check whether there is runtime support for this archive type
+        """
+        # always available...
+        return True
+
+    # constants
+    tag = "local"
+    label = "local"
+
 
 # end of file

--- a/pkg/archives/Local.py
+++ b/pkg/archives/Local.py
@@ -30,9 +30,11 @@ class Local(
     readers = "nisar", "isce2", "gdal", "native"
 
     # interface
+    @qed.export
     def contents(self, uri):
         """
-        Retrieve my contents at {uri}
+        Retrieve my contents at {uri}, a location expected to belong within the archive document
+        space
         """
         # get my root
         root = self.fs

--- a/pkg/archives/Local.py
+++ b/pkg/archives/Local.py
@@ -8,11 +8,12 @@
 import qed
 import journal
 
+# superclass
+from .Archive import Archive
+
 
 # a local data archive
-class Local(
-    qed.component, family="qed.archives.local", implements=qed.protocols.archive
-):
+class Local(Archive, family="qed.archives.local"):
     """
     A data archive that resides on local disk
     """
@@ -75,6 +76,22 @@ class Local(
         self.fs = qed.filesystem.local(root=self.uri.address)
         # all done
         return
+
+    # visitor support
+    def identify(self, visitor, **kwds):
+        """
+        Let {visitor} know i'm a local archive
+        """
+        # attempt to
+        try:
+            # ask {visitor} for it's base handler
+            handler = visitor.onLocal
+        # if it doesn't understand
+        except AttributeError:
+            # chain up
+            return super().identify(visitor=visitor, **kwds)
+        # if all went well, invoke the hook
+        return handler(archive=self, **kwds)
 
     # hooks
     @classmethod

--- a/pkg/archives/S3.py
+++ b/pkg/archives/S3.py
@@ -24,9 +24,11 @@ class S3(qed.component, family="qed.archives.s3", implements=qed.protocols.archi
     readers = ("nisar",)
 
     # interface
-    def contents(self, uri, **kwds):
+    @qed.provides
+    def contents(self, uri):
         """
-        Retrieve my contents at {uri}
+        Retrieve the archive contents at {uri}, a location expected to belong within the archive
+        document space
         """
         # get my root
         root = self.fs

--- a/pkg/archives/S3.py
+++ b/pkg/archives/S3.py
@@ -8,9 +8,12 @@
 import qed
 import journal
 
+# superclass
+from .Archive import Archive
+
 
 # a S3 data archive
-class S3(qed.component, family="qed.archives.s3", implements=qed.protocols.archive):
+class S3(Archive, family="qed.archives.s3"):
     """
     A data archive that resides in an S3 bucket
     """
@@ -95,6 +98,22 @@ class S3(qed.component, family="qed.archives.s3", implements=qed.protocols.archi
 
         # all done
         return
+
+    # visitor support
+    def identify(self, visitor, **kwds):
+        """
+        Let {visitor} know i'm an S3 archive
+        """
+        # attempt to
+        try:
+            # ask {visitor} for it's base handler
+            handler = visitor.onS3
+        # if it doesn't understand
+        except AttributeError:
+            # chain up
+            return super().identify(visitor=visitor, **kwds)
+        # if all went well, invoke the hook
+        return handler(archive=self, **kwds)
 
     # hooks
     @classmethod

--- a/pkg/archives/S3.py
+++ b/pkg/archives/S3.py
@@ -24,7 +24,7 @@ class S3(qed.component, family="qed.archives.s3", implements=qed.protocols.archi
     readers = ("nisar",)
 
     # interface
-    @qed.provides
+    @qed.export
     def contents(self, uri):
         """
         Retrieve the archive contents at {uri}, a location expected to belong within the archive

--- a/pkg/archives/S3.py
+++ b/pkg/archives/S3.py
@@ -94,5 +94,26 @@ class S3(qed.component, family="qed.archives.s3", implements=qed.protocols.archi
         # all done
         return
 
+    # hooks
+    @classmethod
+    def isSupported(cls):
+        """
+        Check whether there is runtime support for this archive type
+        """
+        # attempt to
+        try:
+            # access the external packages we need
+            import boto3
+        # if anything goes wrong
+        except ImportError as error:
+            # no dice
+            return False
+        # otherwise, chances are good the runtime support is present
+        return True
+
+    # constants
+    tag = "s3"
+    label = "s3"
+
 
 # end of file

--- a/pkg/archives/TimeInterval.py
+++ b/pkg/archives/TimeInterval.py
@@ -8,13 +8,12 @@
 import qed
 import journal
 
+# superclass
+from .Filter import Filter
+
 
 # a point on the surface of a sphere
-class TimeInterval(
-    qed.component,
-    family="qed.archives.filters.when",
-    implements=qed.protocols.archiveFilter,
-):
+class TimeInterval(Filter, family="qed.archives.filters.when"):
     """
     A filter for earthdata searches that identifies datasets from a given time interval
     """
@@ -26,12 +25,19 @@ class TimeInterval(
     end = qed.properties.str()
     end.doc = "the latitude of the point"
 
-    # interface
-    @qed.export
-    def filter(self):
+    # implementation details
+    # visitor support
+    def onEarthAccess(self, **kwds):
         """
-        Apply the filter to a search
+        Generate the required representation so an {EarthAccess} archive can filter its contents
         """
+        # produce the {earthaccess} keyword
+        yield (
+            # the name
+            "temporal",
+            # the contents
+            (self.begin, self.end),
+        )
         # all done
         return
 

--- a/pkg/archives/TimeInterval.py
+++ b/pkg/archives/TimeInterval.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2025 all rights reserved
+
+
+# support
+import qed
+import journal
+
+
+# a point on the surface of a sphere
+class TimeInterval(
+    qed.component,
+    family="qed.archives.filters.when",
+    implements=qed.protocols.archiveFilter,
+):
+    """
+    A filter for earthdata searches that identifies datasets from a given time interval
+    """
+
+    # user-configurable state
+    begin = qed.properties.str()
+    begin.doc = "the longitude of the point"
+
+    end = qed.properties.str()
+    end.doc = "the latitude of the point"
+
+    # interface
+    @qed.export
+    def filter(self):
+        """
+        Apply the filter to a search
+        """
+        # all done
+        return
+
+    # framework hooks
+    def pyre_configured(self, **kwds):
+        # chain up
+        yield from super().pyre_configured(**kwds)
+        # show me
+        channel = journal.info("qed.archives.time")
+        channel.line(f"{self}")
+        channel.indent()
+        channel.line(f"begin: {self.begin}")
+        channel.line(f"  end: {self.end}")
+        channel.outdent()
+        # all done
+        return
+
+
+# end of file

--- a/pkg/archives/__init__.py
+++ b/pkg/archives/__init__.py
@@ -5,9 +5,15 @@
 
 
 # publish
-from .EarthAccess import EarthAccess as earth
 from .Local import Local as local
 from .S3 import S3 as s3
+
+# earth access and its filters
+from .EarthAccess import EarthAccess as earth
+from .GeoPoint import GeoPoint as geoPoint
+from .GeoCircle import GeoCircle as geoCircle
+from .GeoLine import GeoLine as geoLine
+from .GeoPolygon import GeoPolygon as geoPolygon
 
 
 # discovery

--- a/pkg/archives/__init__.py
+++ b/pkg/archives/__init__.py
@@ -10,6 +10,7 @@ from .S3 import S3 as s3
 
 # earth access and its filters
 from .EarthAccess import EarthAccess as earth
+from .GeoBBox import GeoBBox as geoBBox
 from .GeoPoint import GeoPoint as geoPoint
 from .GeoCircle import GeoCircle as geoCircle
 from .GeoLine import GeoLine as geoLine

--- a/pkg/archives/__init__.py
+++ b/pkg/archives/__init__.py
@@ -15,6 +15,7 @@ from .GeoPoint import GeoPoint as geoPoint
 from .GeoCircle import GeoCircle as geoCircle
 from .GeoLine import GeoLine as geoLine
 from .GeoPolygon import GeoPolygon as geoPolygon
+from .TimeInterval import TimeInterval as timeInterval
 
 
 # discovery

--- a/pkg/archives/__init__.py
+++ b/pkg/archives/__init__.py
@@ -5,7 +5,32 @@
 
 
 # publish
+from .EarthAccess import EarthAccess as earth
 from .Local import Local as local
 from .S3 import S3 as s3
+
+
+# discovery
+def supported():
+    """
+    Return a list of known archive types
+    """
+    # build this by hand, for now
+    return (local, s3, earth)
+
+
+def available():
+    """
+    Generate a sequence of the archive type for which there is available runtime support
+    """
+    # go through the available types
+    for factory in supported():
+        # ask the archive to determine whether there is runtime support
+        if factory.isSupported():
+            # and if so, make it available
+            yield factory
+    # all done
+    return
+
 
 # end of file

--- a/pkg/gql/ArchiveType.py
+++ b/pkg/gql/ArchiveType.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2025 all rights reserved
+
+
+# externals
+import graphene
+
+# my interface
+from .Node import Node
+
+
+# my node type
+class ArchiveType(graphene.ObjectType):
+    """
+    A data archive type
+    """
+
+    # {graphene} metadata
+    class Meta:
+        # register my interface
+        interfaces = (Node,)
+
+    # my fields
+    id = graphene.ID()
+    name = graphene.String()
+    label = graphene.String()
+
+    # the resolvers
+    @staticmethod
+    def resolve_id(archive, *_):
+        """
+        Get the {archive} id
+        """
+        # use the archive {uri} to build a unique identifier
+        return f"Archive:{archive.tag}"
+
+    @staticmethod
+    def resolve_name(archive, *_):
+        """
+        Generate the archive name
+        """
+        # use the component name
+        return archive.tag
+
+    @staticmethod
+    def resolve_label(archive, *_):
+        """
+        Get the label for the archive type
+        """
+        # ask the archive
+        return archive.label
+
+
+# end of file

--- a/pkg/gql/ConnectArchive.py
+++ b/pkg/gql/ConnectArchive.py
@@ -60,12 +60,15 @@ class ConnectArchive(graphene.Mutation):
         elif uri.scheme == "s3":
             # mount it
             archive = qed.archives.s3(name=name, uri=uri)
+        # if it's a collection of datasets on earth access
+        elif uri.scheme == "earth":
+            archive = qed.archives.earth(name=name, uri=uri)
         # anything else
         else:
             # make a channel
             channel = journal.error("qed.gql.connect")
             # complain
-            channel.line(f"unknown scheme '{uri.shceme}'")
+            channel.line(f"unknown scheme '{uri.scheme}'")
             channel.indent()
             channel.line(f"while attempting to connect to '{uri}'")
             # flush

--- a/pkg/gql/ConnectEarthAccessArchive.py
+++ b/pkg/gql/ConnectEarthAccessArchive.py
@@ -70,6 +70,7 @@ class ConnectEarthAccessArchive(graphene.Mutation):
         channel.indent()
         channel.line(f"{uri=}")
         channel.line(f"{filters=}")
+        channel.line(f"{when=}")
         channel.line(f"{geo=}")
         channel.line(f"{point=}")
         channel.line(f"{circle=}")

--- a/pkg/gql/ConnectEarthAccessArchive.py
+++ b/pkg/gql/ConnectEarthAccessArchive.py
@@ -10,6 +10,7 @@ import journal
 import qed
 
 # my input types
+from .GeoBBoxInput import GeoBBoxInput
 from .GeoVertexInput import GeoVertexInput
 from .GeoCircleInput import GeoCircleInput
 from .GeoLineInput import GeoLineInput
@@ -32,6 +33,7 @@ class ConnectEarthAccessArchive(graphene.Mutation):
         uri = graphene.String(required=True)
         filters = graphene.List(graphene.String)
         geo = graphene.String()
+        bbox = GeoBBoxInput()
         point = GeoVertexInput()
         circle = GeoCircleInput()
         line = GeoLineInput()
@@ -49,6 +51,7 @@ class ConnectEarthAccessArchive(graphene.Mutation):
         uri,
         filters,
         geo,
+        bbox,
         point,
         circle,
         line,
@@ -94,8 +97,16 @@ class ConnectEarthAccessArchive(graphene.Mutation):
         if "geo" in filters:
             # build the name of the filter
             filterName = f"{name}.geo.{geo}"
+            # if the selection is a bounding box
+            if geo == "bbox":
+                # make a geo bounding box
+                filter = qed.archives.geoBBox(
+                    name=filterName,
+                    ne=(bbox["ne"]["longitude"], bbox["ne"]["latitude"]),
+                    sw=(bbox["sw"]["longitude"], bbox["sw"]["latitude"]),
+                )
             # if the selection is a point
-            if geo == "point":
+            elif geo == "point":
                 # make a geo point
                 filter = qed.archives.geoPoint(name=filterName, **point)
             # if it's a circle

--- a/pkg/gql/GeoBBoxInput.py
+++ b/pkg/gql/GeoBBoxInput.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2025 all rights reserved
+
+
+# externals
+import graphene
+
+# my parts
+from .GeoVertexInput import GeoVertexInput
+
+
+# the payload for the vertices of bounding box
+class GeoBBoxInput(graphene.InputObjectType):
+    """
+    The payload for the vertices of a bounding box on earth
+    """
+
+    # the fields
+    ne = GeoVertexInput()
+    sw = GeoVertexInput()
+
+
+# end of file

--- a/pkg/gql/GeoCircleInput.py
+++ b/pkg/gql/GeoCircleInput.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2025 all rights reserved
+
+
+# externals
+import graphene
+
+
+# the payload for a circle centered at some point on earth
+class GeoCircleInput(graphene.InputObjectType):
+    """
+    The payload for a circle centered at some point on earth
+    """
+
+    # the fields
+    radius = graphene.String(required=True)
+    longitude = graphene.String(required=True)
+    latitude = graphene.String(required=True)
+
+
+# end of file

--- a/pkg/gql/GeoLineInput.py
+++ b/pkg/gql/GeoLineInput.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2025 all rights reserved
+
+
+# externals
+import graphene
+
+# my parts
+from .GeoVertexInput import GeoVertexInput
+
+
+# the payload for a collection of line segments on earth
+class GeoLineInput(graphene.InputObjectType):
+    """
+    The payload for a collection of line segments on earth
+    """
+
+    # the fields
+    vertices = graphene.List(GeoVertexInput)
+
+
+# end of file

--- a/pkg/gql/GeoPolygonInput.py
+++ b/pkg/gql/GeoPolygonInput.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2025 all rights reserved
+
+
+# externals
+import graphene
+
+# my parts
+from .GeoVertexInput import GeoVertexInput
+
+
+# the payload for the vertices of a polygon on earth
+class GeoPolygonInput(graphene.InputObjectType):
+    """
+    The payload for the vertices of a polygon on earth
+    """
+
+    # the fields
+    vertices = graphene.List(GeoVertexInput)
+
+
+# end of file

--- a/pkg/gql/GeoVertexInput.py
+++ b/pkg/gql/GeoVertexInput.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2025 all rights reserved
+
+
+# externals
+import graphene
+
+
+# the payload for a point on earth
+class GeoVertexInput(graphene.InputObjectType):
+    """
+    The payload for a point on earth
+    """
+
+    # the fields
+    longitude = graphene.String(required=True)
+    latitude = graphene.String(required=True)
+
+
+# end of file

--- a/pkg/gql/Mutation.py
+++ b/pkg/gql/Mutation.py
@@ -13,6 +13,7 @@ from . import views
 
 # explorer
 from .ConnectArchive import ConnectArchive
+from .ConnectEarthAccessArchive import ConnectEarthAccessArchive
 from .DisconnectArchive import DisconnectArchive
 from .ConnectReader import ConnectReader
 from .DisconnectReader import DisconnectReader
@@ -67,6 +68,7 @@ class Mutation(graphene.ObjectType):
 
     # data archive connection management
     connectArchive = ConnectArchive.Field()
+    connectEarthAccessArchive = ConnectEarthAccessArchive.Field()
     disconnectArchive = DisconnectArchive.Field()
     # data reader connection management
     connectReader = ConnectReader.Field()

--- a/pkg/gql/QED.py
+++ b/pkg/gql/QED.py
@@ -16,6 +16,7 @@ from .Node import Node
 
 # my parts
 from .Archive import Archive
+from .ArchiveType import ArchiveType
 from .Reader import Reader
 from . import views
 
@@ -34,6 +35,7 @@ class QED(graphene.ObjectType):
     # metadata
     id = graphene.ID(required=True)
     # my parts
+    availableArchiveTypes = graphene.List(ArchiveType)
     views = graphene.List(views.view)
     archives = graphene.List(Archive)
     readers = graphene.List(Reader)
@@ -46,6 +48,17 @@ class QED(graphene.ObjectType):
         """
         # easy enough
         return "QED"
+
+    # available archive types
+    @staticmethod
+    def resolve_availableArchiveTypes(store, info, **kwds):
+        """
+        Retrieve the archive types for which there is runtime support
+        """
+        # go through the archive types for which there is runtime support
+        yield from qed.archives.available()
+        # all done
+        return
 
     # views
     @staticmethod

--- a/pkg/gql/TimeIntervalInput.py
+++ b/pkg/gql/TimeIntervalInput.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2025 all rights reserved
+
+
+# externals
+import graphene
+
+
+# the payload for a point on earth
+class TimeIntervalInput(graphene.InputObjectType):
+    """
+    The payload for a time interval
+    """
+
+    # the fields
+    begin = graphene.String(required=True)
+    end = graphene.String(required=True)
+
+
+# end of file

--- a/pkg/protocols/Archive.py
+++ b/pkg/protocols/Archive.py
@@ -19,5 +19,13 @@ class Archive(qed.protocol, family="qed.archives"):
     uri.default = qed.primitives.uri(address=qed.primitives.path.cwd())
     uri.doc = "the location of the archive"
 
+    # interface
+    @qed.provides
+    def contents(self, uri):
+        """
+        Retrieve the archive contents at {uri}, a location expected to belong within the archive
+        document space
+        """
+
 
 # end of file

--- a/pkg/protocols/ArchiveFilter.py
+++ b/pkg/protocols/ArchiveFilter.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2025 all rights reserved
+
+
+# framework
+import qed
+
+
+# protocol for data archives
+class ArchiveFilter(qed.protocol, family="qed.archives.filters"):
+    """
+    The protocol for {qed} data archive filters
+    """
+
+    # interface requirements
+    @qed.provides
+    def filter(self, **kwds):
+        """
+        Apply the filter to a dataset search
+        """
+
+
+# end of file

--- a/pkg/protocols/__init__.py
+++ b/pkg/protocols/__init__.py
@@ -14,6 +14,7 @@ from .Specification import Specification as specification
 
 # data archives
 from .Archive import Archive as archive
+from .ArchiveFilter import ArchiveFilter as archiveFilter
 
 # datasets and their readers
 from .Datatype import Datatype as datatype

--- a/ux/client/palette.js
+++ b/ux/client/palette.js
@@ -86,7 +86,14 @@ const dark = {
 
     // widgets
     widgets: {
-        focus: "hsl(0deg, 0%, 15%)",
+        focus: {
+            color: "hsl(28deg, 90%, 55%)",
+            background: "hsl(0deg, 0%, 15%)",
+        },
+        selection: {
+            color: "hsl(28deg, 90%, 55%)",
+            background: "hsl(0deg, 0%, 75%)",
+        },
         background: "hsl(0deg, 0%, 10%)",
     },
 

--- a/ux/client/qed.js
+++ b/ux/client/qed.js
@@ -98,7 +98,7 @@ const Root = () => {
     //   users run the server, it grabs a port on its host and browsers connect directly
     //   using host:port
 
-    // - hosting as a embedded app in an existing document structure
+    // - hosting as an embedded app in an existing document structure
     //   an example of which is the NISAR on-demand system, where the url seen by the user,
     //   e.g. https://<host>/ondemand/user/<username>/qed, is forwarded to the qed server port
 

--- a/ux/client/views/explorer/archive/archive.js
+++ b/ux/client/views/explorer/archive/archive.js
@@ -14,11 +14,12 @@ import { useCollapseViewport } from '../explorer/useCollapseViewport'
 // components
 import { Panel } from './panel'
 import { Cancel, DisabledConnect, } from './buttons'
-import { Local } from './local'
-import { S3 } from './s3'
 import { TypeSelector } from './type'
 import { Form, Body } from '../form'
-
+// supported archives
+import { Local } from './local'
+import { Earth } from './earth'
+import { S3 } from './s3'
 
 // the form
 export const Archive = ({ view, viewport }) => {
@@ -60,7 +61,7 @@ export const Archive = ({ view, viewport }) => {
         )
     }
     // otherwise, resolve the connector
-    const Connector = types[type]
+    const Connector = supportedArchiveTypes[type]
     // and render it
     return (
         <Connector view={view} setType={update} hide={hide} />
@@ -68,10 +69,10 @@ export const Archive = ({ view, viewport }) => {
 }
 
 // the dispatch table with the archive types
-const types = {
+export const supportedArchiveTypes = {
     local: Local,
     s3: S3,
+    earth: Earth,
 }
-
 
 // end of file

--- a/ux/client/views/explorer/archive/archive.js
+++ b/ux/client/views/explorer/archive/archive.js
@@ -6,7 +6,6 @@
 
 // external
 import React from 'react'
-import styled from 'styled-components'
 
 // local
 // hooks
@@ -74,5 +73,6 @@ export const supportedArchiveTypes = {
     s3: S3,
     earth: Earth,
 }
+
 
 // end of file

--- a/ux/client/views/explorer/archive/bbox.js
+++ b/ux/client/views/explorer/archive/bbox.js
@@ -1,0 +1,129 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2025 all rights reserved
+
+
+// external
+import React from 'react'
+import styled from 'styled-components'
+
+// local
+// components
+import { Longitude } from './longitude'
+import { Latitude } from './latitude'
+import { Field, Value, SpacerBetween } from '../form'
+
+
+// collect the coordinates of a polygon of interest
+export const BBox = ({ region, update }) => {
+    // unpack the region
+    const { ne, sw } = region
+    // validate my contents
+    const good = (
+        // check the north east corner
+        ne.longitude !== "" & ne.latitude !== "" &&
+        // and the south west corner
+        sw.longitude !== "" && sw.latitude !== ""
+    )
+    // convert into a mark
+    const ok = good ? "ok" : ""
+    // specialize the form update
+    // for the north-east corner
+    const updateNE = ne => {
+        // adjust my region
+        const bbox = { ...region, ne }
+        // and update the form
+        update("bbox", bbox)
+        // all done
+        return
+    }
+    // for the south-west corner
+    const updateSW = sw => {
+        // adjust my region
+        const bbox = { ...region, sw }
+        // and update the form
+        update("bbox", bbox)
+        // all done
+        return
+    }
+
+    // render
+    return (
+        <Field name="bbox" value={ok} tip="the bounding box of a region">
+            <Value>
+                <Title />
+                <EntryBox>
+                    <Info>SW</Info>
+                    <SpacerBetween />
+                    <Longitude region={ne} update={updateNE} />
+                    <SpacerBetween />
+                    <Latitude region={ne} update={updateNE} />
+                </EntryBox>
+                <EntryBox>
+                    <Info>NE</Info>
+                    <SpacerBetween />
+                    <Longitude region={sw} update={updateSW} />
+                    <SpacerBetween />
+                    <Latitude region={sw} update={updateSW} />
+                </EntryBox>
+            </Value>
+        </Field>
+    )
+}
+
+
+// the table title
+const Title = () => {
+    return (
+        <TitleBox>
+            <Info />
+            <SpacerBetween />
+            <Header>longitude</Header>
+            <SpacerBetween />
+            <Header>latitude</Header>
+        </TitleBox>
+    )
+}
+
+// the containers
+const TitleBox = styled.div`
+    display: flex;
+    align-items: end;
+    font-family: rubik-light;
+    height: 1.2em;
+    margin: 0rem;
+    padding: 0.0rem 0.0rem;
+`
+
+const EntryBox = styled.div`
+    display: flex;
+    align-items: end;
+    height: 1.2em;
+    margin: 0rem;
+    padding: 0.125rem 0.0rem;
+`
+
+// headers
+const Header = styled.span`
+    display: inline-block;
+    width: 6.0em;
+    text-align: end;
+    vertical-align: bottom;
+    padding: 0.0rem 0.0 0.0rem 0.0rem;
+    margin: 0.0rem 0.0rem 0.0rem 0.0rem;
+    cursor: default;
+`
+// entries
+const Info = styled.span`
+    display: inline-block;
+    width: 2.0em;
+    text-align: end;
+    vertical-align: bottom;
+    padding: 0.0rem 0.0 0.0rem 0.0rem;
+    margin: 0.0rem 0.0rem 0.0rem 0.0rem;
+    cursor: default;
+`
+
+
+// end of file

--- a/ux/client/views/explorer/archive/buttons.js
+++ b/ux/client/views/explorer/archive/buttons.js
@@ -52,4 +52,5 @@ export const DisabledConnect = ({ children }) => {
     )
 }
 
+
 // end of file

--- a/ux/client/views/explorer/archive/circle.js
+++ b/ux/client/views/explorer/archive/circle.js
@@ -12,11 +12,13 @@ import React from 'react'
 import { Latitude } from './latitude'
 import { Longitude } from './longitude'
 import { Radius } from './radius'
-import { Field, Value, SpacerFirst, SpacerRest } from '../form'
+import { Field, Value, SpacerFirst, SpacerBetween } from '../form'
 
 
 // collect the coordinates of a point of interest
-export const Circle = ({ longitude, latitude, radius, update }) => {
+export const Circle = ({ region, update }) => {
+    // unpack the region
+    const { radius, longitude, latitude } = region
     // check the value
     const valid = longitude === "" || latitude == "" || radius == "" ? "" : "ok"
     // specialize the form update
@@ -27,9 +29,9 @@ export const Circle = ({ longitude, latitude, radius, update }) => {
             <Value>
                 <SpacerFirst title="positive number, in meters">radius:</SpacerFirst>
                 <Radius region={{ longitude, latitude, radius }} update={updateCircle} />
-                <SpacerRest title="decimal degrees in [-180, 180]">longitude:</SpacerRest>
+                <SpacerBetween title="decimal degrees in [-180, 180]">longitude:</SpacerBetween>
                 <Longitude region={{ longitude, latitude, radius }} update={updateCircle} />
-                <SpacerRest title="decimal degrees in [-90, 90]">latitude:</SpacerRest>
+                <SpacerBetween title="decimal degrees in [-90, 90]">latitude:</SpacerBetween>
                 <Latitude region={{ longitude, latitude, radius }} update={updateCircle} />
             </Value>
         </Field>

--- a/ux/client/views/explorer/archive/circle.js
+++ b/ux/client/views/explorer/archive/circle.js
@@ -9,156 +9,32 @@ import React from 'react'
 
 // local
 // components
-import { Field, Value, Numeric, SpacerFirst, SpacerRest } from '../form'
+import { Latitude } from './latitude'
+import { Longitude } from './longitude'
+import { Radius } from './radius'
+import { Field, Value, SpacerFirst, SpacerRest } from '../form'
 
 
 // collect the coordinates of a point of interest
 export const Circle = ({ longitude, latitude, radius, update }) => {
     // check the value
     const valid = longitude === "" || latitude == "" || radius == "" ? "" : "ok"
-    // build the radius mutator
-    const updateRadius = current => {
-        // build the event handler
-        const set = evt => {
-            // get the value from the form field
-            const candidate = evt.target.value
-            // the validation regex; checks for numbers in [-90, 90]
-            const regex = new RegExp([
-                "^", // the beginning of the string
-                "[+]?", // optional sign
-                "(?:", // followed by
-                "(?:\\d*)?", // the integer part
-                "(?:\\.*)?", // the decimal point
-                "(?:\\d*)?", // the fractional part
-                ")?",
-                "$", // the end of the string
-            ].join(''))
-            // build the point
-            const circle = {
-                // copy the longitude
-                longitude,
-                // copy the latitude
-                latitude,
-                // compete the radius
-                radius: candidate === "" || regex.test(candidate) ? candidate : current,
-            }
-            // update the form state
-            update("circle", circle)
-            // all done
-            return
-        }
-        // and return it
-        return set
-    }
-    // build the longitude mutator
-    const updateLongitude = current => {
-        // build the event handler
-        const set = evt => {
-            // get the value from the form field
-            const candidate = evt.target.value
-            // the validation regex; checks for numbers in [-180, 180]
-            const regex = new RegExp([
-                "^", // the beginning of the string
-                "[+-]?", // optional sign
-                "(?:", // followed by
-                "180(?:\\.0*)?", // the interval edges
-                "|", // or
-                "(?:(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:\\.\\d*)?)", // numbers in (-180, 180)
-                ")?",
-                "$", // the end of the string
-            ].join(''))
-            // build the circle
-            const circle = {
-                // copy the radius
-                radius,
-                // copy the latitude
-                latitude,
-                // compete the longitude
-                longitude: candidate === "" || regex.test(candidate) ? candidate : current,
-            }
-            // update the form state
-            update("circle", circle)
-            // all done
-            return
-        }
-        // and return it
-        return set
-    }
-    // build the latitude mutator
-    const updateLatitude = current => {
-        // build the event handler
-        const set = evt => {
-            // get the value from the form field
-            const candidate = evt.target.value
-            // the validation regex; checks for numbers in [-90, 90]
-            const regex = new RegExp([
-                "^", // the beginning of the string
-                "[+-]?", // optional sign
-                "(?:", // followed by
-                "90(?:\\.0*)?", // the interval edges
-                "|", // or
-                "(?:(?:[0-9]|[1-8][0-9])(?:\\.\\d*)?)", // numbers in (-90, 90)
-                ")?",
-                "$", // the end of the string
-            ].join(''))
-            // build the circle
-            const circle = {
-                // copy the radius
-                radius,
-                // copy the longitude
-                longitude,
-                // compete the latitude
-                latitude: candidate === "" || regex.test(candidate) ? candidate : current,
-            }
-            // update the form state
-            update("circle", circle)
-            // all done
-            return
-        }
-        // and return it
-        return set
-    }
-
-    // the behavior of the radius field
-    const setRadius = {
-        onChange: updateRadius(radius)
-    }
-    // the behavior of the longitude field
-    const setLongitude = {
-        onChange: updateLongitude(longitude)
-    }
-    // the behavior of the latitude field
-    const setLatitude = {
-        onChange: updateLatitude(latitude)
-    }
-
+    // specialize the form update
+    const updateCircle = (circle) => update("circle", circle)
     // render
     return (
         <Field name="circle" value={valid} tip="the center and radius of the circle of interest">
             <Value>
                 <SpacerFirst title="positive number, in meters">radius:</SpacerFirst>
-                <Numeric
-                    title="positive number, in meters"
-                    type="text" value={radius}
-                    {...setRadius}
-                />
+                <Radius region={{ longitude, latitude, radius }} update={updateCircle} />
                 <SpacerRest title="decimal degrees in [-180, 180]">longitude:</SpacerRest>
-                <Numeric
-                    title="decimal degrees in [-180, 180]"
-                    type="text" value={longitude}
-                    {...setLongitude}
-                />
+                <Longitude region={{ longitude, latitude, radius }} update={updateCircle} />
                 <SpacerRest title="decimal degrees in [-90, 90]">latitude:</SpacerRest>
-                <Numeric
-                    title="decimal degrees in [-90, 90]"
-                    type="text" value={latitude}
-                    {...setLatitude}
-                />
+                <Latitude region={{ longitude, latitude, radius }} update={updateCircle} />
             </Value>
         </Field>
     )
 }
-
 
 
 // end of file

--- a/ux/client/views/explorer/archive/circle.js
+++ b/ux/client/views/explorer/archive/circle.js
@@ -1,0 +1,164 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2025 all rights reserved
+
+
+// external
+import React from 'react'
+
+// local
+// components
+import { Field, Value, Numeric, SpacerFirst, SpacerRest } from '../form'
+
+
+// collect the coordinates of a point of interest
+export const Circle = ({ longitude, latitude, radius, update }) => {
+    // check the value
+    const valid = longitude === "" || latitude == "" || radius == "" ? "" : "ok"
+    // build the radius mutator
+    const updateRadius = current => {
+        // build the event handler
+        const set = evt => {
+            // get the value from the form field
+            const candidate = evt.target.value
+            // the validation regex; checks for numbers in [-90, 90]
+            const regex = new RegExp([
+                "^", // the beginning of the string
+                "[+]?", // optional sign
+                "(?:", // followed by
+                "(?:\\d*)?", // the integer part
+                "(?:\\.*)?", // the decimal point
+                "(?:\\d*)?", // the fractional part
+                ")?",
+                "$", // the end of the string
+            ].join(''))
+            // build the point
+            const circle = {
+                // copy the longitude
+                longitude,
+                // copy the latitude
+                latitude,
+                // compete the radius
+                radius: candidate === "" || regex.test(candidate) ? candidate : current,
+            }
+            // update the form state
+            update("circle", circle)
+            // all done
+            return
+        }
+        // and return it
+        return set
+    }
+    // build the longitude mutator
+    const updateLongitude = current => {
+        // build the event handler
+        const set = evt => {
+            // get the value from the form field
+            const candidate = evt.target.value
+            // the validation regex; checks for numbers in [-180, 180]
+            const regex = new RegExp([
+                "^", // the beginning of the string
+                "[+-]?", // optional sign
+                "(?:", // followed by
+                "180(?:\\.0*)?", // the interval edges
+                "|", // or
+                "(?:(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:\\.\\d*)?)", // numbers in (-180, 180)
+                ")?",
+                "$", // the end of the string
+            ].join(''))
+            // build the circle
+            const circle = {
+                // copy the radius
+                radius,
+                // copy the latitude
+                latitude,
+                // compete the longitude
+                longitude: candidate === "" || regex.test(candidate) ? candidate : current,
+            }
+            // update the form state
+            update("circle", circle)
+            // all done
+            return
+        }
+        // and return it
+        return set
+    }
+    // build the latitude mutator
+    const updateLatitude = current => {
+        // build the event handler
+        const set = evt => {
+            // get the value from the form field
+            const candidate = evt.target.value
+            // the validation regex; checks for numbers in [-90, 90]
+            const regex = new RegExp([
+                "^", // the beginning of the string
+                "[+-]?", // optional sign
+                "(?:", // followed by
+                "90(?:\\.0*)?", // the interval edges
+                "|", // or
+                "(?:(?:[0-9]|[1-8][0-9])(?:\\.\\d*)?)", // numbers in (-90, 90)
+                ")?",
+                "$", // the end of the string
+            ].join(''))
+            // build the circle
+            const circle = {
+                // copy the radius
+                radius,
+                // copy the longitude
+                longitude,
+                // compete the latitude
+                latitude: candidate === "" || regex.test(candidate) ? candidate : current,
+            }
+            // update the form state
+            update("circle", circle)
+            // all done
+            return
+        }
+        // and return it
+        return set
+    }
+
+    // the behavior of the radius field
+    const setRadius = {
+        onChange: updateRadius(radius)
+    }
+    // the behavior of the longitude field
+    const setLongitude = {
+        onChange: updateLongitude(longitude)
+    }
+    // the behavior of the latitude field
+    const setLatitude = {
+        onChange: updateLatitude(latitude)
+    }
+
+    // render
+    return (
+        <Field name="circle" value={valid} tip="the center and radius of the circle of interest">
+            <Value>
+                <SpacerFirst title="positive number, in meters">radius:</SpacerFirst>
+                <Numeric
+                    title="positive number, in meters"
+                    type="text" value={radius}
+                    {...setRadius}
+                />
+                <SpacerRest title="decimal degrees in [-180, 180]">longitude:</SpacerRest>
+                <Numeric
+                    title="decimal degrees in [-180, 180]"
+                    type="text" value={longitude}
+                    {...setLongitude}
+                />
+                <SpacerRest title="decimal degrees in [-90, 90]">latitude:</SpacerRest>
+                <Numeric
+                    title="decimal degrees in [-90, 90]"
+                    type="text" value={latitude}
+                    {...setLatitude}
+                />
+            </Value>
+        </Field>
+    )
+}
+
+
+
+// end of file

--- a/ux/client/views/explorer/archive/earth.js
+++ b/ux/client/views/explorer/archive/earth.js
@@ -21,6 +21,7 @@ import { Form, Body, Error } from '../form'
 // fields
 import { Name } from './name'
 import { Geo } from './geo'
+import { Filters } from './filters'
 // geographic region types
 import { Circle } from './circle'
 import { Line } from './line'
@@ -35,6 +36,8 @@ export const Earth = ({ view, setType, hide }) => {
     const [form, setForm] = React.useState({
         // the nickname
         name: "",
+        // the filters
+        filters: new Set(),
         // the type of region of interest
         geo: "",
         // point
@@ -156,8 +159,12 @@ export const Earth = ({ view, setType, hide }) => {
     )
     // use this to figure out which button to render
     const Connect = ready ? EnabledConnect : DisabledConnect
+
+    // unpack the selected filters
+    const geo = form.filters.has("geo")
     // resolve the geo search type
     const Region = form.geo === "" ? null : regionTypes[form.geo]
+
     // render
     return (
         <Panel>
@@ -165,8 +172,9 @@ export const Earth = ({ view, setType, hide }) => {
                 <Body>
                     <TypeSelector value="earth" update={setType} />
                     <Name value={form.name} update={update} />
-                    <Geo value={form.geo} update={update} types={regionTypes} />
-                    {form.geo && <Region region={form[form.geo]} update={update} />}
+                    <Filters value={form.filters} update={update} types={filterTypes} />
+                    {geo && <Geo value={form.geo} update={update} types={regionTypes} />}
+                    {geo && form.geo && <Region region={form[form.geo]} update={update} />}
                 </Body>
             </Form>
             <Connect connect={connect} />
@@ -192,6 +200,10 @@ const connectMutation = graphql`
     }
 `
 
+// the dispatch table with the supported filters
+const filterTypes = {
+    geo: Geo,
+}
 
 // the dispatch table with the supported geographic region types
 const regionTypes = {

--- a/ux/client/views/explorer/archive/earth.js
+++ b/ux/client/views/explorer/archive/earth.js
@@ -16,8 +16,16 @@ import { Busy } from './busy'
 import { Panel } from './panel'
 import { EnabledConnect, DisabledConnect, Cancel } from './buttons'
 import { TypeSelector } from './type'
-import { Name } from './name'
 import { Form, Body, Error } from '../form'
+
+// fields
+import { Name } from './name'
+import { Geo } from './geo'
+// geographic region types
+import { Circle } from './circle'
+import { Line } from './line'
+import { Point } from './point'
+import { Polygon } from './polygon'
 
 // a earth access data archive
 export const Earth = ({ view, setType, hide }) => {
@@ -27,6 +35,20 @@ export const Earth = ({ view, setType, hide }) => {
     const [form, setForm] = React.useState({
         // the nickname
         name: "",
+        // the type of region of interest
+        geo: "",
+        // point
+        point: { longitude: "", latitude: "" },
+        // circle
+        circle: { longitude: "", latitude: "", radius: "" },
+        // line
+        line: {
+            vertices: [],
+        },
+        // polygon
+        polygon: {
+            vertices: [],
+        },
     })
     // get the view mutator
     const decorate = useSetActiveView()
@@ -43,7 +65,7 @@ export const Earth = ({ view, setType, hide }) => {
                 // a copy of the old state
                 ...old,
                 // with the value of the given field replaced with the new one
-                [field]: value,
+                [field]: old[field] == value ? "" : value,
             }
             // hand it off
             return clone
@@ -134,6 +156,8 @@ export const Earth = ({ view, setType, hide }) => {
     )
     // use this to figure out which button to render
     const Connect = ready ? EnabledConnect : DisabledConnect
+    // resolve the geo search type
+    const Region = form.geo === "" ? null : regionTypes[form.geo]
     // render
     return (
         <Panel>
@@ -141,13 +165,15 @@ export const Earth = ({ view, setType, hide }) => {
                 <Body>
                     <TypeSelector value="earth" update={setType} />
                     <Name value={form.name} update={update} />
+                    <Geo value={form.geo} update={update} types={regionTypes} />
+                    {form.geo && <Region region={form[form.geo]} update={update} />}
                 </Body>
             </Form>
             <Connect connect={connect} />
             {!isInFlight && <Cancel onClick={cancel}>cancel</Cancel>}
             {error && <Error errors={error} />}
             {isInFlight && <Busy />}
-        </Panel>
+        </Panel >
     )
 }
 
@@ -165,5 +191,15 @@ const connectMutation = graphql`
         }
     }
 `
+
+
+// the dispatch table with the supported geographic region types
+const regionTypes = {
+    point: Point,
+    circle: Circle,
+    line: Line,
+    polygon: Polygon,
+}
+
 
 // end of file

--- a/ux/client/views/explorer/archive/earth.js
+++ b/ux/client/views/explorer/archive/earth.js
@@ -1,0 +1,168 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2025 all rights reserved
+
+
+// external
+import React from 'react'
+import { graphql, useMutation } from 'react-relay/hooks'
+
+// local
+// hooks
+import { useSetActiveView } from '../explorer/useSetActiveView'
+// components
+import { Busy } from './busy'
+import { Panel } from './panel'
+import { EnabledConnect, DisabledConnect, Cancel } from './buttons'
+import { TypeSelector } from './type'
+import { Name } from './name'
+import { Form, Body, Error } from '../form'
+
+// a earth access data archive
+export const Earth = ({ view, setType, hide }) => {
+    // error placeholder
+    const [error, setError] = React.useState(null)
+    // set up my state
+    const [form, setForm] = React.useState({
+        // the nickname
+        name: "",
+    })
+    // get the view mutator
+    const decorate = useSetActiveView()
+    // build the mutation request
+    const [request, isInFlight] = useMutation(connectMutation)
+    // set up the state update
+    const update = (field, value) => {
+        // clear any errors
+        setError(null)
+        // replace my state
+        setForm(old => {
+            // with
+            const clone = {
+                // a copy of the old state
+                ...old,
+                // with the value of the given field replaced with the new one
+                [field]: value,
+            }
+            // hand it off
+            return clone
+        })
+        // if the field is the archive nickname
+        if (field === "name") {
+            // update the uri of the archive in the current view
+            view.archive.uri = `earth:${value}`
+            // and set it
+            decorate(view)
+        }
+        // all done
+        return
+    }
+    // set up the archive connector
+    const connect = () => {
+        // if there is already a pending operation
+        if (isInFlight) {
+            // skip this update
+            return
+        }
+        // otherwise, collect the current state
+        const name = form.name
+        // send the mutation to the server
+        request({
+            // input
+            variables: {
+                // the payload
+                name: `earth:${name}`,
+                uri: `earth:${name}`,
+            },
+            // updater
+            updater: store => {
+                // get the root field of the query result
+                const payload = store.getRootField("connectArchive")
+                // if it's trivial
+                if (!payload) {
+                    // raise an issue
+                    throw new Error("could not connect to the data archive")
+                }
+                // ask for the new archive
+                const archive = payload.getLinkedRecord("archive")
+                // get the session manager
+                const qed = store.get("QED")
+                // get its connected archives
+                const archives = qed.getLinkedRecords("archives")
+                // add the new one to the pile
+                qed.setLinkedRecords([...archives, archive], "archives")
+                // all done
+                return
+            },
+            // when done
+            onCompleted: data => {
+                // clear the error
+                setError(null)
+                // remove the form from the view
+                hide()
+                // all done
+                return
+            },
+            // if something went wrong
+            onError: error => {
+                // record the error
+                setError([
+                    `got: ${error}`,
+                    `while connecting to the data archive '${name}'`,
+                ])
+                // all done
+                return
+            }
+        })
+    }
+    // build a handler that removes the form from view
+    const cancel = evt => {
+        // stop this event from bubbling up
+        evt.stopPropagation()
+        // and quash any side effects
+        evt.preventDefault()
+        // remove the view in my viewport from the pile
+        hide()
+        // all done
+        return
+    }
+    // determine whether i have enough information to make the connection
+    const ready = (
+        !isInFlight &&
+        form.name !== null && form.name.length
+    )
+    // use this to figure out which button to render
+    const Connect = ready ? EnabledConnect : DisabledConnect
+    // render
+    return (
+        <Panel>
+            <Form>
+                <Body>
+                    <TypeSelector value="earth" update={setType} />
+                    <Name value={form.name} update={update} />
+                </Body>
+            </Form>
+            <Connect connect={connect} />
+            {!isInFlight && <Cancel onClick={cancel}>cancel</Cancel>}
+            {error && <Error errors={error} />}
+            {isInFlight && <Busy />}
+        </Panel>
+    )
+}
+
+
+// the mutation that connects an earth access archive
+const connectMutation = graphql`
+    mutation earthArchiveMutation($name: String!, $uri: String!) {
+        connectArchive(name: $name, uri: $uri) {
+            archive {
+                id
+                name
+                readers
+            }
+        }
+    }
+`
+
+// end of file

--- a/ux/client/views/explorer/archive/earth.js
+++ b/ux/client/views/explorer/archive/earth.js
@@ -99,11 +99,17 @@ export const Earth = ({ view, setType, hide }) => {
                 // the payload
                 name: `earth:${name}`,
                 uri: `earth:${name}`,
+                filters: [...form.filters],
+                geo: form.geo,
+                point: form.point,
+                circle: form.circle,
+                line: form.line,
+                polygon: form.polygon,
             },
             // updater
             updater: store => {
                 // get the root field of the query result
-                const payload = store.getRootField("connectArchive")
+                const payload = store.getRootField("connectEarthAccessArchive")
                 // if it's trivial
                 if (!payload) {
                     // raise an issue
@@ -188,8 +194,17 @@ export const Earth = ({ view, setType, hide }) => {
 
 // the mutation that connects an earth access archive
 const connectMutation = graphql`
-    mutation earthArchiveMutation($name: String!, $uri: String!) {
-        connectArchive(name: $name, uri: $uri) {
+    mutation earthArchiveMutation(
+        $name: String!, $uri: String!, $filters: [String!]!,
+        $geo: String,
+        $point: GeoVertexInput, $circle: GeoCircleInput,
+        $line: GeoLineInput, $polygon: GeoPolygonInput
+    ) {
+        connectEarthAccessArchive(
+            name: $name, uri: $uri,
+            filters: $filters,
+            geo: $geo, point: $point, circle: $circle, line: $line, polygon: $polygon
+            ) {
             archive {
                 id
                 name

--- a/ux/client/views/explorer/archive/earth.js
+++ b/ux/client/views/explorer/archive/earth.js
@@ -23,6 +23,7 @@ import { Name } from './name'
 import { Geo } from './geo'
 import { Filters } from './filters'
 // geographic region types
+import { BBox } from './bbox'
 import { Circle } from './circle'
 import { Line } from './line'
 import { Point } from './point'
@@ -40,6 +41,8 @@ export const Earth = ({ view, setType, hide }) => {
         filters: new Set(),
         // the type of region of interest
         geo: "",
+        // bounding box
+        bbox: { ne: { longitude: "", latitude: "" }, sw: { longitude: "", latitude: "" } },
         // point
         point: { longitude: "", latitude: "" },
         // circle
@@ -101,6 +104,7 @@ export const Earth = ({ view, setType, hide }) => {
                 uri: `earth:${name}`,
                 filters: [...form.filters],
                 geo: form.geo,
+                bbox: form.bbox,
                 point: form.point,
                 circle: form.circle,
                 line: form.line,
@@ -197,13 +201,13 @@ const connectMutation = graphql`
     mutation earthArchiveMutation(
         $name: String!, $uri: String!, $filters: [String!]!,
         $geo: String,
-        $point: GeoVertexInput, $circle: GeoCircleInput,
+        $bbox: GeoBBoxInput, $point: GeoVertexInput, $circle: GeoCircleInput,
         $line: GeoLineInput, $polygon: GeoPolygonInput
     ) {
         connectEarthAccessArchive(
             name: $name, uri: $uri,
             filters: $filters,
-            geo: $geo, point: $point, circle: $circle, line: $line, polygon: $polygon
+            geo: $geo, bbox: $bbox, point: $point, circle: $circle, line: $line, polygon: $polygon
             ) {
             archive {
                 id
@@ -222,6 +226,7 @@ const filterTypes = {
 
 // the dispatch table with the supported geographic region types
 const regionTypes = {
+    bbox: BBox,
     point: Point,
     circle: Circle,
     line: Line,

--- a/ux/client/views/explorer/archive/earth.js
+++ b/ux/client/views/explorer/archive/earth.js
@@ -22,6 +22,8 @@ import { Form, Body, Error } from '../form'
 import { Name } from './name'
 import { Geo } from './geo'
 import { Filters } from './filters'
+// time interval
+import { When } from './when'
 // geographic region types
 import { BBox } from './bbox'
 import { Circle } from './circle'
@@ -39,6 +41,8 @@ export const Earth = ({ view, setType, hide }) => {
         name: "",
         // the filters
         filters: new Set(),
+        // a time interval
+        when: { begin: "", end: "" },
         // the type of region of interest
         geo: "",
         // bounding box
@@ -103,6 +107,7 @@ export const Earth = ({ view, setType, hide }) => {
                 name: `earth:${name}`,
                 uri: `earth:${name}`,
                 filters: [...form.filters],
+                when: form.when,
                 geo: form.geo,
                 bbox: form.bbox,
                 point: form.point,
@@ -172,6 +177,7 @@ export const Earth = ({ view, setType, hide }) => {
 
     // unpack the selected filters
     const geo = form.filters.has("geo")
+    const when = form.filters.has("when")
     // resolve the geo search type
     const Region = form.geo === "" ? null : regionTypes[form.geo]
 
@@ -183,6 +189,7 @@ export const Earth = ({ view, setType, hide }) => {
                     <TypeSelector value="earth" update={setType} />
                     <Name value={form.name} update={update} />
                     <Filters value={form.filters} update={update} types={filterTypes} />
+                    {when && <When interval={form.when} update={update} />}
                     {geo && <Geo value={form.geo} update={update} types={regionTypes} />}
                     {geo && form.geo && <Region region={form[form.geo]} update={update} />}
                 </Body>
@@ -200,6 +207,7 @@ export const Earth = ({ view, setType, hide }) => {
 const connectMutation = graphql`
     mutation earthArchiveMutation(
         $name: String!, $uri: String!, $filters: [String!]!,
+        $when: TimeIntervalInput,
         $geo: String,
         $bbox: GeoBBoxInput, $point: GeoVertexInput, $circle: GeoCircleInput,
         $line: GeoLineInput, $polygon: GeoPolygonInput
@@ -207,6 +215,7 @@ const connectMutation = graphql`
         connectEarthAccessArchive(
             name: $name, uri: $uri,
             filters: $filters,
+            when: $when,
             geo: $geo, bbox: $bbox, point: $point, circle: $circle, line: $line, polygon: $polygon
             ) {
             archive {
@@ -221,6 +230,7 @@ const connectMutation = graphql`
 
 // the dispatch table with the supported filters
 const filterTypes = {
+    when: When,
     geo: Geo,
 }
 

--- a/ux/client/views/explorer/archive/earth.js
+++ b/ux/client/views/explorer/archive/earth.js
@@ -159,6 +159,7 @@ const connectMutation = graphql`
             archive {
                 id
                 name
+                uri
                 readers
             }
         }

--- a/ux/client/views/explorer/archive/filters.js
+++ b/ux/client/views/explorer/archive/filters.js
@@ -22,20 +22,24 @@ export const Filters = ({ value, update, types }) => {
         if (value.has(type)) {
             // build a handler that removes it
             return () => {
+                // copy the current value
+                const clone = new Set([...value])
                 // remove the value
-                value.delete(type)
+                clone.delete(type)
                 // update the form
-                update("filter", value)
+                update("filters", clone)
                 // all done
                 return
             }
         }
         // otherwise, build a handler that adds it
         return () => {
+            // copy the current value
+            const clone = new Set([...value])
             // add the value
-            value.add(type)
+            clone.add(type)
             // update the form
-            update("filter", type)
+            update("filters", clone)
             // all done
             return
         }

--- a/ux/client/views/explorer/archive/filters.js
+++ b/ux/client/views/explorer/archive/filters.js
@@ -1,0 +1,77 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2025 all rights reserved
+
+
+// externals
+import React from 'react'
+
+
+// local
+// components
+import { Field, Values, enumValue } from '../form'
+
+// the set of supported filters
+export const Filters = ({ value, update, types }) => {
+    // validate my contents
+    const ok = value.size ? "ok" : ""
+    // make a handler that sets the region type
+    const toggle = type => {
+        // if {value} already contains this filter type
+        if (value.has(type)) {
+            // build a handler that removes it
+            return () => {
+                // remove the value
+                value.delete(type)
+                // update the form
+                update("filter", value)
+                // all done
+                return
+            }
+        }
+        // otherwise, build a handler that adds it
+        return () => {
+            // add the value
+            value.add(type)
+            // update the form
+            update("filter", type)
+            // all done
+            return
+        }
+    }
+    // render
+    return (
+        <Field name="filters" value={ok} tip="select the search filters">
+            <Values>
+                {Object.keys(types).map(type => (
+                    <Type
+                        key={type}
+                        name={type} rep={type} current={value} toggle={toggle} />
+                ))}
+            </Values>
+        </Field>
+    )
+}
+
+
+// the filter type
+const Type = ({ name, rep, current, toggle }) => {
+    // assemble the behaviors
+    const behaviors = {
+        onClick: toggle(rep),
+    }
+    // deduce my state
+    const state = current.has(rep) ? "selected" : "enabled"
+    // pick a field selector based on my state
+    const Selector = enumValue(state)
+    // and render it
+    return (
+        <Selector {...behaviors}>
+            {name}
+        </Selector>
+    )
+}
+
+
+// end of file

--- a/ux/client/views/explorer/archive/geo.js
+++ b/ux/client/views/explorer/archive/geo.js
@@ -57,4 +57,5 @@ const Type = ({ name, rep, current, select }) => {
     )
 }
 
+
 // end of file

--- a/ux/client/views/explorer/archive/geo.js
+++ b/ux/client/views/explorer/archive/geo.js
@@ -1,0 +1,60 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2025 all rights reserved
+
+
+// externals
+import React from 'react'
+
+
+// local
+// components
+import { Field, Values, enumValue } from '../form'
+
+// the geographic search type selector
+export const Geo = ({ value, update, types }) => {
+    // make a handler that sets the region type
+    const select = type => {
+        // build the selector
+        return () => {
+            // update the form state
+            update("geo", type)
+            // all done
+            return
+        }
+    }
+    // render
+    return (
+        <Field name="search region" value={value} tip="select the type of region of interest">
+            <Values>
+                {Object.keys(types).map(type => (
+                    <Type
+                        key={type}
+                        name={type} rep={type} current={value} select={select} />
+                ))}
+            </Values>
+        </Field>
+    )
+}
+
+
+// the region type
+const Type = ({ name, rep, current, select }) => {
+    // assemble the behaviors
+    const behaviors = {
+        onClick: select(rep),
+    }
+    // deduce my state
+    const state = current === rep ? "selected" : "enabled"
+    // pick a field selector based on my state
+    const Selector = enumValue(state)
+    // and render it
+    return (
+        <Selector {...behaviors}>
+            {name}
+        </Selector>
+    )
+}
+
+// end of file

--- a/ux/client/views/explorer/archive/index.js
+++ b/ux/client/views/explorer/archive/index.js
@@ -9,4 +9,5 @@ export { Connect } from './connect'
 export { Archive } from './archive'
 export { Selector } from './selector'
 
+
 // end of file

--- a/ux/client/views/explorer/archive/latitude.js
+++ b/ux/client/views/explorer/archive/latitude.js
@@ -1,0 +1,66 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2025 all rights reserved
+
+
+// external
+import React from 'react'
+
+// local
+// components
+import { Numeric } from '../form'
+
+
+// collect the latitude of a region of interest
+export const Latitude = ({ region, update }) => {
+    // unpack the region
+    const { latitude, ...rest } = region
+    // build the latitude mutator
+    const set = () => {
+        // build the event handler
+        const handler = evt => {
+            // get the value from the form field
+            const candidate = evt.target.value
+            // the validation regex; checks for numbers in [-90, 90]
+            const regex = new RegExp([
+                "^", // the beginning of the string
+                "[+-]?", // optional sign
+                "(?:", // followed by
+                "90(?:\\.0*)?", // the interval edges
+                "|", // or
+                "(?:(?:[0-9]|[1-8][0-9])(?:\\.\\d*)?)", // numbers in (-90, 90)
+                ")?",
+                "$", // the end of the string
+            ].join(''))
+            // build the new region
+            const replacement = {
+                // unpack the rest of the region properties
+                ...rest,
+                // compete the latitude
+                latitude: candidate === "" || regex.test(candidate) ? candidate : latitude,
+            }
+            // update the form state
+            update(replacement)
+            // all done
+            return
+        }
+        // and return it
+        return handler
+    }
+    // the behaviors of the latitude field
+    const behaviors = {
+        onChange: set()
+    }
+    // render
+    return (
+        <Numeric
+            title="decimal degrees in [-90, 90]" type="text"
+            value={latitude}
+            {...behaviors}
+        />
+    )
+}
+
+
+// end of file

--- a/ux/client/views/explorer/archive/latitude.js
+++ b/ux/client/views/explorer/archive/latitude.js
@@ -29,7 +29,7 @@ export const Latitude = ({ region, update }) => {
                 "(?:", // followed by
                 "90(?:\\.0*)?", // the interval edges
                 "|", // or
-                "(?:(?:[0-9]|[1-8][0-9])(?:\\.\\d*)?)", // numbers in (-90, 90)
+                "(?:(?:[0-9]|[1-8][0-9])?(?:\\.\\d*)?)", // numbers in (-90, 90)
                 ")?",
                 "$", // the end of the string
             ].join(''))

--- a/ux/client/views/explorer/archive/line.js
+++ b/ux/client/views/explorer/archive/line.js
@@ -1,0 +1,81 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2025 all rights reserved
+
+
+// external
+import React from 'react'
+import styled from 'styled-components'
+
+// local
+// components
+import { Vertex } from './vertex'
+import { Field, Value, SpacerBetween } from '../form'
+
+
+// collect the coordinates of a line of interest
+export const Line = ({ region, update }) => {
+    // unpack the region
+    const { vertices } = region
+    // check the size
+    const empty = vertices.length === 0
+    // check that the contents are non trivial
+    const nontrivial = vertices.some(v => v.longitude !== "" && v.latitude !== "")
+    // validate my contents
+    const ok = nontrivial ? "ok" : ""
+    // make sure there is something the user can modify
+    if (empty) {
+        // by adding a trivial vertex to the displayed pile
+        vertices.splice(0, 0, { longitude: "", latitude: "" })
+    }
+    // specialize the form update
+    const updateLine = (line) => update("line", line)
+    // render
+    return (
+        <Field name="line" value={ok} tip="the coordinates the vertices of a line interest">
+            <Value>
+                <Title />
+                {vertices.map((_, idx) =>
+                    <Vertex key={`v${idx}`} idx={idx} region={region} update={updateLine} />
+                )}
+            </Value>
+        </Field>
+    )
+}
+
+
+// the table title
+const Title = () => {
+    return (
+        <Box>
+            <Header>longitude</Header>
+            <SpacerBetween />
+            <Header>latitude</Header>
+        </Box>
+    )
+}
+
+// the container
+const Box = styled.div`
+    display: flex;
+    align-items: end;
+    font-family: rubik-light;
+    height: 1.2em;
+    margin: 0em;
+    padding: 0.0rem 0.0rem;
+`
+
+// headers
+const Header = styled.span`
+    display: inline-block;
+    width: 6.0em;
+    text-align: end;
+    vertical-align: bottom;
+    padding: 0.0rem 0.0 0.0rem 0.0rem;
+    margin: 0.0rem 0.0rem 0.0rem 0.0rem;
+    cursor: default;
+`
+
+
+// end of file

--- a/ux/client/views/explorer/archive/local.js
+++ b/ux/client/views/explorer/archive/local.js
@@ -173,4 +173,5 @@ const connectMutation = graphql`
     }
 `
 
+
 // end of file

--- a/ux/client/views/explorer/archive/longitude.js
+++ b/ux/client/views/explorer/archive/longitude.js
@@ -1,0 +1,66 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2025 all rights reserved
+
+
+// external
+import React from 'react'
+
+// local
+// components
+import { Numeric } from '../form'
+
+
+// collect the longitude of a region of interest
+export const Longitude = ({ region, update }) => {
+    // unpack the region
+    const { longitude, ...rest } = region
+    // build the longitude mutator
+    const set = () => {
+        // build the event handler
+        const handler = evt => {
+            // get the value from the form field
+            const candidate = evt.target.value
+            // the validation regex; checks for numbers in [-90, 90]
+            const regex = new RegExp([
+                "^", // the beginning of the string
+                "[+-]?", // optional sign
+                "(?:", // followed by
+                "180(?:\\.0*)?", // the interval edges
+                "|", // or
+                "(?:(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:\\.\\d*)?)", // numbers in (-180, 180)
+                ")?",
+                "$", // the end of the string
+            ].join(''))
+            // build the new region
+            const replacement = {
+                // unpack the rest of the region properties
+                ...rest,
+                // compete the longitude
+                longitude: candidate === "" || regex.test(candidate) ? candidate : longitude,
+            }
+            // update the form state
+            update(replacement)
+            // all done
+            return
+        }
+        // and return it
+        return handler
+    }
+    // the behaviors of the longitude field
+    const behaviors = {
+        onChange: set()
+    }
+    // render
+    return (
+        <Numeric
+            title="decimal degrees in [-180, 180]" type="text"
+            value={longitude}
+            {...behaviors}
+        />
+    )
+}
+
+
+// end of file

--- a/ux/client/views/explorer/archive/longitude.js
+++ b/ux/client/views/explorer/archive/longitude.js
@@ -29,7 +29,7 @@ export const Longitude = ({ region, update }) => {
                 "(?:", // followed by
                 "180(?:\\.0*)?", // the interval edges
                 "|", // or
-                "(?:(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:\\.\\d*)?)", // numbers in (-180, 180)
+                "(?:(?:[0-9]|[1-9][0-9]|1[0-7][0-9])?(?:\\.\\d*)?)", // numbers in (-180, 180)
                 ")?",
                 "$", // the end of the string
             ].join(''))

--- a/ux/client/views/explorer/archive/point.js
+++ b/ux/client/views/explorer/archive/point.js
@@ -1,0 +1,115 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2025 all rights reserved
+
+
+// external
+import React from 'react'
+
+// local
+// components
+import { Field, Value, Numeric, SpacerFirst, SpacerRest } from '../form'
+
+
+// collect the coordinates of a point of interest
+export const Point = ({ longitude, latitude, update }) => {
+    // check the value
+    const valid = longitude === "" || latitude == "" ? "" : "ok"
+    // build the longitude mutator
+    const updateLongitude = current => {
+        // build the event handler
+        const set = evt => {
+            // get the value from the form field
+            const candidate = evt.target.value
+            // the validation regex; checks for numbers in [-180, 180]
+            const regex = new RegExp([
+                "^", // the beginning of the string
+                "[+-]?", // optional sign
+                "(?:", // followed by
+                "180(?:\\.0*)?", // the interval edges
+                "|", // or
+                "(?:(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:\\.\\d*)?)", // numbers in (-180, 180)
+                ")?",
+                "$", // the end of the string
+            ].join(''))
+            // build the point
+            const point = {
+                // copy the latitude
+                latitude,
+                // compete the longitude
+                longitude: candidate === "" || regex.test(candidate) ? candidate : current,
+            }
+            // update the form state
+            update("point", point)
+            // all done
+            return
+        }
+        // and return it
+        return set
+    }
+    // build the latitude mutator
+    const updateLatitude = current => {
+        // build the event handler
+        const set = evt => {
+            // get the value from the form field
+            const candidate = evt.target.value
+            // the validation regex; checks for numbers in [-90, 90]
+            const regex = new RegExp([
+                "^", // the beginning of the string
+                "[+-]?", // optional sign
+                "(?:", // followed by
+                "90(?:\\.0*)?", // the interval edges
+                "|", // or
+                "(?:(?:[0-9]|[1-8][0-9])(?:\\.\\d*)?)", // numbers in (-90, 90)
+                ")?",
+                "$", // the end of the string
+            ].join(''))
+            // build the point
+            const point = {
+                // copy the longitude
+                longitude,
+                // compete the latitude
+                latitude: candidate === "" || regex.test(candidate) ? candidate : current,
+            }
+            // update the form state
+            update("point", point)
+            // all done
+            return
+        }
+        // and return it
+        return set
+    }
+
+    // the behavior of the longitude field
+    const setLongitude = {
+        onChange: updateLongitude(longitude)
+    }
+    // the behavior of the latitude field
+    const setLatitude = {
+        onChange: updateLatitude(latitude)
+    }
+
+    // render
+    return (
+        <Field name="point" value={valid} tip="the coordinates the point of interest">
+            <Value>
+                <SpacerFirst title="decimal degrees in [-180, 180]">longitude:</SpacerFirst>
+                <Numeric
+                    title="decimal degrees in [-180, 180]"
+                    type="text" value={longitude === null ? "" : longitude}
+                    {...setLongitude}
+                />
+                <SpacerRest title="decimal degrees in [-90, 90]">latitude:</SpacerRest>
+                <Numeric
+                    title="decimal degrees in [-90, 90]"
+                    type="text" value={latitude === null ? "" : latitude}
+                    {...setLatitude}
+                />
+            </Value>
+        </Field>
+    )
+}
+
+
+// end of file

--- a/ux/client/views/explorer/archive/point.js
+++ b/ux/client/views/explorer/archive/point.js
@@ -11,11 +11,13 @@ import React from 'react'
 // components
 import { Latitude } from './latitude'
 import { Longitude } from './longitude'
-import { Field, Value, SpacerFirst, SpacerRest } from '../form'
+import { Field, Value, SpacerFirst, SpacerBetween } from '../form'
 
 
 // collect the coordinates of a point of interest
-export const Point = ({ longitude, latitude, update }) => {
+export const Point = ({ region, update }) => {
+    // unpack the point
+    const { longitude, latitude } = region
     // check the value
     const valid = longitude === "" || latitude == "" ? "" : "ok"
     // specialize the form update
@@ -26,7 +28,7 @@ export const Point = ({ longitude, latitude, update }) => {
             <Value>
                 <SpacerFirst title="decimal degrees in [-180, 180]">longitude:</SpacerFirst>
                 <Longitude region={{ longitude, latitude }} update={updatePoint} />
-                <SpacerRest title="decimal degrees in [-90, 90]">latitude:</SpacerRest>
+                <SpacerBetween title="decimal degrees in [-90, 90]">latitude:</SpacerBetween>
                 <Latitude region={{ longitude, latitude }} update={updatePoint} />
             </Value>
         </Field>

--- a/ux/client/views/explorer/archive/point.js
+++ b/ux/client/views/explorer/archive/point.js
@@ -9,103 +9,25 @@ import React from 'react'
 
 // local
 // components
-import { Field, Value, Numeric, SpacerFirst, SpacerRest } from '../form'
+import { Latitude } from './latitude'
+import { Longitude } from './longitude'
+import { Field, Value, SpacerFirst, SpacerRest } from '../form'
 
 
 // collect the coordinates of a point of interest
 export const Point = ({ longitude, latitude, update }) => {
     // check the value
     const valid = longitude === "" || latitude == "" ? "" : "ok"
-    // build the longitude mutator
-    const updateLongitude = current => {
-        // build the event handler
-        const set = evt => {
-            // get the value from the form field
-            const candidate = evt.target.value
-            // the validation regex; checks for numbers in [-180, 180]
-            const regex = new RegExp([
-                "^", // the beginning of the string
-                "[+-]?", // optional sign
-                "(?:", // followed by
-                "180(?:\\.0*)?", // the interval edges
-                "|", // or
-                "(?:(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:\\.\\d*)?)", // numbers in (-180, 180)
-                ")?",
-                "$", // the end of the string
-            ].join(''))
-            // build the point
-            const point = {
-                // copy the latitude
-                latitude,
-                // compete the longitude
-                longitude: candidate === "" || regex.test(candidate) ? candidate : current,
-            }
-            // update the form state
-            update("point", point)
-            // all done
-            return
-        }
-        // and return it
-        return set
-    }
-    // build the latitude mutator
-    const updateLatitude = current => {
-        // build the event handler
-        const set = evt => {
-            // get the value from the form field
-            const candidate = evt.target.value
-            // the validation regex; checks for numbers in [-90, 90]
-            const regex = new RegExp([
-                "^", // the beginning of the string
-                "[+-]?", // optional sign
-                "(?:", // followed by
-                "90(?:\\.0*)?", // the interval edges
-                "|", // or
-                "(?:(?:[0-9]|[1-8][0-9])(?:\\.\\d*)?)", // numbers in (-90, 90)
-                ")?",
-                "$", // the end of the string
-            ].join(''))
-            // build the point
-            const point = {
-                // copy the longitude
-                longitude,
-                // compete the latitude
-                latitude: candidate === "" || regex.test(candidate) ? candidate : current,
-            }
-            // update the form state
-            update("point", point)
-            // all done
-            return
-        }
-        // and return it
-        return set
-    }
-
-    // the behavior of the longitude field
-    const setLongitude = {
-        onChange: updateLongitude(longitude)
-    }
-    // the behavior of the latitude field
-    const setLatitude = {
-        onChange: updateLatitude(latitude)
-    }
-
+    // specialize the form update
+    const updatePoint = (point) => update("point", point)
     // render
     return (
         <Field name="point" value={valid} tip="the coordinates the point of interest">
             <Value>
                 <SpacerFirst title="decimal degrees in [-180, 180]">longitude:</SpacerFirst>
-                <Numeric
-                    title="decimal degrees in [-180, 180]"
-                    type="text" value={longitude === null ? "" : longitude}
-                    {...setLongitude}
-                />
+                <Longitude region={{ longitude, latitude }} update={updatePoint} />
                 <SpacerRest title="decimal degrees in [-90, 90]">latitude:</SpacerRest>
-                <Numeric
-                    title="decimal degrees in [-90, 90]"
-                    type="text" value={latitude === null ? "" : latitude}
-                    {...setLatitude}
-                />
+                <Latitude region={{ longitude, latitude }} update={updatePoint} />
             </Value>
         </Field>
     )

--- a/ux/client/views/explorer/archive/polygon.js
+++ b/ux/client/views/explorer/archive/polygon.js
@@ -1,0 +1,74 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2025 all rights reserved
+
+
+// external
+import React from 'react'
+import styled from 'styled-components'
+
+// local
+// components
+import { Vertex } from './vertex'
+import { Field, Value, SpacerBetween } from '../form'
+
+
+// collect the coordinates of a polygon of interest
+export const Polygon = ({ region, update }) => {
+    // unpack the region
+    const { vertices } = region
+    // validate my contents
+    const ok = (
+        vertices.length > 0 && vertices.some(v => v.longitude !== "" && v.latitude !== "")
+    ) ? "ok" : ""
+    // specialize the form update
+    const updatePolygon = (polygon) => update("polygon", polygon)
+    // render
+    return (
+        <Field name="polygon" value={ok} tip="the coordinates the corners of a polygon interest">
+            <Value>
+                <Title />
+                {vertices.map((_, idx) =>
+                    <Vertex key={`v${idx}`} idx={idx} region={region} update={updatePolygon} />
+                )}
+            </Value>
+        </Field>
+    )
+}
+
+
+// the table title
+const Title = () => {
+    return (
+        <Box>
+            <Header>longitude</Header>
+            <SpacerBetween />
+            <Header>latitude</Header>
+        </Box>
+    )
+}
+
+// the container
+const Box = styled.div`
+    display: flex;
+    align-items: end;
+    font-family: rubik-light;
+    height: 1.2em;
+    margin: 0em;
+    padding: 0.0rem 0.0rem;
+`
+
+// headers
+const Header = styled.span`
+    display: inline-block;
+    width: 6.0em;
+    text-align: end;
+    vertical-align: bottom;
+    padding: 0.0rem 0.0 0.0rem 0.0rem;
+    margin: 0.0rem 0.0rem 0.0rem 0.0rem;
+    cursor: default;
+`
+
+
+// end of file

--- a/ux/client/views/explorer/archive/polygon.js
+++ b/ux/client/views/explorer/archive/polygon.js
@@ -18,10 +18,17 @@ import { Field, Value, SpacerBetween } from '../form'
 export const Polygon = ({ region, update }) => {
     // unpack the region
     const { vertices } = region
+    // check the size
+    const empty = vertices.length === 0
+    // check that the contents are non trivial
+    const nontrivial = vertices.some(v => v.longitude !== "" && v.latitude !== "")
     // validate my contents
-    const ok = (
-        vertices.length > 0 && vertices.some(v => v.longitude !== "" && v.latitude !== "")
-    ) ? "ok" : ""
+    const ok = nontrivial ? "ok" : ""
+    // make sure there is something the user can modify
+    if (empty) {
+        // by adding a trivial vertex to the displayed pile
+        vertices.splice(0, 0, { longitude: "", latitude: "" })
+    }
     // specialize the form update
     const updatePolygon = (polygon) => update("polygon", polygon)
     // render

--- a/ux/client/views/explorer/archive/polygon.js
+++ b/ux/client/views/explorer/archive/polygon.js
@@ -21,9 +21,9 @@ export const Polygon = ({ region, update }) => {
     // check the size
     const empty = vertices.length === 0
     // check that the contents are non trivial
-    const nontrivial = vertices.some(v => v.longitude !== "" && v.latitude !== "")
+    const nontrivial = vertices.every(v => v.longitude !== "" && v.latitude !== "")
     // validate my contents
-    const ok = nontrivial ? "ok" : ""
+    const ok = (!empty && nontrivial) ? "ok" : ""
     // make sure there is something the user can modify
     if (empty) {
         // by adding a trivial vertex to the displayed pile

--- a/ux/client/views/explorer/archive/radius.js
+++ b/ux/client/views/explorer/archive/radius.js
@@ -1,0 +1,66 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2025 all rights reserved
+
+
+// external
+import React from 'react'
+
+// local
+// components
+import { Numeric } from '../form'
+
+
+// collect the radius of a region of interest
+export const Radius = ({ region, update }) => {
+    // unpack the region
+    const { radius, ...rest } = region
+    // build the radius mutator
+    const set = () => {
+        // build the event handler
+        const handler = evt => {
+            // get the value from the form field
+            const candidate = evt.target.value
+            // the validation regex; checks for numbers in [-90, 90]
+            const regex = new RegExp([
+                "^", // the beginning of the string
+                "[+]?", // optional sign
+                "(?:", // followed by
+                "(?:\\d*)?", // the integer part
+                "(?:\\.*)?", // the decimal point
+                "(?:\\d*)?", // the fractional part
+                ")?",
+                "$", // the end of the string
+            ].join(''))
+            // build the new region
+            const replacement = {
+                // unpack the rest of the region properties
+                ...rest,
+                // compete the radius
+                radius: candidate === "" || regex.test(candidate) ? candidate : radius,
+            }
+            // update the form state
+            update(replacement)
+            // all done
+            return
+        }
+        // and return it
+        return handler
+    }
+    // the behaviors of the radius field
+    const behaviors = {
+        onChange: set()
+    }
+    // render
+    return (
+        <Numeric
+            title="decimal degrees in [-180, 180]" type="text"
+            value={radius}
+            {...behaviors}
+        />
+    )
+}
+
+
+// end of file

--- a/ux/client/views/explorer/archive/styles.js
+++ b/ux/client/views/explorer/archive/styles.js
@@ -7,7 +7,7 @@
 // get colors
 import { theme, wheel } from "~/palette"
 // paint for my badges
-import { control, selector as baseSelector } from '../explorer/styles'
+import { badge, control, selector as baseSelector } from '../explorer/styles'
 
 
 // just use the base selector
@@ -18,6 +18,18 @@ export const selector = baseSelector
 export const connect = {
     // inherit
     ...control,
+}
+
+// the button that adds a vertex to a pile
+export const add = {
+    // inherit
+    ...badge,
+}
+
+// the button that deletes a vertex from a pile
+export const del = {
+    // inherit
+    ...badge,
 }
 
 

--- a/ux/client/views/explorer/archive/timestamp.js
+++ b/ux/client/views/explorer/archive/timestamp.js
@@ -1,0 +1,80 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2025 all rights reserved
+
+
+// external
+import React from 'react'
+import styled from 'styled-components'
+
+// local
+// components
+import { EnabledInput } from '../form'
+
+
+// collect a (partial) timestamp
+export const Timestamp = ({ interval, field, update }) => {
+    // build the interval mutator
+    const set = () => {
+        // build the event handler
+        const handler = evt => {
+            // get the value from the form field
+            const candidate = evt.target.value
+            // build the new region
+            const replacement = {
+                // unpack the rest of the region properties
+                ...interval,
+                // compete my field
+                [field]: candidate === "" || regex.test(candidate) ? candidate : interval[field],
+            }
+            // update the form state
+            update(replacement)
+            // all done
+            return
+        }
+        // and return it
+        return handler
+    }
+    // the behaviors of the longitude field
+    const behaviors = {
+        onChange: set()
+    }
+    // render
+    return (
+        <Stamp
+            title="a timestamp in YYYY-MM-DD HH:mm:ss" type="text"
+            value={interval[field]}
+            {...behaviors}
+        />
+    )
+}
+
+
+// the input field
+const Stamp = styled(EnabledInput)`
+    width: 12rem;
+`
+
+// the timestamp regular expression
+// the parts
+const YEAR = /2(?:0(?:\d(?:\d)?)?)?/
+const MONTH = /(?:-(?:(?:0\d?)|(?:1[0-2]?))?)?/
+const DAY = /(?:-(?:(?:3[01]?)|(?:[1-2]\d?)|(?:0[1-9]?))?)?/
+const SEP = /(?:\s+)?/
+const HOUR = /(?:(?:[01]\d?)|(?:2[0-3]?))?/
+const MINUTE = /(?::(?:[0-5]\d?)?)?/
+const SECOND = /(?::(?:[0-5]\d?)?)?/
+// putting it all together
+const regex = new RegExp(
+    `^` +
+    `${YEAR.source}${MONTH.source}${DAY.source}` +
+    `${SEP.source}` +
+    `${HOUR.source}${MINUTE.source}${SECOND.source}` +
+    `$`
+)
+// show me
+console.log(regex.source)
+
+
+// end of file

--- a/ux/client/views/explorer/archive/timestamp.js
+++ b/ux/client/views/explorer/archive/timestamp.js
@@ -43,7 +43,7 @@ export const Timestamp = ({ interval, field, update }) => {
     // render
     return (
         <Stamp
-            title="a timestamp in YYYY-MM-DD HH:mm:ss" type="text"
+            title="a timestamp in YYYY-mm-dd HH:MM:SS" type="text"
             value={interval[field]}
             {...behaviors}
         />

--- a/ux/client/views/explorer/archive/type.js
+++ b/ux/client/views/explorer/archive/type.js
@@ -62,4 +62,5 @@ const Type = ({ name, rep, current, select }) => {
     )
 }
 
+
 // end of file

--- a/ux/client/views/explorer/archive/type.js
+++ b/ux/client/views/explorer/archive/type.js
@@ -8,6 +8,8 @@
 import React from 'react'
 
 // local
+// hooks
+import { useGetAvailableArchiveTypes } from '../explorer/useGetAvailableArchiveTypes'
 // components
 import {
     Field,
@@ -17,6 +19,8 @@ import {
 
 // the archive type selector
 export const TypeSelector = ({ value, update }) => {
+    // ask the server for the available archive types
+    const availableArchiveTypes = useGetAvailableArchiveTypes()
     // make a handler that sets the archive type
     const select = type => {
         // build the selector
@@ -31,8 +35,9 @@ export const TypeSelector = ({ value, update }) => {
     return (
         <Field name="type" value={value} tip="select the archive type">
             <Values>
-                <Type name="local" rep="local" current={value} select={select} />
-                <Type name="s3" rep="s3" current={value} select={select} />
+                {availableArchiveTypes.map(({ name, label }) => (
+                    <Type key={label} name={label} rep={name} current={value} select={select} />
+                ))}
             </Values>
         </Field>
     )

--- a/ux/client/views/explorer/archive/vertex.js
+++ b/ux/client/views/explorer/archive/vertex.js
@@ -129,4 +129,5 @@ const Box = styled.div`
     padding: 0.125rem 0.0rem;
 `
 
+
 // end of file

--- a/ux/client/views/explorer/archive/vertex.js
+++ b/ux/client/views/explorer/archive/vertex.js
@@ -1,0 +1,132 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2025 all rights reserved
+
+
+// external
+import React from 'react'
+import styled from 'styled-components'
+
+// project
+// widgets
+import { Badge } from '~/widgets'
+// shapes
+import { Plus, X } from '~/shapes'
+
+// local
+// components
+import { Latitude } from './latitude'
+import { Longitude } from './longitude'
+import { SpacerBetween } from '../form'
+// styles
+import { add as paintAdd, del as paintDelete } from './styles'
+
+
+// a point in a line or polygon geographic search
+export const Vertex = ({ idx, region, update }) => {
+    // unpack the region
+    let { vertices } = region
+    // set up my flags
+    const only = vertices.length == 1
+    const last = idx == vertices.length - 1
+    // extract my vertex
+    const vertex = vertices[idx]
+
+    // build the form mutators
+    // edit a vertex in-place
+    const edit = (value) => {
+        // adjust the pile
+        vertices[idx] = value
+        // and update the form
+        update({ ...region, vertices })
+        // all done
+        return
+    }
+    // add a vertex between two others
+    const insert = () => {
+        // get the next entry; it is guaranteed to exist
+        const next = vertices[idx + 1]
+        // build the new entry; convert to number, interpolate, and back to string
+        const newbie = {
+            latitude: ((Number(vertex.latitude) + Number(next.latitude)) / 2).toString(),
+            longitude: ((Number(vertex.longitude) + Number(next.longitude)) / 2).toString(),
+        }
+        // add it to the pile
+        vertices.splice(idx + 1, 0, newbie)
+        // and update the form
+        update({ ...region, vertices })
+        // all done
+        return
+    }
+    // add an empty vertex
+    const push = () => {
+        // add an entry at the end
+        vertices.push({ longitude: "", latitude: "" })
+        // and update the form
+        update({ ...region, vertices })
+        // all done
+        return
+    }
+    // delete a vertex
+    const remove = () => {
+        // adjust the pile
+        vertices.splice(idx, 1)
+        // and update the form
+        update({ ...region, vertices })
+        // all done
+        return
+    }
+
+    // render
+    return (
+        <Box>
+            <Longitude region={vertex} update={edit} />
+            <SpacerBetween />
+            <Latitude region={vertex} update={edit} />
+            {!last && <Add update={insert} />}
+            {last && vertex.longitude != "" && vertex.latitude != "" && <Add update={push} />}
+            {!only && <Delete update={remove} />}
+        </Box>
+    )
+}
+
+// add a vertex
+const Add = ({ update }) => {
+    // build the button behaviors
+    const behaviors = {
+        onClick: update,
+    }
+    // render
+    return (
+        <Badge size={12} state="enabled" behaviors={behaviors} style={paintAdd}>
+            <Plus />
+        </Badge>
+    )
+}
+// the delete action
+const Delete = ({ update }) => {
+    // build the button behaviors
+    const behaviors = {
+        onClick: update,
+    }
+    // render
+    return (
+        <Badge size={12} state="enabled" behaviors={behaviors} style={paintDelete}>
+            <X />
+        </Badge>
+    )
+}
+
+
+// the container
+const Box = styled.div`
+    display: flex;
+    align-items: end;
+    font-family: inconsolata;
+    height: 1.2em;
+    margin: 0em;
+    padding: 0.125rem 0.0rem;
+`
+
+// end of file

--- a/ux/client/views/explorer/archive/when.js
+++ b/ux/client/views/explorer/archive/when.js
@@ -27,11 +27,11 @@ export const When = ({ interval, update }) => {
         <Field name="time" value={valid} tip="the time interval of interest">
             <Value>
                 <Box>
-                    <Spacer title="a timestamp in YYYY-MM-DD HH:mm:ss">from:</Spacer>
+                    <Spacer title="a timestamp in YYYY-mm-dd HH:MM:SS">from:</Spacer>
                     <Timestamp interval={interval} field="begin" update={updateWhen} />
                 </Box>
                 <Box>
-                    <Spacer title="a timestamp in YYYY-MM-DD HH:mm:ss">until:</Spacer>
+                    <Spacer title="a timestamp in YYYY-mm-dd HH:MM:SS">until:</Spacer>
                     <Timestamp interval={interval} field="end" update={updateWhen} />
                 </Box>
             </Value>

--- a/ux/client/views/explorer/archive/when.js
+++ b/ux/client/views/explorer/archive/when.js
@@ -1,0 +1,56 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2025 all rights reserved
+
+
+// external
+import React from 'react'
+import styled from 'styled-components'
+
+// local
+// components
+import { Timestamp } from './timestamp'
+import { Field, Value } from '../form'
+
+
+// collect a time interval
+export const When = ({ interval, update }) => {
+    // unpack the point
+    const { begin, end } = interval
+    // check the value
+    const valid = (begin === "" || end == "") ? "" : "ok"
+    // specialize the form update
+    const updateWhen = interval => update("when", interval)
+    // render
+    return (
+        <Field name="time" value={valid} tip="the time interval of interest">
+            <Value>
+                <Box>
+                    <Spacer title="a timestamp in YYYY-MM-DD HH:mm:ss">from:</Spacer>
+                    <Timestamp interval={interval} field="begin" update={updateWhen} />
+                </Box>
+                <Box>
+                    <Spacer title="a timestamp in YYYY-MM-DD HH:mm:ss">until:</Spacer>
+                    <Timestamp interval={interval} field="end" update={updateWhen} />
+                </Box>
+            </Value>
+        </Field>
+    )
+}
+
+
+// the container
+const Box = styled.div`
+`
+
+// the spacer
+const Spacer = styled.span`
+    display: inline-block;
+    width: 3rem;
+    text-align: end;
+    padding: 0.0rem 0.25rem 0.25rem 0.0rem;
+`
+
+
+// end of file

--- a/ux/client/views/explorer/explorer/context.js
+++ b/ux/client/views/explorer/explorer/context.js
@@ -12,8 +12,13 @@ import { graphql, useFragment } from 'react-relay/hooks'
 // the provider factory
 export const Provider = ({ qed, children }) => {
     // ask it for all known data archives and attach them as read-only state
-    const { archives } = useFragment(graphql`
+    const { availableArchiveTypes, archives } = useFragment(graphql`
         fragment context_archives on QED {
+            availableArchiveTypes {
+                id
+                name
+                label
+            }
             archives {
                 id
                 name
@@ -25,12 +30,14 @@ export const Provider = ({ qed, children }) => {
     )
     // the set of known views; it starts out with one empty vew
     const [views, setViews] = React.useState([emptyView()])
-    //  the active viewport is an index into the set of views
+    // the active viewport is an index into the set of views
     const [activeViewport, setActiveViewport] = React.useState(0)
 
     // build the initial context value
     const context = {
-        // the data archives
+        // the available archive types
+        availableArchiveTypes,
+        // the connected data archives
         archives,
 
         // the known views
@@ -53,7 +60,9 @@ export const Provider = ({ qed, children }) => {
 export const Context = React.createContext(
     // the default value clients see when accessing the context outside a provide
     {
-        // the data archives
+        // the available archive types
+        availableArchiveTypes: [],
+        // the connected data archives
         archives: [],
 
         // the known views

--- a/ux/client/views/explorer/explorer/useGetAvailableArchiveTypes.js
+++ b/ux/client/views/explorer/explorer/useGetAvailableArchiveTypes.js
@@ -1,0 +1,24 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2025 all rights reserved
+
+
+// externals
+import React from 'react'
+
+// local
+// context
+import { Context } from './context'
+
+
+// provide access to the collection of data archives
+export const useGetAvailableArchiveTypes = () => {
+    // get the data sources
+    const { availableArchiveTypes } = React.useContext(Context)
+    // and return them
+    return availableArchiveTypes
+}
+
+
+// end of file

--- a/ux/client/views/explorer/form/form.js
+++ b/ux/client/views/explorer/form/form.js
@@ -38,12 +38,14 @@ export const Prompt = styled.td`
     width: 10.0em;
     min-width: 10.0em;
     max-width: 12.0em;
+    vertical-align: top;
 `
 
 export const Separator = styled.td`
     width: 1.0em;
     padding: 0.0em 0.25em 0.0em 0.25em;
     text-align: center;
+    vertical-align: top;
 `
 
 export const Required = styled.span`

--- a/ux/client/views/explorer/form/index.js
+++ b/ux/client/views/explorer/form/index.js
@@ -26,7 +26,7 @@ export { Value, EnabledValue, Values } from './value'
 export { Input, EnabledInput, SelectedInput, Numeric } from './input'
 
 // spacers
-export { SpacerFirst, SpacerRest } from './spacers'
+export { SpacerFirst, SpacerBetween } from './spacers'
 
 
 // end of file

--- a/ux/client/views/explorer/form/index.js
+++ b/ux/client/views/explorer/form/index.js
@@ -25,5 +25,8 @@ export { Error } from './error'
 export { Value, EnabledValue, Values } from './value'
 export { Input, EnabledInput, SelectedInput, Numeric } from './input'
 
+// spacers
+export { SpacerFirst, SpacerRest } from './spacers'
+
 
 // end of file

--- a/ux/client/views/explorer/form/input.js
+++ b/ux/client/views/explorer/form/input.js
@@ -29,7 +29,6 @@ export const Input = styled.input`
 export const EnabledInput = styled(Input)`
     & {
         color: hsl(0deg, 0%, 60%);
-        color: hsl(28deg, 90%, 55%);
         background-color: ${theme.widgets.background};
     }
 
@@ -38,12 +37,12 @@ export const EnabledInput = styled(Input)`
     }
 
     &:active{
-        color: hsl(0deg, 0%, 60%);
+        color: hsl(28deg, 90%, 55%);
     }
 
     &:focus{
-        color: hsl(0deg, 0%, 60%);
-        background-color: ${theme.widgets.focus};
+        color: ${theme.widgets.focus.color};
+        background-color: ${theme.widgets.focus.background};
     }
 
     &:invalid {
@@ -51,8 +50,8 @@ export const EnabledInput = styled(Input)`
     }
 
     &::selection {
-        color: hsl(0deg, 0%, 60%);
-        background-color: hsl(0deg, 0%, 20%);
+        background-color: ${theme.widgets.selection.color};
+        background-color: ${theme.widgets.selection.background};
     }
 `
 

--- a/ux/client/views/explorer/form/spacers.js
+++ b/ux/client/views/explorer/form/spacers.js
@@ -13,7 +13,7 @@ import styled from 'styled-components'
 export const SpacerFirst = styled.span`
     padding-right: 0.25em;
 `
-export const SpacerRest = styled.span`
+export const SpacerBetween = styled.span`
     padding-left: 1.0em;
     padding-right: 0.25em;
 `

--- a/ux/client/views/explorer/form/spacers.js
+++ b/ux/client/views/explorer/form/spacers.js
@@ -1,0 +1,21 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2025 all rights reserved
+
+
+// externals
+import React from 'react'
+import styled from 'styled-components'
+
+
+// spacers
+export const SpacerFirst = styled.span`
+    padding-right: 0.25em;
+`
+export const SpacerRest = styled.span`
+    padding-left: 1.0em;
+    padding-right: 0.25em;
+`
+
+// end of file

--- a/ux/client/views/explorer/form/value.js
+++ b/ux/client/views/explorer/form/value.js
@@ -12,6 +12,7 @@ import styled from 'styled-components'
 export const Values = styled.td`
     font-family: "inconsolata";
     text-align: left;
+    vertical-align: top;
 `
 
 // base field value
@@ -21,6 +22,7 @@ export const Value = styled.td`
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+    vertical-align: top;
 `
 
 // active

--- a/ux/schema/qed.gql
+++ b/ux/schema/qed.gql
@@ -304,6 +304,7 @@ type Mutation {
   connectEarthAccessArchive(
     name: String!, uri: String!,
     filters: [String!]!,
+    when: TimeIntervalInput,
     geo: String,
     bbox: GeoBBoxInput,
     point: GeoVertexInput,
@@ -485,6 +486,11 @@ input GeoCircleInput {
   radius: String!
   longitude: String!
   latitude: String!
+}
+
+input TimeIntervalInput {
+  begin: String!
+  end: String!
 }
 
 input GeoBBoxInput {

--- a/ux/schema/qed.gql
+++ b/ux/schema/qed.gql
@@ -305,6 +305,7 @@ type Mutation {
     name: String!, uri: String!,
     filters: [String!]!,
     geo: String,
+    bbox: GeoBBoxInput,
     point: GeoVertexInput,
     circle: GeoCircleInput,
     line: GeoLineInput,
@@ -484,6 +485,11 @@ input GeoCircleInput {
   radius: String!
   longitude: String!
   latitude: String!
+}
+
+input GeoBBoxInput {
+  ne: GeoVertexInput!
+  sw: GeoVertexInput!
 }
 
 input GeoVertexInput {

--- a/ux/schema/qed.gql
+++ b/ux/schema/qed.gql
@@ -301,6 +301,15 @@ type Mutation {
 
   # data archive connections
   connectArchive(name: String!, uri: String!): ArchiveInfo!
+  connectEarthAccessArchive(
+    name: String!, uri: String!,
+    filters: [String!]!,
+    geo: String,
+    point: GeoVertexInput,
+    circle: GeoCircleInput,
+    line: GeoLineInput,
+    polygon: GeoPolygonInput,
+    ): ArchiveInfo!
   disconnectArchive(uri: String!): ArchiveInfo!
   # reader connections
   connectReader(spec: ReaderInput!): ReaderInfo!
@@ -468,6 +477,26 @@ type ValueControllerInfo {
   view: View!
   # the updated controller
   controller: ValueController!
+}
+
+# earth access archive connector types
+input GeoCircleInput {
+  radius: String!
+  longitude: String!
+  latitude: String!
+}
+
+input GeoVertexInput {
+  longitude: String!
+  latitude: String!
+}
+
+input GeoLineInput {
+  vertices: [GeoVertexInput!]
+}
+
+input GeoPolygonInput {
+  vertices: [GeoVertexInput!]
 }
 
 

--- a/ux/schema/qed.gql
+++ b/ux/schema/qed.gql
@@ -41,6 +41,8 @@ type Version {
 type QED implements Node {
   # the id
   id: ID!
+  # the available archive types
+  availableArchiveTypes: [ArchiveType]
   # the visible viewports
   views: [View]
   # the connected data archives
@@ -49,6 +51,15 @@ type QED implements Node {
   readers: [Reader]
 }
 
+
+# archive types
+type ArchiveType implements Node {
+  # node requirements
+  id: ID!
+  # the name
+  name: String!
+  label: String!
+}
 
 # viewports
 type View implements Node {


### PR DESCRIPTION
Adds basic support for converting the results of an {earthaccess} search into a connected archive on the client so users can navigate the large NISAR data store efficiently.

The search is implemented using the `earthaccess` package, which creates a new dependency for `qed`. In order to help manage this and remain robust, a new mechanism has been put in place so that archive types can check whether the runtime support they require is present. The server informs the client which archive types are supported by the back end and the client may choose to elide unsupported options. This technique can be generalized to other parts of the app, such as data readers that require external packages. This PR does not attempt to tackle this.

The support comes with a fairly general implementation of search filters that can be retrofitted to `local` and `s3` archives as well, although this PR does not to attempt to tackle this.

Another notable improvement is the input validation that prevents obviously incorrect values from being entered in the input boxes for longitudes and latitudes, timestamps. etc. This style of checking should definitely be retrofitted to all other data gathering to improve robustness.

As of the opening of this PR, there are a few loose ends to tie up. Some of these will be addressed in future commits, as time permits. The rest are bugs...
