### PR TITLE
Stack membership: per-member participation mask

### DIFF
--- a/doc/stack-membership.md
+++ b/doc/stack-membership.md
@@ -7,8 +7,11 @@ michael a.g. aïvázis <michael.aivazis@para-sim.com>
 
 # Stack membership — replacing the stack-index slider
 
-> Status: **Wave 1 landed** (branch `stack-membership`, builds clean via `mm`); Wave 2 — the
-> All / Reset / Invert convenience actions — and the tests are still to do.
+> Status: **Wave 1 complete and tested** (branch `stack-membership`, builds clean via `mm`). The
+> client ships the raw per-member toggles. The **reset** capability landed server-side (resolver +
+> `viewResetMembers` mutation) but its client buttons are **deferred** — we want to show the raw
+> capability and gather feedback before committing to the All / Invert / Reset UI. All / Invert
+> were client-only sugar and are not yet built.
 
 ## Why
 
@@ -43,8 +46,10 @@ aggregation over an arbitrary subset.
    different subsets in different viewports — the point of having viewports for comparison.
 3. **Order-preserving structure.** The mask is a positional `list[bool]` aligned to the already
    ordered `Stack.readers`; never a `set`. Member order is canonical config (qed.yaml) order.
-4. **Convenience actions (All / Reset / Invert)** ship in Wave 2, on top of the proven mutation.
-   "None" is omitted — the empty set is forbidden at runtime.
+4. **Convenience actions (All / Reset / Invert)** are Wave 2, on top of the proven mutation.
+   "None" is omitted — the empty set is forbidden at runtime. All / Invert are pure client
+   computations over the current mask; **Reset is a server action** (`viewResetMembers`) so the
+   default never leaves the server. The client UI is deferred pending feedback (see Wave 2).
 
 ## Vocabulary
 
@@ -59,23 +64,25 @@ aggregation over an arbitrary subset.
 ## Render path (why C++ is untouched)
 
 `View → Dataset.render → channel.tile`. `MeanPower.tile`/`StackCoherence.tile` build the C++
-member vector from `source.members`, then call `qed.libqed.nisar.stack.meanpower`
+member vector from the `members` they are handed, then call `qed.libqed.nisar.stack.meanpower`
 (`lib/qed/nisar/stack/meanpower.h`), which already reduces over *whatever vector it is handed*.
 A subset is just a shorter vector — so the subset logic is pure Python and the C++ engines need
 no change. The aggregate `Dataset` is shared across all Views (built once in
 `Stack._loadDatasets`), so per-View membership must be threaded down at render time, never
-stored on the shared dataset.
+stored on the shared dataset: `Dataset.render` resolves the participating members (full list, or
+the mask's subset) and names them explicitly to the channel, which has no fallback of its own.
 
 ## Wave 1 — the spine
 
 1. **`pkg/stacks/Stack.py`** — add `membership` trait; in `__init__` resolve `self.defaultMask`
    (empty ⇒ all `True`, preserving `readers` order, guard all-`False` → all-`True`).
 2. **`pkg/readers/nisar/products/channels/MeanPower.py` + `StackCoherence.py`** —
-   `tile(self, source, …, members=None, **kwds)`: build `sources` from
-   `source.members if members is None else members`.
-3. **`pkg/stacks/Dataset.py`** — `render(self, channel, …, mask=None, **kwds)`: when `mask` is
-   given, pass `members=[m for m, on in zip(self.members, mask) if on]` to `channel.tile`.
-   `_collectStatistics` stays over the full set for now (known limitation, see below).
+   `tile(self, source, …, members, **kwds)`: build `sources` from the required `members` list;
+   no `source.members` fallback (render always names them).
+3. **`pkg/stacks/Dataset.py`** — `render(self, channel, …, mask=None, **kwds)`: resolve
+   `members = self.members if mask is None else [m for m, on in zip(self.members, mask) if on]`
+   and pass it explicitly to `channel.tile`. `_collectStatistics` stays over the full set for
+   now (known limitation, see below).
 4. **`pkg/ux/View.py`** —
    - trait `stackIndex` → `members` (`list[bool]`);
    - `pyre_configured`: seed `self.members = list(reader.defaultMask)` when the reader is a stack
@@ -99,23 +106,45 @@ stored on the shared dataset.
 
 ## Wave 2 — convenience actions
 
-**All** (all `True`), **Reset** (restore `reader.defaultMask`), **Invert** (flip, same empty
-guard). "None" omitted. Optionally expose `defaultMask` on the GraphQL `Reader` type so Reset
-need not recompute it.
+**Reset** is the only part with a server side, and it **landed**: `View.resetMembers`
+(restores `reader.defaultMask` via `setMembers`) → `Viewport`/`Store` forwarders →
+`viewResetMembers` resolver and SDL mutation. The default stays server-internal; **no
+`Reader.defaultMask` is exposed** (an earlier draft did; it was backed out — the client never
+needs the default).
+
+**All** (all `True`) and **Invert** (flip, with the empty-set guard) are pure client computations
+over the current mask. "None" is omitted — the empty set is forbidden.
+
+The client UI for all three (`action.js`, `useResetMembers.js`, the actions row in `stack.js`)
+was built, then **backed out** so we can demo the raw per-member toggles first. Re-wiring is
+purely client work against the already-present `viewSetMembers` / `viewResetMembers` mutations.
 
 ## Tests
 
-- `tests/qed.pkg`: seed resolution (empty ⇒ all, explicit subset, all-`False` guard);
-  `setMembers` rejects empty / wrong length; `_effectiveDataset` branch at 1 vs > 1;
-  `Dataset.render(mask=…)` builds the right subset vector (stand-in-member trick).
-- `tests/qed.ux.playwright`: toggle members, assert button states, assert isolating one member
-  exposes its native channels.
+Landed (`tests/qed.pkg`, stand-in based, no NISAR data needed):
+- `stacks.py` — `Stack._resolveMask` (empty ⇒ all, named subset, order preserved, no-match
+  fallback) and `Dataset.render(mask=…)` (subset selection + no-mask full-list passthrough).
+- `membership.py` — `View._activeMembers` (mask → indices) and `View.setMembers` (empty-set
+  rejected; real mask stored and re-resolves).
+
+> Gotcha learned here: pyre components are keyed by name — reusing a component name returns the
+> cached instance, so each test dataset needs its own name (this silently fed an old dataset's
+> members into a later test).
+
+Deferred until we synthesize a NISAR stack fixture (need a real stack reader):
+- `_effectiveDataset` single-member swap to native channels; `availableSelectors` widening;
+  `setMembers`/`resetMembers` → `resolve` across the single-member boundary; the end-to-end
+  mean-power/coherence subset render with real data; the `viewSetMembers`/`viewResetMembers`
+  GraphQL round-trips; the `tests/qed.ux.playwright` driveability test.
 
 ## Automation surface tie-in
 
-Tag each member button with stable `data-qed-*` (`data-qed-stack-member`, `data-qed-member-active`)
-and ARIA `aria-pressed`. Per-member targets are far more driveable than slider geometry and slot
-directly into the automation-surface work — the reason this redesign precedes it.
+Each member toggle carries stable identity in `data-qed-stack-member` (the index) with its
+participation state in ARIA `aria-checked` — following the codebase convention (see
+`coordinate.js`) that identity lives in `data-*` and state lives in ARIA, never mirrored into
+`data-*`. The member group is `data-qed-control="stack"`. Per-member targets are far more
+driveable than the old slider geometry and slot directly into the automation-surface work — the
+reason this redesign precedes it.
 
 ## To confirm during implementation
 

--- a/doc/stack-membership.md
+++ b/doc/stack-membership.md
@@ -7,8 +7,8 @@ michael a.g. aïvázis <michael.aivazis@para-sim.com>
 
 # Stack membership — replacing the stack-index slider
 
-> Status: **in progress** (branch `stack-membership`). Wave 1 is the cross-layer spine; Wave 2
-> adds convenience actions once the mutation is proven.
+> Status: **Wave 1 landed** (branch `stack-membership`, builds clean via `mm`); Wave 2 — the
+> All / Reset / Invert convenience actions — and the tests are still to do.
 
 ## Why
 
@@ -124,7 +124,7 @@ directly into the automation-surface work — the reason this redesign precedes 
 2. **Subset-aware stats** — deferred; the color range is computed over all members, so a subset
    may stretch slightly off. Same class as the existing center-sample limitation; flagged, not
    silent.
-3. **Trait identifier form** — `Stack.membership` by member *name* (robust to yaml reordering)
-   vs raw index. Leaning name.
+3. **Trait identifier form** — resolved: `Stack.membership` lists member *names*, matched
+   against each member reader's `pyre_name` in `_resolveMask` (robust to yaml reordering).
 
 <!-- end of file -->

--- a/doc/stack-membership.md
+++ b/doc/stack-membership.md
@@ -1,0 +1,130 @@
+<!-- -*- markdown -*- -->
+<!-- -*- coding: utf-8 -*- -->
+<!--
+michael a.g. aïvázis <michael.aivazis@para-sim.com>
+(c) 1998-2026 all rights reserved
+-->
+
+# Stack membership — replacing the stack-index slider
+
+> Status: **in progress** (branch `stack-membership`). Wave 1 is the cross-layer spine; Wave 2
+> adds convenience actions once the mutation is proven.
+
+## Why
+
+The current stack control (`ux/client/views/viz/reader/stack.js`) is a `Slider` with one tick
+per member. Clicking pins a single member; clicking the pinned tick again clears the pin and
+returns to the collective aggregate. It does not scale past a handful of members, the un-pin
+gesture is invisible, it shows an index rather than member identity, and "aggregate vs. member"
+is implied by the *absence* of a marker.
+
+We replace it with a row of toggle buttons — one per member, styled identically to the other
+selectors — where each button toggles whether that member **participates in the aggregate**.
+All members participate by default; the default is configurable on the `Stack`.
+
+## Key insight — this generalizes, it does not replace
+
+The proposed model is a strict superset of today's behavior:
+
+- old "pin member *k*" ≡ new "all off except *k*"
+- old "clear pin" ≡ new "all on"
+
+So the single-member path (swap in the member's own dataset, expose its native channels, widen
+availability, validate selections) is *reused unchanged*. The only genuinely new behavior is
+aggregation over an arbitrary subset.
+
+## Decisions (settled)
+
+1. **Single active member → that member's native channels** (the existing `_pinnedDataset`
+   path), not aggregate-of-one. Preserves phase for complex members and reuses built machinery.
+2. **Membership default is a `Stack` trait** that primes the initial mask in the `Stack`
+   constructor; **empty ⇒ all**. After construction the live mask is **per-View**, seeded by
+   copying the trait-resolved default. Per-View (not global) preserves the ability to show
+   different subsets in different viewports — the point of having viewports for comparison.
+3. **Order-preserving structure.** The mask is a positional `list[bool]` aligned to the already
+   ordered `Stack.readers`; never a `set`. Member order is canonical config (qed.yaml) order.
+4. **Convenience actions (All / Reset / Invert)** ship in Wave 2, on top of the proven mutation.
+   "None" is omitted — the empty set is forbidden at runtime.
+
+## Vocabulary
+
+- **`Stack.membership`** — config trait, ordered list of member identifiers active at startup;
+  empty ⇒ all.
+- **`Stack.defaultMask`** — `list[bool]`, length `extent`, aligned to `Stack.readers`; computed
+  once in `__init__` from `membership` (empty ⇒ all `True`; all-`False` guarded back to all-`True`).
+- **`View.members`** — `list[bool]`, the per-View live mask; replaces `View.stackIndex`.
+- Rule everywhere: `active = [i for i, on in enumerate(members) if on]`. `len(active) == 1` →
+  that member's native dataset; `> 1` → aggregate over the subset; `== 0` → forbidden.
+
+## Render path (why C++ is untouched)
+
+`View → Dataset.render → channel.tile`. `MeanPower.tile`/`StackCoherence.tile` build the C++
+member vector from `source.members`, then call `qed.libqed.nisar.stack.meanpower`
+(`lib/qed/nisar/stack/meanpower.h`), which already reduces over *whatever vector it is handed*.
+A subset is just a shorter vector — so the subset logic is pure Python and the C++ engines need
+no change. The aggregate `Dataset` is shared across all Views (built once in
+`Stack._loadDatasets`), so per-View membership must be threaded down at render time, never
+stored on the shared dataset.
+
+## Wave 1 — the spine
+
+1. **`pkg/stacks/Stack.py`** — add `membership` trait; in `__init__` resolve `self.defaultMask`
+   (empty ⇒ all `True`, preserving `readers` order, guard all-`False` → all-`True`).
+2. **`pkg/readers/nisar/products/channels/MeanPower.py` + `StackCoherence.py`** —
+   `tile(self, source, …, members=None, **kwds)`: build `sources` from
+   `source.members if members is None else members`.
+3. **`pkg/stacks/Dataset.py`** — `render(self, channel, …, mask=None, **kwds)`: when `mask` is
+   given, pass `members=[m for m, on in zip(self.members, mask) if on]` to `channel.tile`.
+   `_collectStatistics` stays over the full set for now (known limitation, see below).
+4. **`pkg/ux/View.py`** —
+   - trait `stackIndex` → `members` (`list[bool]`);
+   - `pyre_configured`: seed `self.members = list(reader.defaultMask)` when the reader is a stack
+     and the mask is unset;
+   - `setStackIndex(index)` → `setMembers(members)`: validate length and reject empty, store,
+     `resolve()`, new `session`;
+   - `_pinnedDataset` → `_effectiveDataset`: branch on `len(active)` (`== 1` reuses the existing
+     member-swap path with `active[0]`; else the aggregate stands);
+   - `availableSelectors`: same branch;
+   - render dispatch: pass `mask=self.members` into `dataset.render` when the aggregate stands;
+   - `clone()`: `members=list(self.members)`.
+5. **`pkg/ux/Viewport.py` + `pkg/ux/Store.py`** — `setStackIndex` → `setMembers` forwarders.
+6. **GraphQL** — `pkg/gql/views/View.py`: `stackIndex` → `members` (`[Boolean!]`), rename
+   resolver; rename `SetStackIndex.py` → `SetMembers.py` (args `members: [Boolean!]!`); update
+   `views/__init__.py` and `Mutation.py` (`viewSetMembers`).
+7. **Client** — `useSetStackIndex.js` → `useSetMembers.js` (mutation `viewSetMembers`, same
+   updater/fragment-spray/`pending` guard); `context.js` (`stackIndex` → `members`); `stack.js`
+   (row of toggle buttons styled like the NISAR band/frequency/polarization selectors; flip bit
+   *i* and commit the full mask; no-op when *i* is the only active member; keep the
+   `stackExtent < 2` early return).
+
+## Wave 2 — convenience actions
+
+**All** (all `True`), **Reset** (restore `reader.defaultMask`), **Invert** (flip, same empty
+guard). "None" omitted. Optionally expose `defaultMask` on the GraphQL `Reader` type so Reset
+need not recompute it.
+
+## Tests
+
+- `tests/qed.pkg`: seed resolution (empty ⇒ all, explicit subset, all-`False` guard);
+  `setMembers` rejects empty / wrong length; `_effectiveDataset` branch at 1 vs > 1;
+  `Dataset.render(mask=…)` builds the right subset vector (stand-in-member trick).
+- `tests/qed.ux.playwright`: toggle members, assert button states, assert isolating one member
+  exposes its native channels.
+
+## Automation surface tie-in
+
+Tag each member button with stable `data-qed-*` (`data-qed-stack-member`, `data-qed-member-active`)
+and ARIA `aria-pressed`. Per-member targets are far more driveable than slider geometry and slot
+directly into the automation-surface work — the reason this redesign precedes it.
+
+## To confirm during implementation
+
+1. **Re-seed on reader switch** — `pyre_configured` covers the initial bind; verify the runtime
+   reader-change path re-seeds `members` (or seed lazily on first access if it bypasses the hook).
+2. **Subset-aware stats** — deferred; the color range is computed over all members, so a subset
+   may stretch slightly off. Same class as the existing center-sample limitation; flagged, not
+   silent.
+3. **Trait identifier form** — `Stack.membership` by member *name* (robust to yaml reordering)
+   vs raw index. Leaning name.
+
+<!-- end of file -->

--- a/pkg/gql/Mutation.py
+++ b/pkg/gql/Mutation.py
@@ -66,8 +66,8 @@ class Mutation(graphene.ObjectType):
     viewZoomToggleCoupled = views.zoomToggleCoupled.Field()
     viewZoomReset = views.zoomReset.Field()
 
-    # stack member pinning
-    viewSetStackIndex = views.setStackIndex.Field()
+    # stack member participation
+    viewSetMembers = views.setMembers.Field()
 
     # data archive connection management
     connectArchive = ConnectArchive.Field()

--- a/pkg/gql/Mutation.py
+++ b/pkg/gql/Mutation.py
@@ -68,6 +68,7 @@ class Mutation(graphene.ObjectType):
 
     # stack member participation
     viewSetMembers = views.setMembers.Field()
+    viewResetMembers = views.resetMembers.Field()
 
     # data archive connection management
     connectArchive = ConnectArchive.Field()

--- a/pkg/gql/views/ResetMembers.py
+++ b/pkg/gql/views/ResetMembers.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import graphene
+
+# the result types
+from .View import View
+
+
+# restore a stack to its default participation mask for a viewport
+class ResetMembers(graphene.Mutation):
+    """
+    Restore a stack's membership to the default it was primed with
+    """
+
+    # inputs
+    class Arguments:
+        # the viewport
+        viewport = graphene.Int(required=True)
+        # the stack to act on
+        source = graphene.String(required=True)
+
+    # the result is the updated view
+    view = graphene.Field(View)
+
+    # the mutator
+    @staticmethod
+    def mutate(root, info, viewport, source):
+        """
+        Restore the default membership of the stack {source} in {viewport}
+        """
+        # get the store
+        store = info.context["store"]
+        # ask it to reset the mask
+        view = store.resetMembers(viewport=viewport, source=source)
+        # form the mutation resolution context
+        context = {"view": view}
+        # and resolve the mutation
+        return context
+
+
+# end of file

--- a/pkg/gql/views/SetMembers.py
+++ b/pkg/gql/views/SetMembers.py
@@ -11,10 +11,10 @@ import graphene
 from .View import View
 
 
-# pin or clear a stack member for a viewport
-class SetStackIndex(graphene.Mutation):
+# set the per-member participation mask of a stack for a viewport
+class SetMembers(graphene.Mutation):
     """
-    Pin a stack member, or clear the pin to return to the collective aggregate view
+    Set which members of a stack participate in its aggregate views
     """
 
     # inputs
@@ -23,22 +23,22 @@ class SetStackIndex(graphene.Mutation):
         viewport = graphene.Int(required=True)
         # the stack to act on
         source = graphene.String(required=True)
-        # the member to pin; omit or pass null to clear the pin
-        index = graphene.Int(required=False)
+        # the per-member participation mask, aligned to the stack's member order
+        members = graphene.List(graphene.NonNull(graphene.Boolean), required=True)
 
     # the result is the updated view
     view = graphene.Field(View)
 
     # the mutator
     @staticmethod
-    def mutate(root, info, viewport, source, index=None):
+    def mutate(root, info, viewport, source, members):
         """
-        Pin the stack member {index} of {source} in {viewport}, or clear it when {index} is None
+        Set the participation {members} of the stack {source} in {viewport}
         """
         # get the store
         store = info.context["store"]
-        # ask it to pin or clear the member
-        view = store.setStackIndex(viewport=viewport, source=source, index=index)
+        # ask it to set the mask
+        view = store.setMembers(viewport=viewport, source=source, members=members)
         # form the mutation resolution context
         context = {"view": view}
         # and resolve the mutation

--- a/pkg/gql/views/View.py
+++ b/pkg/gql/views/View.py
@@ -46,8 +46,8 @@ class View(graphene.ObjectType):
     measure = graphene.Field(Measure)
     sync = graphene.Field(Sync)
     zoom = graphene.Field(Zoom)
-    # the pinned stack member, if any
-    stackIndex = graphene.Int()
+    # the per-member participation mask, if the reader is a stack
+    members = graphene.List(graphene.NonNull(graphene.Boolean))
     # the available selector values, reflecting any pinned member
     available = graphene.List(Selectors)
 
@@ -77,12 +77,12 @@ class View(graphene.ObjectType):
         return view.selections.items()
 
     @staticmethod
-    def resolve_stackIndex(view, info, **kwds):
+    def resolve_members(view, info, **kwds):
         """
-        Resolve the pinned stack member, if any
+        Resolve the per-member participation mask, if the reader is a stack
         """
         # hand it off
-        return view.stackIndex
+        return view.members
 
     @staticmethod
     def resolve_available(view, info, **kwds):

--- a/pkg/gql/views/__init__.py
+++ b/pkg/gql/views/__init__.py
@@ -45,6 +45,6 @@ from .ZoomToggleCoupled import ZoomToggleCoupled as zoomToggleCoupled
 from .ZoomReset import ZoomReset as zoomReset
 
 # stack
-from .SetStackIndex import SetStackIndex as setStackIndex
+from .SetMembers import SetMembers as setMembers
 
 # end of file

--- a/pkg/gql/views/__init__.py
+++ b/pkg/gql/views/__init__.py
@@ -46,5 +46,6 @@ from .ZoomReset import ZoomReset as zoomReset
 
 # stack
 from .SetMembers import SetMembers as setMembers
+from .ResetMembers import ResetMembers as resetMembers
 
 # end of file

--- a/pkg/readers/nisar/products/channels/MeanPower.py
+++ b/pkg/readers/nisar/products/channels/MeanPower.py
@@ -60,12 +60,9 @@ class MeanPower(Channel, family="qed.channels.nisar.meanpower"):
         # all done
         return
 
-    def tile(self, source, zoom, origin, shape, datatype, members=None, **kwds):
+    def tile(self, source, zoom, origin, shape, datatype, members, **kwds):
         """
-        Render a mean-power tile from the members of a {source} stack
-
-        When {members} is given, it is the subset of member datasets that participate; otherwise
-        every member of the {source} does.
+        Render a mean-power tile over the given {members} of a {source} stack
         """
         # my pipeline reduces several sources at once
         pipeline = qed.libqed.nisar.stack.meanpower
@@ -75,10 +72,8 @@ class MeanPower(Channel, family="qed.channels.nisar.meanpower"):
         origin = qed.libpyre.grid.Index2D(index=origin)
         # and the zoom into strides
         stride = qed.libpyre.grid.Index2D(index=tuple(2**level for level in zoom))
-        # the participating members default to every member of the source
-        participants = source.members if members is None else members
         # collect the data handle of each participating member
-        sources = [member.data.dataset for member in participants]
+        sources = [member.data.dataset for member in members]
         # lift my range out of log scale
         low = 10 ** self.power.low
         # at both ends

--- a/pkg/readers/nisar/products/channels/MeanPower.py
+++ b/pkg/readers/nisar/products/channels/MeanPower.py
@@ -60,9 +60,12 @@ class MeanPower(Channel, family="qed.channels.nisar.meanpower"):
         # all done
         return
 
-    def tile(self, source, zoom, origin, shape, datatype, **kwds):
+    def tile(self, source, zoom, origin, shape, datatype, members=None, **kwds):
         """
         Render a mean-power tile from the members of a {source} stack
+
+        When {members} is given, it is the subset of member datasets that participate; otherwise
+        every member of the {source} does.
         """
         # my pipeline reduces several sources at once
         pipeline = qed.libqed.nisar.stack.meanpower
@@ -72,8 +75,10 @@ class MeanPower(Channel, family="qed.channels.nisar.meanpower"):
         origin = qed.libpyre.grid.Index2D(index=origin)
         # and the zoom into strides
         stride = qed.libpyre.grid.Index2D(index=tuple(2**level for level in zoom))
-        # collect the data handle of each stack member
-        sources = [member.data.dataset for member in source.members]
+        # the participating members default to every member of the source
+        participants = source.members if members is None else members
+        # collect the data handle of each participating member
+        sources = [member.data.dataset for member in participants]
         # lift my range out of log scale
         low = 10 ** self.power.low
         # at both ends

--- a/pkg/readers/nisar/products/channels/StackCoherence.py
+++ b/pkg/readers/nisar/products/channels/StackCoherence.py
@@ -63,12 +63,9 @@ class StackCoherence(Channel, family="qed.channels.nisar.stack.coherence"):
         # all done
         return
 
-    def tile(self, source, zoom, origin, shape, datatype, members=None, **kwds):
+    def tile(self, source, zoom, origin, shape, datatype, members, **kwds):
         """
-        Render a coherence tile from the members of a {source} stack
-
-        When {members} is given, it is the subset of member datasets that participate; otherwise
-        every member of the {source} does.
+        Render a coherence tile over the given {members} of a {source} stack
         """
         # my pipeline reduces several sources at once
         pipeline = qed.libqed.nisar.stack.coherence
@@ -78,10 +75,8 @@ class StackCoherence(Channel, family="qed.channels.nisar.stack.coherence"):
         origin = qed.libpyre.grid.Index2D(index=origin)
         # and the zoom into strides
         stride = qed.libpyre.grid.Index2D(index=tuple(2**level for level in zoom))
-        # the participating members default to every member of the source
-        participants = source.members if members is None else members
         # collect the data handle of each participating member
-        sources = [member.data.dataset for member in participants]
+        sources = [member.data.dataset for member in members]
         # build the visualization pipeline and return it; the coherence range is already linear
         return pipeline(
             sources=sources,

--- a/pkg/readers/nisar/products/channels/StackCoherence.py
+++ b/pkg/readers/nisar/products/channels/StackCoherence.py
@@ -63,9 +63,12 @@ class StackCoherence(Channel, family="qed.channels.nisar.stack.coherence"):
         # all done
         return
 
-    def tile(self, source, zoom, origin, shape, datatype, **kwds):
+    def tile(self, source, zoom, origin, shape, datatype, members=None, **kwds):
         """
         Render a coherence tile from the members of a {source} stack
+
+        When {members} is given, it is the subset of member datasets that participate; otherwise
+        every member of the {source} does.
         """
         # my pipeline reduces several sources at once
         pipeline = qed.libqed.nisar.stack.coherence
@@ -75,8 +78,10 @@ class StackCoherence(Channel, family="qed.channels.nisar.stack.coherence"):
         origin = qed.libpyre.grid.Index2D(index=origin)
         # and the zoom into strides
         stride = qed.libpyre.grid.Index2D(index=tuple(2**level for level in zoom))
-        # collect the data handle of each stack member
-        sources = [member.data.dataset for member in source.members]
+        # the participating members default to every member of the source
+        participants = source.members if members is None else members
+        # collect the data handle of each participating member
+        sources = [member.data.dataset for member in participants]
         # build the visualization pipeline and return it; the coherence range is already linear
         return pipeline(
             sources=sources,

--- a/pkg/stacks/Dataset.py
+++ b/pkg/stacks/Dataset.py
@@ -58,10 +58,19 @@ class Dataset(
         # look up the channel and return it
         return self.channels[name]
 
-    def render(self, channel, zoom, origin, shape, **kwds):
+    def render(self, channel, zoom, origin, shape, mask=None, **kwds):
         """
         Render a tile of the given specification
+
+        When {mask} is given, it is a per-member boolean selecting the subset that participates
+        in the aggregate; my full membership stands when it is absent.
         """
+        # if a participation mask was supplied
+        if mask is not None:
+            # reduce my members to the participating subset, preserving their order
+            kwds["members"] = [
+                member for member, on in zip(self.members, mask) if on
+            ]
         # hand the request to the channel, pointing it at me as the source of members
         return channel.tile(
             source=self,

--- a/pkg/stacks/Dataset.py
+++ b/pkg/stacks/Dataset.py
@@ -65,19 +65,21 @@ class Dataset(
         When {mask} is given, it is a per-member boolean selecting the subset that participates
         in the aggregate; my full membership stands when it is absent.
         """
-        # if a participation mask was supplied
-        if mask is not None:
-            # reduce my members to the participating subset, preserving their order
-            kwds["members"] = [
-                member for member, on in zip(self.members, mask) if on
-            ]
-        # hand the request to the channel, pointing it at me as the source of members
+        # a mask reduces my members to the participating subset, preserving order; without one,
+        # every member i carry participates
+        members = (
+            self.members
+            if mask is None
+            else [member for member, active in zip(self.members, mask) if active]
+        )
+        # hand the request to the channel, naming the members it should reduce over
         return channel.tile(
             source=self,
             datatype=self.datatype.htype,
             zoom=zoom,
             origin=origin,
             shape=shape,
+            members=members,
             **kwds,
         )
 

--- a/pkg/stacks/Stack.py
+++ b/pkg/stacks/Stack.py
@@ -40,6 +40,10 @@ class Stack(
     readers = qed.properties.list(schema=qed.protocols.reader())
     readers.doc = "the readers of my stack"
 
+    # the members that start active; empty means all of them
+    membership = qed.properties.strings()
+    membership.doc = "the names of the members active at startup; empty means all"
+
     # interface
     def select(self, selector):
         """
@@ -97,6 +101,8 @@ class Stack(
         readers = self.readers
         # remember how many members i have
         self.extent = len(readers)
+        # resolve the participation mask my views start from; empty membership means all
+        self.defaultMask = self._resolveMask()
         # if i somehow have none
         if not readers:
             # there is nothing to aggregate
@@ -117,6 +123,28 @@ class Stack(
         return
 
     # implementation details
+    def _resolveMask(self):
+        """
+        Build the initial participation mask from my {membership}, preserving member order
+        """
+        # get my members
+        readers = self.readers
+        # an empty membership means every member participates
+        if not self.membership:
+            # so the whole stack is on
+            return [True] * len(readers)
+        # otherwise, the names that should start active; the set is only a membership test,
+        # the mask itself is built positionally so member order is preserved
+        active = set(self.membership)
+        # mark each member by whether its name was named
+        mask = [reader.pyre_name in active for reader in readers]
+        # if nothing matched, e.g. the names were misspelled, an empty stack is useless
+        if not any(mask):
+            # so fall back to the whole stack
+            return [True] * len(readers)
+        # hand off the resolved mask
+        return mask
+
     def _loadDatasets(self):
         """
         Build one aggregate dataset per selector assignment shared by all my members

--- a/pkg/ux/Store.py
+++ b/pkg/ux/Store.py
@@ -218,16 +218,16 @@ class Store(qed.shells.command, family="qed.cli.ux"):
         # and delegate
         return port.toggleCoordinate(source=source, axis=axis, coordinate=coordinate)
 
-    def setStackIndex(self, viewport, source, index):
+    def setMembers(self, viewport, source, members):
         """
-        Pin (or clear, when {index} is None) the stack member for {viewport}
+        Set the per-member participation mask of the stack {source} for {viewport}
         """
         # locate the source
         source = self.source(name=source)
         # get the viewport configuration
         port = self._viewports[viewport]
         # and delegate
-        return port.setStackIndex(source=source, index=index)
+        return port.setMembers(source=source, members=members)
 
     def toggleMeasure(self, viewport, source):
         """

--- a/pkg/ux/Store.py
+++ b/pkg/ux/Store.py
@@ -229,6 +229,17 @@ class Store(qed.shells.command, family="qed.cli.ux"):
         # and delegate
         return port.setMembers(source=source, members=members)
 
+    def resetMembers(self, viewport, source):
+        """
+        Restore the stack {source} to its default participation mask for {viewport}
+        """
+        # locate the source
+        source = self.source(name=source)
+        # get the viewport configuration
+        port = self._viewports[viewport]
+        # and delegate
+        return port.resetMembers(source=source)
+
     def toggleMeasure(self, viewport, source):
         """
         Toggle the measure layer state on {viewport}

--- a/pkg/ux/View.py
+++ b/pkg/ux/View.py
@@ -497,6 +497,19 @@ class View(qed.component, family="qed.ux.views.view", implements=qed.protocols.u
         # all done
         return self
 
+    def resetMembers(self):
+        """
+        Restore my participation mask to the default the stack was primed with
+        """
+        # get my reader
+        reader = self.reader
+        # only a stack has a default mask to restore
+        if isinstance(reader, qed.stacks.stack):
+            # set my mask to a copy of the stack's default, reusing the setter's validation
+            self.setMembers(members=list(reader.defaultMask))
+        # all done
+        return self
+
     # state resolution
     def resolve(self):
         """

--- a/pkg/ux/View.py
+++ b/pkg/ux/View.py
@@ -52,8 +52,9 @@ class View(qed.component, family="qed.ux.views.view", implements=qed.protocols.u
     session = qed.properties.str()
     session.doc = "the session token"
 
-    stackIndex = qed.properties.int(default=None)
-    stackIndex.doc = "the pinned stack member, or None for the collective aggregate view"
+    members = qed.properties.list(schema=qed.properties.bool())
+    members.default = None
+    members.doc = "the per-member participation mask, or None until seeded from a stack reader"
 
     # interface
     def tile(self, channel, zoom, origin, shape):
@@ -64,9 +65,16 @@ class View(qed.component, family="qed.ux.views.view", implements=qed.protocols.u
         name = f"{self.pyre_name}.{channel}"
         # locate the pipeline
         pipeline = self._pipelines[name]
+        # an aggregate dataset renders over only the members my mask leaves active; a
+        # single-member dataset is a plain reader dataset that knows nothing of masks
+        extra = (
+            {"mask": self.members}
+            if isinstance(self.dataset, qed.stacks.dataset)
+            else {}
+        )
         # and ask my dataset to render the tile
         return self.dataset.render(
-            channel=pipeline, zoom=zoom, origin=origin, shape=shape
+            channel=pipeline, zoom=zoom, origin=origin, shape=shape, **extra
         )
 
     def toggleSelection(self, key, value):
@@ -461,13 +469,28 @@ class View(qed.component, family="qed.ux.views.view", implements=qed.protocols.u
         # all done
         return self
 
-    def setStackIndex(self, index):
+    def setMembers(self, members):
         """
-        Pin the stack member with the given {index}, or clear the pin when {index} is None
+        Set my per-member participation mask; at least one member must stay active
         """
-        # store the new pin
-        self.stackIndex = index
-        # re-resolve my dataset and channel
+        # the mask must line up with my reader's members
+        if self.members is not None and len(members) != len(self.members):
+            # a mismatch is a client bug
+            firewall = journal.firewall("qed.ux.store")
+            # complain
+            firewall.line(f"member mask of length {len(members)} for {self}")
+            firewall.line(f"expected length {len(self.members)}")
+            # flush
+            firewall.log()
+            # and bail, just in case firewalls aren't fatal
+            return self
+        # an empty stack has nothing to show, so reject a mask that turns everyone off
+        if not any(members):
+            # leave the current mask in place
+            return self
+        # store the new mask
+        self.members = members
+        # re-resolve my dataset and channel; this may cross the single-member boundary
         self.resolve()
         # grab a new session token so the client refetches tiles
         self.session = uuid.uuid1()
@@ -534,8 +557,8 @@ class View(qed.component, family="qed.ux.views.view", implements=qed.protocols.u
         if not self.dataset:
             # all done
             return self
-        # if a stack member is pinned, switch from the aggregate to that member's dataset
-        dataset = self._pinnedDataset(dataset=dataset)
+        # when exactly one member is active, switch from the aggregate to that member's dataset
+        dataset = self._effectiveDataset(dataset=dataset)
         # record the resolved dataset
         self.dataset = dataset
         # get the channel
@@ -589,7 +612,7 @@ class View(qed.component, family="qed.ux.views.view", implements=qed.protocols.u
             measure=self.measure.clone(),
             sync=self.sync.clone(),
             zoom=self.zoom.clone(),
-            stackIndex=self.stackIndex,
+            members=list(self.members) if self.members is not None else None,
         )
 
     def pipelines(self):
@@ -622,22 +645,38 @@ class View(qed.component, family="qed.ux.views.view", implements=qed.protocols.u
         return
 
     # implementation details
-    def _pinnedDataset(self, dataset):
+    def _activeMembers(self):
         """
-        If a stack member is pinned, return that member's dataset in place of the aggregate
+        The indices of the members my mask leaves active, in member order
         """
-        # get my pinned index
-        index = self.stackIndex
-        # if nothing is pinned, the aggregate dataset stands
-        if index is None:
-            # hand it back unchanged
-            return dataset
+        # get my mask
+        mask = self.members
+        # if i have none, e.g. my reader is not a stack, nothing is singled out
+        if not mask:
+            # so report no active members
+            return []
+        # otherwise, the positions that are on
+        return [index for index, on in enumerate(mask) if on]
+
+    def _effectiveDataset(self, dataset):
+        """
+        When exactly one member is active, return that member's dataset in place of the aggregate
+        """
         # get my reader
         reader = self.reader
-        # only a stack can pin members
+        # only a stack singles members out
         if not isinstance(reader, qed.stacks.stack):
             # hand the dataset back unchanged
             return dataset
+        # find the active members
+        active = self._activeMembers()
+        # the member-native view applies only when exactly one member is active; otherwise the
+        # aggregate dataset stands, rendered over whatever subset the mask leaves on
+        if len(active) != 1:
+            # so hand the aggregate back unchanged
+            return dataset
+        # the single active member
+        (index,) = active
         # get the member dataset that matches my current selection
         member = reader.member(index=index, selector=dataset.selector)
         # if there is no such member
@@ -684,12 +723,15 @@ class View(qed.component, family="qed.ux.views.view", implements=qed.protocols.u
         if not reader:
             # hand back an empty map
             return {}
-        # a pinned member can realize more combos than the aggregate
-        index = self.stackIndex
-        # so when a member is pinned on a stack
-        if index is not None and isinstance(reader, qed.stacks.stack):
-            # use that member's wider availability
-            return reader.memberAvailable(index)
+        # a single active member can realize more combos than the aggregate
+        if isinstance(reader, qed.stacks.stack):
+            # find the active members
+            active = self._activeMembers()
+            # when exactly one is active
+            if len(active) == 1:
+                # use that member's wider availability
+                (index,) = active
+                return reader.memberAvailable(index)
         # otherwise, the reader's own availability stands
         return reader.available
 
@@ -736,6 +778,11 @@ class View(qed.component, family="qed.ux.views.view", implements=qed.protocols.u
         if not reader:
             # nothing more to do; report no errors
             return []
+        # if my reader is a stack and i have not been given a mask, seed mine from the stack's
+        # configured default so every view starts from the membership the stack was primed with
+        if self.members is None and isinstance(reader, qed.stacks.stack):
+            # copy it so later edits stay local to me
+            self.members = list(reader.defaultMask)
         # otherwise, get my selections
         selections = self.selections
         # if i don't have any

--- a/pkg/ux/Viewport.py
+++ b/pkg/ux/Viewport.py
@@ -66,14 +66,14 @@ class Viewport(
         # all done
         return self.view()
 
-    def setStackIndex(self, source, index):
+    def setMembers(self, source, members):
         """
-        Pin (or clear, when {index} is None) the stack member
+        Set the per-member participation mask of the stack {source}
         """
         # activate the {source}
         view = self._selectSource(source=source)
         # and delegate
-        view.setStackIndex(index=index)
+        view.setMembers(members=members)
         # all done
         return self.view()
 

--- a/pkg/ux/Viewport.py
+++ b/pkg/ux/Viewport.py
@@ -77,6 +77,17 @@ class Viewport(
         # all done
         return self.view()
 
+    def resetMembers(self, source):
+        """
+        Restore the stack {source} to its default participation mask
+        """
+        # activate the {source}
+        view = self._selectSource(source=source)
+        # and delegate
+        view.resetMembers()
+        # all done
+        return self.view()
+
     def toggleMeasure(self, source):
         """
         Toggle {coordinate}

--- a/tests/qed.pkg/membership.py
+++ b/tests/qed.pkg/membership.py
@@ -1,0 +1,91 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Exercise the per-member participation logic a view carries for a stack reader
+"""
+
+
+# externals
+import types
+
+# support
+import qed
+
+
+# check the translation from a participation mask to the list of active member indices
+def activeMembers():
+    """
+    Exercise {View._activeMembers}: the on positions, in member order; nothing when there is no mask
+    """
+    # the accessor, borrowed from the view class
+    active = qed.ux.view._activeMembers
+    # no mask, e.g. the reader is not a stack, means no active members
+    assert active(types.SimpleNamespace(members=None)) == []
+    # an empty mask likewise
+    assert active(types.SimpleNamespace(members=[])) == []
+    # a mixed mask reports the on positions in order
+    assert active(types.SimpleNamespace(members=[True, False, True])) == [0, 2]
+    # an all-on mask reports every position
+    assert active(types.SimpleNamespace(members=[True, True, True])) == [0, 1, 2]
+    # all done
+    return
+
+
+# check the guards and effect of setting a participation mask
+def setMembers():
+    """
+    Exercise {View.setMembers}: the empty set is rejected; a real mask is stored and re-resolved
+    """
+    # the mutator, borrowed from the view class
+    setter = qed.ux.view.setMembers
+
+    # turning every member off would empty the stack, so it is rejected
+    calls = []
+    standin = types.SimpleNamespace(members=[True, True], resolve=lambda: calls.append(1))
+    # ask to turn everyone off
+    setter(standin, members=[False, False])
+    # the mask is left untouched
+    assert standin.members == [True, True]
+    # and the view does not re-resolve
+    assert calls == []
+
+    # a non-empty mask is accepted, stored, and triggers a re-resolution
+    standin = types.SimpleNamespace(members=[True, False], resolve=lambda: calls.append(1))
+    # ask to turn the second member back on
+    setter(standin, members=[True, True])
+    # the new mask is stored
+    assert standin.members == [True, True]
+    # and the view re-resolves exactly once
+    assert calls == [1]
+
+    # all done
+    return
+
+
+# the driver
+def test():
+    """
+    Check the view's participation-mask helpers in isolation
+    """
+    # the mask-to-indices translation
+    activeMembers()
+    # the mask mutator and its empty-set guard
+    setMembers()
+    # all done
+    return 0
+
+
+# bootstrap
+if __name__ == "__main__":
+    # invoke the driver
+    status = test()
+    # and share the status with the shell
+    raise SystemExit(status)
+
+
+# end of file

--- a/tests/qed.pkg/stacks.py
+++ b/tests/qed.pkg/stacks.py
@@ -42,6 +42,72 @@ def member():
     )
 
 
+# a lightweight stand-in for a stack, carrying just what {_resolveMask} reads
+def stackStandin(names, membership):
+    """
+    Build a minimal stand-in for a stack with the given member {names} and {membership}
+    """
+    # each member needs only its name for the mask resolution
+    readers = [types.SimpleNamespace(pyre_name=name) for name in names]
+    # hand back an object with the attributes {_resolveMask} reads
+    return types.SimpleNamespace(readers=readers, membership=membership)
+
+
+# check that the default participation mask is resolved correctly from the membership trait
+def membershipMask():
+    """
+    Exercise {Stack._resolveMask}: empty means all, names select positionally, order is preserved
+    """
+    # the resolver, borrowed from the stack class
+    resolve = qed.stacks.stack._resolveMask
+    # an empty membership turns every member on
+    assert resolve(stackStandin(["a", "b", "c"], [])) == [True, True, True]
+    # a named subset turns on exactly those members
+    assert resolve(stackStandin(["a", "b", "c"], ["a", "c"])) == [True, False, True]
+    # the mask follows member order, not the order the names were listed in
+    assert resolve(stackStandin(["a", "b", "c"], ["c", "a"])) == [True, False, True]
+    # a membership that matches nothing falls back to the whole stack
+    assert resolve(stackStandin(["a", "b"], ["x", "y"])) == [True, True]
+    # all done
+    return
+
+
+# check that an aggregate dataset renders over only the participating members
+def subsetRender():
+    """
+    Exercise {Dataset.render}: a mask reduces the members handed to the channel; absence means all
+    """
+    # build an aggregate over three members; pyre keys components by name, so this needs a name
+    # all its own to avoid colliding with the dataset {test} builds above
+    members = [member(), member(), member()]
+    # the dataset under test
+    dataset = qed.stacks.dataset(
+        name="test.stack.subset.L.A.HH", members=members, selector={"band": "L"}
+    )
+    # a fake channel that records the members it is asked to reduce
+    seen = {}
+
+    def tile(source, datatype, zoom, origin, shape, members, **kwds):
+        # remember what arrived
+        seen["members"] = members
+        # the result is irrelevant to this check
+        return None
+
+    channel = types.SimpleNamespace(tile=tile)
+    # render with a mask that drops the middle member
+    dataset.render(
+        channel=channel, zoom=(0, 0), origin=(0, 0), shape=(8, 8), mask=[True, False, True]
+    )
+    # the channel must see exactly the first and third members, in order
+    assert seen["members"] == [members[0], members[2]]
+    # render without a mask, the channel reduces over every member
+    dataset.render(channel=channel, zoom=(0, 0), origin=(0, 0), shape=(8, 8))
+    # so it sees the full membership
+    assert seen["members"] == members
+    # all done
+    return
+
+
 # the driver
 def test():
     """
@@ -68,6 +134,11 @@ def test():
     for tag, pipeline in dataset.channels.items():
         # the registry key the view builds is "{view}.{dataset}.{tag}"
         assert pipeline.pyre_name == f"{dataset.pyre_name}.{tag}"
+
+    # check that the membership trait resolves into a sensible default mask
+    membershipMask()
+    # check that a mask reduces the members an aggregate dataset renders over
+    subsetRender()
 
     # all done
     return 0

--- a/ux/client/views/viz/reader/context.js
+++ b/ux/client/views/viz/reader/context.js
@@ -46,8 +46,8 @@ export const Provider = props => {
     )
     // if i am a stack, the number of members i have
     const stackExtent = reader.stackExtent
-    // the pinned member, but only meaningful when i am the active reader
-    const stackIndex = active ? view.stackIndex : null
+    // the per-member participation mask, but only meaningful when i am the active reader
+    const members = active ? view.members : null
 
     // assemble the context value
     const context = {
@@ -65,8 +65,8 @@ export const Provider = props => {
         selections,
         // the number of members if i am a stack
         stackExtent,
-        // my pinned member, if i am the active reader
-        stackIndex,
+        // my per-member participation mask, if i am the active reader
+        members,
     }
 
     // provide for my children
@@ -130,7 +130,7 @@ export const contextReaderGetViewFragment = graphql`
             name
             value
         }
-        stackIndex
+        members
         available {
             name
             values

--- a/ux/client/views/viz/reader/member.js
+++ b/ux/client/views/viz/reader/member.js
@@ -1,0 +1,74 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// externals
+import React from 'react'
+
+// locals
+// hooks
+import { useReader } from './useReader'
+// styles
+import styles from './styles'
+
+
+// display a single stack member as a participation toggle
+export const Member = ({ index, active, locked, toggle }) => {
+    // get my reader
+    const reader = useReader()
+    // park hover styling here, the way the coordinate selectors do
+    const [polish, setPolish] = React.useState(false)
+
+    // active members render as selected, the rest as enabled and available to add
+    const state = active ? "selected" : "enabled"
+
+    // make a click handler
+    const onClick = evt => {
+        // stop this event from propagating
+        evt.stopPropagation()
+        // and quash any side effects
+        evt.preventDefault()
+        // a locked member is the last one standing; toggling it would empty the stack
+        if (!locked) {
+            // otherwise, flip my participation
+            toggle(index)
+        }
+        // drop any hover polish
+        setPolish(false)
+        // all done
+        return
+    }
+    // a locked member never changes, so it gets no hover affordance
+    const behaviors = locked ? { onClick } : {
+        onClick,
+        onMouseEnter: () => setPolish(true),
+        onMouseLeave: () => setPolish(false),
+    }
+
+    // mix my paint
+    const paint = styles.coordinate(state, polish)
+    // pick my tip
+    const tip = active
+        ? (locked
+            ? `member ${index} is the only active member of '${reader.name}'`
+            : `drop member ${index} from the aggregate of '${reader.name}'`)
+        : `add member ${index} to the aggregate of '${reader.name}'`
+
+    // and render; the client owns this control's identity -- the member {index} lives in {data-*},
+    // while participation is state and lives in ARIA, never mirrored into {data-*}
+    return (
+        <div title={tip} style={paint}
+            role="checkbox"
+            aria-checked={active}
+            aria-disabled={locked}
+            data-qed-stack-member={index}
+            {...behaviors}>
+            {index}
+        </div>
+    )
+}
+
+
+/* end of file */

--- a/ux/client/views/viz/reader/reader.js
+++ b/ux/client/views/viz/reader/reader.js
@@ -98,8 +98,8 @@ const Panel = ({ qed }) => {
                     // build an axis and return it
                     return <Axis key={axis} axis={axis}>{values}</Axis>
                 })}
-                {channels.length > 0 && <Channels>{channels}</Channels>}
                 <Stack />
+                {channels.length > 0 && <Channels>{channels}</Channels>}
             </Meta.Table>
         </Tray>
     )

--- a/ux/client/views/viz/reader/stack.js
+++ b/ux/client/views/viz/reader/stack.js
@@ -6,80 +6,69 @@
 
 // externals
 import React from 'react'
-import styled from 'styled-components'
 
 // project
 // widgets
-import { Meta, Slider, SVG } from '~/widgets'
+import { Meta } from '~/widgets'
 
 // local
 // context
 import { Context } from './context'
+// components
+import { Member } from './member'
 // hooks
-import { useSetStackIndex } from './useSetStackIndex'
+import { useSetMembers } from './useSetMembers'
 // styles
 import styles from './styles'
 
 
-// display a stack member selector
+// display the stack member participation control
 export const Stack = () => {
     // get my stack details from the reader context
-    const { stackExtent, stackIndex } = React.useContext(Context)
-    // the mutation that pins or clears a member
-    const setStackIndex = useSetStackIndex()
+    const { stackExtent, members } = React.useContext(Context)
+    // the mutation that updates the membership mask
+    const setMembers = useSetMembers()
 
-    // if i am not a stack, or the stack has too few members to be interesting
+    // if i am not a stack, or the stack has too few members to be worth toggling
     if (!stackExtent || stackExtent < 2) {
         // there is nothing to show
         return null
     }
 
-    // my members are indexed from zero to one less than my extent
-    const max = stackExtent - 1
-    // the tick marks, one per member
-    const major = [...Array(stackExtent).keys()]
+    // the effective mask; when i'm not the active reader i have no view, so assume the default
+    // all-on state until the user activates me by interacting with a member
+    const mask = members ?? Array(stackExtent).fill(true)
+    // how many members are active; the last active member is locked on so the stack is never empty
+    const live = mask.filter(Boolean).length
 
-    // controller configuration
-    const opt = {
-        // the marker sits on the pinned member; collective leaves it unpinned
-        value: stackIndex,
-        // a click pins the chosen member, or clears the pin if it is already pinned
-        setValue: raw => {
-            // round to a whole member
-            const member = Math.round(raw)
-            // ignore anything off the scale
-            if (member < 0 || member > max) {
-                // nothing to do
-                return
-            }
-            // clicking the pinned member clears the pin; otherwise pin the chosen one
-            setStackIndex(member === stackIndex ? null : member)
-        },
-        min: 0, max, major,
-        direction: "row", labels: "bottom", arrows: "top", markers: true,
-        height: 75, width: 190,
-        tickPrecision: 0, markerPrecision: 0,
+    // toggle member {index}, committing the full new mask
+    const toggle = index => {
+        // refuse to turn off the last active member
+        if (mask[index] && live === 1) {
+            // nothing to do
+            return
+        }
+        // flip member {index} and send the whole mask to the server
+        setMembers(mask.map((on, i) => (i === index ? !on : on)))
+        // all done
+        return
     }
 
     // mix my paint
     const paint = styles.axis()
-    // render
+    // and render; the members form a group of independent toggles, one per stack member, and the
+    // client identifies the control as the stack so a driver can find every member under it
     return (
-        <Meta.Entry attribute="stack index" style={paint}>
-            <Housing height={opt.height} width={opt.width}>
-                <Controller enabled={true} {...opt} />
-            </Housing>
+        <Meta.Entry attribute="members" style={paint}>
+            <div role="group" aria-label="stack members" data-qed-control="stack">
+                {mask.map((on, index) => (
+                    <Member key={index} index={index}
+                        active={on} locked={on && live === 1} toggle={toggle} />
+                ))}
+            </div>
         </Meta.Entry>
     )
 }
 
 
-// the controller housing
-const Housing = styled(SVG)`
-`
-
-// the controller
-const Controller = styled(Slider)`
-`
-
-// end of file
+/* end of file */

--- a/ux/client/views/viz/reader/useSetMembers.js
+++ b/ux/client/views/viz/reader/useSetMembers.js
@@ -16,17 +16,17 @@ import { useViewports } from '~/views/viz'
 import { useReader } from './useReader'
 
 
-// pin a stack member, or clear the pin to return to the collective aggregate view
-export const useSetStackIndex = () => {
+// set the per-member participation mask of a stack
+export const useSetMembers = () => {
     // get the active viewport
     const { activeViewport } = useViewports()
     // get my reader
     const reader = useReader()
-    // pinning a member mutates the server side store
-    const [commit, pending] = useMutation(setStackIndexMutation)
+    // adjusting membership mutates the server side store
+    const [commit, pending] = useMutation(setMembersMutation)
 
-    // make the handler; pass {index} null to clear the pin
-    const setStackIndex = (index, viewport = activeViewport) => {
+    // make the handler; {members} is the full per-member boolean mask
+    const setMembers = (members, viewport = activeViewport) => {
         // if there is already a pending operation
         if (pending) {
             // nothing to do
@@ -38,12 +38,12 @@ export const useSetStackIndex = () => {
             variables: {
                 viewport,
                 source: reader.name,
-                index,
+                members,
             },
             // update the store
             updater: store => {
                 // get the root field of the mutation result
-                const response = store.getRootField("viewSetStackIndex")
+                const response = store.getRootField("viewSetMembers")
                 // ask for the view
                 const view = response.getLinkedRecord("view")
                 // if it's trivial
@@ -62,9 +62,9 @@ export const useSetStackIndex = () => {
             },
             onError: errors => {
                 // send the error to the console
-                console.error(`viz.reader.useSetStackIndex:`)
+                console.error(`viz.reader.useSetMembers:`)
                 console.group()
-                console.error(`ERROR while pinning '${reader.name}' to member '${index}'`)
+                console.error(`ERROR while setting the membership of '${reader.name}'`)
                 console.log(errors)
                 console.groupEnd()
                 // all done
@@ -76,14 +76,14 @@ export const useSetStackIndex = () => {
     }
 
     // all done
-    return setStackIndex
+    return setMembers
 }
 
 
-// the mutation that pins or clears a stack member
-const setStackIndexMutation = graphql`
-    mutation useSetStackIndexMutation($viewport: Int!, $source: String!, $index: Int) {
-        viewSetStackIndex(viewport: $viewport, source: $source, index: $index) {
+// the mutation that sets the per-member participation mask
+const setMembersMutation = graphql`
+    mutation useSetMembersMutation($viewport: Int!, $source: String!, $members: [Boolean!]!) {
+        viewSetMembers(viewport: $viewport, source: $source, members: $members) {
             view {
                 id
                 # for synchronized scrolling
@@ -118,4 +118,4 @@ const setStackIndexMutation = graphql`
 `
 
 
-// end of file
+/* end of file */

--- a/ux/client/views/viz/viewer/info.js
+++ b/ux/client/views/viz/viewer/info.js
@@ -24,8 +24,9 @@ import styles from './styles'
 
 // export the data viewer
 export const Info = ({ viewport, view }) => {
-    // unpack the view
-    const { reader, dataset, channel, zoom, stackIndex } = useFragment(infoViewerGetViewFragment, view)
+    // unpack the view; the view's {members} is the participation mask, aliased so it does not
+    // collide with the reader's {members}, which is the list of member URIs
+    const { reader, dataset, channel, zoom, members: participation } = useFragment(infoViewerGetViewFragment, view)
     // get the viewport registry
     const { viewports } = useViewports()
     // make room for the cursor position
@@ -113,9 +114,9 @@ export const Info = ({ viewport, view }) => {
                 {uri}
             </Meta.Entry>
             {members?.map((memberURI, member) => {
-                // is this the member currently on display?
-                const active = member === stackIndex
-                // mark the active one with an arrow on the left, painted in the highlight color
+                // is this member participating in the aggregate?
+                const active = participation?.[member] ?? false
+                // mark each active one with an arrow on the left, painted in the highlight color
                 return (
                     <Meta.Entry key={member} threshold={2}
                         style={active ? activePaint : paint}
@@ -183,7 +184,7 @@ const infoViewerGetViewFragment = graphql`
             horizontal
             vertical
         }
-        stackIndex
+        members
     }
 `
 

--- a/ux/schema/qed.gql
+++ b/ux/schema/qed.gql
@@ -77,8 +77,8 @@ type View implements Node {
   measure: DatasetMeasure
   sync: DatasetSync
   zoom: DatasetZoom
-  # the pinned stack member, if any
-  stackIndex: Int
+  # the per-member participation mask, if the reader is a stack
+  members: [Boolean!]
   # the available selector values, reflecting any pinned member
   available: [Selectors]
 }
@@ -322,7 +322,7 @@ type Mutation {
   viewZoomToggleCoupled(viewport: Int!): DatasetZoomInfos!
   viewZoomReset(viewport: Int!): DatasetZoomInfo!
   # stack
-  viewSetStackIndex(viewport: Int!, source: String!, index: Int): ViewInfo!
+  viewSetMembers(viewport: Int!, source: String!, members: [Boolean!]!): ViewInfo!
 
   # data archive connections
   connectArchive(name: String!, uri: String!, credentials: CredentialsInput): ArchiveInfo!

--- a/ux/schema/qed.gql
+++ b/ux/schema/qed.gql
@@ -323,6 +323,7 @@ type Mutation {
   viewZoomReset(viewport: Int!): DatasetZoomInfo!
   # stack
   viewSetMembers(viewport: Int!, source: String!, members: [Boolean!]!): ViewInfo!
+  viewResetMembers(viewport: Int!, source: String!): ViewInfo!
 
   # data archive connections
   connectArchive(name: String!, uri: String!, credentials: CredentialsInput): ArchiveInfo!


### PR DESCRIPTION
## Summary

Replaces the stack-index slider with a **per-member participation mask**: a row of
toggle buttons, one per stack member, each independently controlling whether that
member participates in the aggregate. All members participate by default.

This **generalizes** the old control rather than replacing it:

- old "pin member *k*" ≡ new "all off except *k*"
- old "clear pin" ≡ new "all on"

So the single-member path (swap in that member's own dataset, expose its native
channels, widen availability) is reused unchanged. The only genuinely new behavior
is aggregation over an arbitrary subset. The empty set is forbidden.

## Why

The old control (`stack.js`) was a `Slider` with one tick per member. It pinned a
single member; clicking the pinned tick again returned to the collective aggregate.
It did not scale past a handful of members, the un-pin gesture was invisible, it
showed an index rather than member identity, and "aggregate vs. member" was implied
by the *absence* of a marker.

The new toggle row scales, shows member identity directly, and — carrying stable
identity in `data-qed-stack-member` with state in ARIA `aria-checked` — is far more
driveable. That driveability is why this redesign precedes the automation-surface work.

## Design

- **Mask is per-View, seeded from a `Stack` trait.** `Stack.membership` (a list of
  member names, empty ⇒ all) resolves in `Stack.__init__` to `Stack.defaultMask`
  (`list[bool]`); each View copies it in `pyre_configured`. Per-View (not global)
  preserves comparing different subsets across viewports.
- **Order-preserving.** The mask is a positional `list[bool]` aligned to the ordered
  `Stack.readers` — never a set. Member order is canonical qed.yaml order.
- **C++ is untouched.** `MeanPower.tile`/`StackCoherence.tile` build the member
  vector from the `members` they are handed; the engines already reduce over whatever
  vector they get, so a subset is just a shorter vector. The aggregate `Dataset` is
  shared across Views, so per-View membership is threaded down at render time via
  `Dataset.render(mask=…)`, never stored on the shared dataset.

## What changed

**Server**
- `pkg/stacks/Stack.py` — `membership` trait + `defaultMask` resolution.
- `pkg/stacks/Dataset.py` — `render(mask=…)` resolves the participating subset.
- `pkg/readers/nisar/products/channels/{MeanPower,StackCoherence}.py` —
  `tile(members=…)`, no source fallback (render always names them).
- `pkg/ux/View.py` — `stackIndex` → `members`; `_pinnedDataset` → `_effectiveDataset`
  (branch on number active); `setMembers`/`resetMembers`; clone/seed updates.
- `pkg/ux/{Viewport,Store}.py` — `setMembers`/`resetMembers` forwarders.

**GraphQL**
- `View.members: [Boolean!]`; `viewSetMembers` and `viewResetMembers` mutations
  (`SetStackIndex.py` → `SetMembers.py`, new `ResetMembers.py`). Reset is server-side
  so the default never leaves the server; `Reader.defaultMask` is not exposed.

**Client**
- `stack.js` is now a group of `member.js` toggles styled like the NISAR selectors;
  `useSetStackIndex.js` → `useSetMembers.js`; `context.js` carries `members`.
- `reader.js` orders MEMBERS above CHANNELS in the datasets panel — members drive
  which channels are available, so the upstream control now sits above the list it
  reshapes.

**Tests** (`tests/qed.pkg`, stand-in based, no NISAR data needed)
- `stacks.py` — mask resolution (empty ⇒ all, named subset, order preserved,
  no-match fallback) and `Dataset.render(mask=…)`.
- `membership.py` — active-member resolution and `setMembers` (empty-set rejected;
  real mask stored and re-resolves).

## Intentionally deferred (not blockers)

- **Wave 2 convenience UI** (All / Invert / Reset buttons) was built then backed out
  so we can demo the raw toggles and gather feedback first. The server mutations are
  in place, so re-wiring is pure client work. "None" is omitted — empty set forbidden.
- **NISAR-fixture-dependent tests**: single-member native-channel swap,
  `availableSelectors` widening, end-to-end subset render, GraphQL round-trips, and
  the `qed.ux.playwright` driveability test — pending a synthesized stack fixture.

## Known limitation (flagged, not a regression)

Color-range stats are still computed over the full member set, so a subset render may
stretch slightly off — same class as the existing center-sample limitation.

## Validation

- `tests/qed.pkg/{stacks,membership}.py` pass (silence = pass).
- Clean `mm` build verified locally; client reorder confirmed in the running app.

See `doc/stack-membership.md` for the full plan and rationale.
