### PR TITLE
Live client sync over server-sent events

### DIFF
--- a/pkg/ux/Dispatcher.py
+++ b/pkg/ux/Dispatcher.py
@@ -261,6 +261,13 @@ class Dispatcher:
         return response
 
     # basic handlers
+    def events(self, server, **kwds):
+        """
+        Open a server-sent event stream so the client receives live state-change notifications
+        """
+        # hand back a streaming response; the server subscribes this connection to its hub
+        return server.eventStream(server=server)
+
     def stop(self, plexus, server, **kwds):
         """
         The client is asking me to die
@@ -400,6 +407,8 @@ class Dispatcher:
                 r"/(?P<graphql>graphql)",
                 # the schema in SDL form, for external clients
                 r"/(?P<schema>schema)",
+                # the live server-sent event stream
+                r"/(?P<events>events)",
                 # the kill command
                 r"/(?P<stop>stop)",
                 # document requests

--- a/pkg/ux/Dispatcher.py
+++ b/pkg/ux/Dispatcher.py
@@ -275,7 +275,7 @@ class Dispatcher:
         # log it
         plexus.info.log("shutting down")
         # and exit
-        return server.documents.Exit(server=server, code=128 + signal.SIGQUIT)
+        return server.documents.Exit(server=server, exitCode=128 + signal.SIGQUIT)
 
     def document(self, plexus, server, request, **kwds):
         """

--- a/pkg/ux/GraphQL.py
+++ b/pkg/ux/GraphQL.py
@@ -167,8 +167,9 @@ class GraphQL:
             stream = server.eventStream(server=server)
             # a minimal payload: clients treat any message as "refetch your state"
             self._changeFrame = stream.event(json.dumps({"type": "change"}))
-        # broadcast it on the global topic
-        server.hub.publish(self._changeFrame)
+        # broadcast it on the global topic; coalesce, since every change frame is identical, so a
+        # burst of mutations collapses to a single pending "refetch" per client rather than a storm
+        server.hub.publish(self._changeFrame, coalesce=True)
         # all done
         return
 

--- a/pkg/ux/GraphQL.py
+++ b/pkg/ux/GraphQL.py
@@ -8,6 +8,9 @@
 import json
 import traceback
 
+# third party
+import graphql
+
 # support
 import qed
 import journal
@@ -113,6 +116,13 @@ class GraphQL:
             # finally, add the error report to the document
             doc["errors"] = [{"message": "\n".join(messages)}]
 
+        # if this request was a mutation that succeeded, the server state changed; notify every
+        # live client so it can refetch. this is the single broadcast choke point: every state
+        # change arrives as a mutation POST, and they all funnel through here
+        if not result.errors and self._isMutation(query=query):
+            # push a minimal change notification to all subscribers
+            self._notify(server=server)
+
         # encode it using JSON and serve it
         return server.documents.JSON(server=server, value=doc)
 
@@ -133,6 +143,37 @@ class GraphQL:
         journal.error("qed.ux.graphql").fatal = False
         # all done
         return
+
+    # implementation details
+    def _isMutation(self, query):
+        """
+        Determine whether {query} carries a mutation operation
+        """
+        # parse the query; this is safe because we only ask after a successful execution
+        document = graphql.parse(query)
+        # report whether any of its operations is a mutation
+        return any(
+            getattr(definition, "operation", None) is graphql.OperationType.MUTATION
+            for definition in document.definitions
+        )
+
+    def _notify(self, server):
+        """
+        Push a change notification to every live client subscribed to {server}'s hub
+        """
+        # the notification frame is constant, so build it once
+        if self._changeFrame is None:
+            # use the {EventStream} framing so the wire format lives in one place
+            stream = server.eventStream(server=server)
+            # a minimal payload: clients treat any message as "refetch your state"
+            self._changeFrame = stream.event(json.dumps({"type": "change"}))
+        # broadcast it on the global topic
+        server.hub.publish(self._changeFrame)
+        # all done
+        return
+
+    # private data
+    _changeFrame = None
 
 
 # end of file

--- a/tests/qed.ux.playwright/.gitignore
+++ b/tests/qed.ux.playwright/.gitignore
@@ -1,0 +1,3 @@
+# playwright run artifacts
+test-results/
+playwright-report/

--- a/tests/qed.ux.playwright/api/contract.spec.ts
+++ b/tests/qed.ux.playwright/api/contract.spec.ts
@@ -16,14 +16,14 @@ import { test, expect } from "@playwright/test"
 
 test.describe.serial("the window.qed contract", () => {
     test.beforeEach(async ({ page }) => {
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         await page.waitForFunction(() => Boolean(window.qed))
     })
 
     // the value test selects the phase channel; leave the suite on amplitude, as the rest expect
     test.afterAll(async ({ browser }) => {
         const page = await browser.newPage()
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         await page.waitForFunction(() => Boolean(window.qed))
         await page.evaluate(() => window.qed.setChannel("amplitude"))
         await page.close()

--- a/tests/qed.ux.playwright/aria/sliders.spec.ts
+++ b/tests/qed.ux.playwright/aria/sliders.spec.ts
@@ -1,0 +1,42 @@
+// -*- web -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// support
+import { test, expect } from "@playwright/test"
+
+
+// every slider thumb must carry a unique, non-empty accessible name, so a driver -- and assistive
+// tech -- can target a specific one (the low vs high of a range, the two zoom axes, one viz
+// controller among several) WITHOUT resorting to its value, which is state and which the convention
+// (doc/semantic-markup.md) forbids as identity. each name is the server component it reflects (the
+// controller slot, the zoom axis) plus the widget's part. the controls view renders the zoom control
+// and the active channel's viz controllers (the setup project leaves a channel selected).
+test("every slider thumb has a unique accessible name", async ({ page }) => {
+    await page.goto("/controls", { waitUntil: "load" })
+    await page.waitForFunction(() => Boolean(window.qed))
+
+    // every thumb the controls view renders
+    const thumbs = page.locator('[data-pyre-widget="slider"][data-pyre-widget-part="thumb"]')
+    await thumbs.first().waitFor()
+    const names = await thumbs.evaluateAll(els => els.map(el => el.getAttribute("aria-label")))
+
+    // none is anonymous
+    expect(names, `an anonymous slider thumb in ${JSON.stringify(names)}`)
+        .not.toContain(null)
+    expect(
+        names.every(name => (name ?? "").trim().length > 0),
+        `an empty slider thumb name in ${JSON.stringify(names)}`,
+    ).toBe(true)
+    // and each is unique, so exactly one thumb answers to a given name
+    expect(
+        new Set(names).size,
+        `duplicate slider thumb names in ${JSON.stringify(names)}`,
+    ).toBe(names.length)
+})
+
+
+/* end of file */

--- a/tests/qed.ux.playwright/audit/driveability.spec.ts
+++ b/tests/qed.ux.playwright/audit/driveability.spec.ts
@@ -119,13 +119,13 @@ test("driveability audit across routes and states", async ({ page }) => {
 
     // baseline routes -- the same four the coverage gate sweeps
     for (const route of ["/", "/controls", "/explore", "/doc"]) {
-        await page.goto(route, { waitUntil: "networkidle" })
+        await page.goto(route, { waitUntil: "load" })
         await report(page, `native ${route}`)
     }
 
     // STATE: the measure layer on, with a couple of anchors -- exposes the measure panel, the peek
     // pad, and the on-raster markers, none of which the gate's default render shows
-    await page.goto("/controls", { waitUntil: "networkidle" })
+    await page.goto("/controls", { waitUntil: "load" })
     await ensureQED(page)
     await page.evaluate(() => window.qed.measure.reset())
     await page.evaluate(() => window.qed.measure.add(240, 120))
@@ -146,7 +146,7 @@ test("driveability audit across routes and states", async ({ page }) => {
     await page.evaluate(() => window.qed.measure.reset())
 
     // STATE: the NISAR reader on its own server -- the band/frequency/polarization selectors
-    await page.goto(`${nisarBaseURL}/`, { waitUntil: "networkidle" })
+    await page.goto(`${nisarBaseURL}/`, { waitUntil: "load" })
     await report(page, "nisar / (reader selectors)")
 })
 

--- a/tests/qed.ux.playwright/behavior/actions.spec.ts
+++ b/tests/qed.ux.playwright/behavior/actions.spec.ts
@@ -24,7 +24,7 @@ const clickUntilPressed = async (button: Locator, value: string) => {
 
 test.describe.serial("the viewport toggle actions govern their panels", () => {
     test.beforeEach(async ({ page }) => {
-        await page.goto("/controls", { waitUntil: "networkidle" })
+        await page.goto("/controls", { waitUntil: "load" })
         await page.locator('[data-qed-control="viewport"][data-qed-action="measure"]')
             .first().waitFor({ timeout: 10_000 })
     })

--- a/tests/qed.ux.playwright/behavior/controller-drag.spec.ts
+++ b/tests/qed.ux.playwright/behavior/controller-drag.spec.ts
@@ -1,0 +1,113 @@
+// -*- web -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// support
+import { test, expect } from "@playwright/test"
+import type { Locator, Page } from "@playwright/test"
+
+
+// issue #78: a controller drag fires updates far faster than the server round trip. the update hooks
+// must not drop the final resting value -- each uses a trailing-edge throttle (one mutation in
+// flight, hold only the latest, flush it when the in-flight one settles). we force the in-flight
+// overlap with artificial latency on the driver's mutations, perform a real multi-step drag, and
+// assert that a SECOND client -- reflecting server state over live-sync -- reaches the final value.
+// asserting the observer (the server's view), not the driver's local thumb, is what proves the value
+// actually reached the server. the two cases cover the two distinct mechanisms: the Range controller
+// (two-thumb, local state, useUpdateRangeController -- the same throttle useUpdateValueController has)
+// and the zoom Slider (fragment-driven, useSetLevel).
+
+// slow every mutation on {page} so a quick drag overflows the single in-flight slot
+const throttle = (page: Page) =>
+    page.route("**/graphql", async route => {
+        await new Promise(resolve => setTimeout(resolve, 400))
+        return route.continue()
+    })
+
+// drag {thumb} by {dx} pixels along the horizontal axis, in many small steps
+const dragBy = async (page: Page, thumb: Locator, dx: number) => {
+    const box = await thumb.boundingBox()
+    const y = box!.y + box!.height / 2
+    const x0 = box!.x + box!.width / 2
+    await page.mouse.move(x0, y)
+    await page.mouse.down()
+    for (let i = 1; i <= 12; ++i) await page.mouse.move(x0 + dx * (i / 12), y)
+    await page.mouse.up()
+}
+
+// the current value a thumb reports
+const valueOf = (thumb: Locator) => thumb.getAttribute("aria-valuenow").then(Number)
+
+
+test.describe.serial("a controller drag's final value is not dropped", () => {
+    test("the range controller's final value reaches the server", async ({ page, context }) => {
+        const driver = page
+        const observer = await context.newPage()
+        for (const client of [driver, observer]) {
+            await client.goto("/controls", { waitUntil: "load" })
+            await client.waitForFunction(() => Boolean(window.qed))
+        }
+
+        const range = (await driver.evaluate(() => window.qed.controllers()))
+            .find(controller => controller.kind === "range")
+        test.skip(!range, "the active channel exposes no range controller")
+        const { slot, min, max } = range!
+        const tol = (max - min) * 0.02
+
+        const driverHigh = driver.getByRole("slider", { name: `${slot} high` })
+        const observerHigh = observer.getByRole("slider", { name: `${slot} high` })
+        await driverHigh.waitFor()
+        await observerHigh.waitFor()
+
+        // drag the high thumb left under latency, then read the value the driver settled on locally
+        await throttle(driver)
+        await dragBy(driver, driverHigh, -60)
+        const finalValue = await valueOf(driverHigh)
+
+        // the observer reflects the server; it must catch up to the final value, not a dropped one
+        await expect
+            .poll(async () => Math.abs((await valueOf(observerHigh)) - finalValue), { timeout: 15_000 })
+            .toBeLessThan(tol)
+
+        // restore
+        await driver.unroute("**/graphql")
+        await driver.evaluate(controller => window.qed.range.reset(controller), slot)
+        await observer.close()
+    })
+
+    test("the zoom level's final value reaches the server", async ({ page, context }) => {
+        const driver = page
+        const observer = await context.newPage()
+        for (const client of [driver, observer]) {
+            await client.goto("/controls", { waitUntil: "load" })
+            await client.waitForFunction(() => Boolean(window.qed))
+        }
+
+        const driverZoom = driver.getByRole("slider", { name: "zoom horizontal" })
+        const observerZoom = observer.getByRole("slider", { name: "zoom horizontal" })
+        await driverZoom.waitFor()
+        await observerZoom.waitFor()
+        // the lowest level the slider allows; dragging far past it clamps here -- a known endpoint
+        const min = Number(await driverZoom.getAttribute("aria-valuemin"))
+
+        // drag the horizontal thumb far left under latency, so it lands on the min level
+        await throttle(driver)
+        await dragBy(driver, driverZoom, -400)
+
+        // the observer must reach the min level; a dropped final value would strand it short of it
+        await expect
+            .poll(async () => valueOf(observerZoom), { timeout: 15_000 })
+            .toBe(min)
+
+        // restore
+        await driver.unroute("**/graphql")
+        await driver.evaluate(() => window.qed.zoomReset())
+        await observer.close()
+    })
+})
+
+
+/* end of file */

--- a/tests/qed.ux.playwright/behavior/coordinates.spec.ts
+++ b/tests/qed.ux.playwright/behavior/coordinates.spec.ts
@@ -17,7 +17,7 @@ import { test, expect } from "@playwright/test"
 // gate) and restores the scroll it touches.
 test.describe.serial("the minimap window tracks the viewport scroll", () => {
     test("scrolling the viewport moves the reported window origin to the scaled scroll", async ({ page }) => {
-        await page.goto("/controls", { waitUntil: "networkidle" })
+        await page.goto("/controls", { waitUntil: "load" })
         const region = page.locator('[data-qed-region="viewport"]').first()
         await region.waitFor({ timeout: 10_000 })
 

--- a/tests/qed.ux.playwright/behavior/facade.spec.ts
+++ b/tests/qed.ux.playwright/behavior/facade.spec.ts
@@ -14,7 +14,7 @@ import { test, expect } from "@playwright/test"
 // are verified through the same markup the rest of the suite reads, so a broken command fails here.
 test.describe.serial("the automation surface reads the catalog and scrolls", () => {
     test("readers() lists the catalog, including the active reader", async ({ page }) => {
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         await page.waitForFunction(() => Boolean(window.qed))
         // the catalog the facade reports, and the reader the active view is on
         const { active, names } = await page.evaluate(async () => ({
@@ -27,11 +27,19 @@ test.describe.serial("the automation surface reads the catalog and scrolls", () 
     })
 
     test("centerOn scrolls the viewport so the source pixel lands at the window center", async ({ page }) => {
-        await page.goto("/controls", { waitUntil: "networkidle" })
+        await page.goto("/controls", { waitUntil: "load" })
         await page.waitForFunction(() => Boolean(window.qed))
         // a channel is selected (the setup project), so the raster renders; at zoom 0 the whole raster
         // is large enough to scroll a mid-raster pixel to the center
         await page.evaluate(() => window.qed.setZoom(0))
+        // {centerOn} converts source pixels to a scroll offset against the rendered region, so wait
+        // until the mosaic has laid out and the region is actually scrollable before centering --
+        // otherwise the offset is computed against an unsized region and clamped to the origin
+        const region = page.locator('[data-qed-region="viewport"]').first()
+        await region.waitFor()
+        await expect
+            .poll(() => region.evaluate(el => el.scrollHeight - el.clientHeight))
+            .toBeGreaterThan(0)
         const target = { row: 1500, col: 1000 }
         await page.evaluate(t => window.qed.centerOn(t.row, t.col), target)
 

--- a/tests/qed.ux.playwright/behavior/live-sync.spec.ts
+++ b/tests/qed.ux.playwright/behavior/live-sync.spec.ts
@@ -1,0 +1,69 @@
+// -*- web -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// support
+import { test, expect } from "@playwright/test"
+
+
+// the live-sync capability: a state change committed by one client reaches every other connected
+// client over the SSE event stream (the /events route + the mutation broadcast), updating the
+// receiver's Relay store -- and therefore its rendered DOM -- with no reload or fetch on its side.
+// we drive two independent pages on the one shared server: the {driver} mutates through window.qed,
+// while the {observer} only watches its own DOM. the assertion is on the DOM, not on {window.qed.
+// state()} -- which would re-fetch from the network and pass even if the push never arrived. it
+// perturbs viewport 0's zoom and restores it exactly.
+test.describe.serial("live client sync over the event stream", () => {
+    test("a zoom change on one client re-renders another", async ({ page, context }) => {
+        // the client that makes the change
+        const driver = page
+        // a second, independent client on the same server
+        const observer = await context.newPage()
+
+        // bring both up on the viz page and wait for the rendered viewport region
+        for (const client of [driver, observer]) {
+            await client.goto("/controls", { waitUntil: "load" })
+            await client.waitForFunction(() => Boolean(window.qed))
+            await client.locator('[data-qed-region="viewport"]').first().waitFor()
+        }
+
+        // the observer's region; its {data-qed-zoom} mirrors the store zoom and re-renders on update
+        const region = observer.locator('[data-qed-region="viewport"]').first()
+        // what the observer renders before anything changes
+        const before = (await region.getAttribute("data-qed-zoom")) ?? "0,0"
+        const [vertical, horizontal] = before.split(",").map(Number)
+        // a symmetric target distinct from the current zoom
+        const target = vertical === -2 && horizontal === -2 ? -3 : -2
+
+        // mark the observer so we can later prove it never reloaded
+        await observer.evaluate(() => {
+            ;(window as typeof window & { synced?: boolean }).synced = true
+        })
+
+        // the observer does nothing from here on; the driver mutates on the OTHER client
+        await driver.evaluate(level => window.qed.setZoom(level, 0), target)
+
+        // the observer's DOM reflects the new zoom, pushed over the stream and refetched into its store
+        await expect(region).toHaveAttribute("data-qed-zoom", `${target},${target}`, { timeout: 10_000 })
+        // and it got there in place -- it never navigated or reloaded
+        expect(
+            await observer.evaluate(() => (window as typeof window & { synced?: boolean }).synced),
+        ).toBe(true)
+
+        // restore exactly what was there, and confirm that propagates to the observer too
+        await driver.evaluate(
+            ([v, h]) => window.qed.setZoom({ vertical: v, horizontal: h }, 0),
+            [vertical, horizontal] as const,
+        )
+        await expect(region).toHaveAttribute("data-qed-zoom", before, { timeout: 10_000 })
+
+        // tidy up the extra client
+        await observer.close()
+    })
+})
+
+
+/* end of file */

--- a/tests/qed.ux.playwright/behavior/live-sync.spec.ts
+++ b/tests/qed.ux.playwright/behavior/live-sync.spec.ts
@@ -63,6 +63,73 @@ test.describe.serial("live client sync over the event stream", () => {
         // tidy up the extra client
         await observer.close()
     })
+
+    test("a range-controller change on one client re-renders another", async ({ page, context }) => {
+        // the client that makes the change
+        const driver = page
+        // a second, independent client on the same server
+        const observer = await context.newPage()
+
+        // bring both up on the controls page and wait for the controller sliders to render
+        for (const client of [driver, observer]) {
+            await client.goto("/controls", { waitUntil: "load" })
+            await client.waitForFunction(() => Boolean(window.qed))
+            await client.locator('[data-pyre-widget="slider"][data-pyre-widget-part="thumb"]').first().waitFor()
+        }
+
+        // the range controller the active channel exposes (the setup leaves amplitude selected)
+        const range = (await driver.evaluate(() => window.qed.controllers())).find(c => c.kind === "range")
+        test.skip(!range, "the active channel exposes no range controller")
+        const { slot, min, max } = range!
+
+        // read this controller's two thumbs -- identified by their shared extent, which the zoom
+        // slider (-6..4) does not share -- as [low, high]. this reads the rendered DOM, not
+        // window.qed.controllers(), which would re-fetch and pass even if the push never arrived
+        const readBounds = (client: typeof page) => client.evaluate(({ min, max }) => {
+            const thumbs = [...document.querySelectorAll(
+                '[data-pyre-widget="slider"][data-pyre-widget-part="thumb"]',
+            )]
+            return thumbs
+                .filter(t => Math.abs(Number(t.getAttribute("aria-valuemin")) - min) < 1e-6
+                    && Math.abs(Number(t.getAttribute("aria-valuemax")) - max) < 1e-6)
+                .map(t => Number(t.getAttribute("aria-valuenow")))
+                .sort((a, b) => a - b)
+        }, { min, max })
+
+        // a target band well inside the extent, and a tolerance that absorbs server rounding
+        const span = max - min
+        const target = { min, low: min + span * 0.3, high: min + span * 0.6, max }
+        const tol = span * 0.02
+
+        // mark the observer so we can prove it never reloaded
+        await observer.evaluate(() => {
+            ;(window as typeof window & { synced?: boolean }).synced = true
+        })
+
+        // drive the change on the OTHER client
+        await driver.evaluate(([s, b]) => window.qed.range.update(s, b), [slot, target] as const)
+
+        // the observer's thumbs move to the new band, pushed over the stream into its store
+        await expect.poll(async () => {
+            const [low, high] = await readBounds(observer)
+            return Math.max(Math.abs(low - target.low), Math.abs(high - target.high))
+        }, { timeout: 10_000 }).toBeLessThan(tol)
+        // and it updated in place -- it never navigated or reloaded
+        expect(
+            await observer.evaluate(() => (window as typeof window & { synced?: boolean }).synced),
+        ).toBe(true)
+
+        // restore: reset returns the controller to its defaults, and the observer follows -- its
+        // high thumb leaves the target band, proving the reset propagated too
+        await driver.evaluate(s => window.qed.range.reset(s), slot)
+        await expect.poll(async () => {
+            const [, high] = await readBounds(observer)
+            return Math.abs(high - target.high)
+        }, { timeout: 10_000 }).toBeGreaterThan(tol)
+
+        // tidy up the extra client
+        await observer.close()
+    })
 })
 
 

--- a/tests/qed.ux.playwright/behavior/live-sync.spec.ts
+++ b/tests/qed.ux.playwright/behavior/live-sync.spec.ts
@@ -82,19 +82,11 @@ test.describe.serial("live client sync over the event stream", () => {
         test.skip(!range, "the active channel exposes no range controller")
         const { slot, min, max } = range!
 
-        // read this controller's two thumbs -- identified by their shared extent, which the zoom
-        // slider (-6..4) does not share -- as [low, high]. this reads the rendered DOM, not
+        // the observer's high thumb, addressed by its accessible name ("<slot> high") -- the
+        // identity fix; no value/extent heuristic. read aria-valuenow off the rendered DOM, not
         // window.qed.controllers(), which would re-fetch and pass even if the push never arrived
-        const readBounds = (client: typeof page) => client.evaluate(({ min, max }) => {
-            const thumbs = [...document.querySelectorAll(
-                '[data-pyre-widget="slider"][data-pyre-widget-part="thumb"]',
-            )]
-            return thumbs
-                .filter(t => Math.abs(Number(t.getAttribute("aria-valuemin")) - min) < 1e-6
-                    && Math.abs(Number(t.getAttribute("aria-valuemax")) - max) < 1e-6)
-                .map(t => Number(t.getAttribute("aria-valuenow")))
-                .sort((a, b) => a - b)
-        }, { min, max })
+        const observerHigh = observer.getByRole("slider", { name: `${slot} high` })
+        const readNow = () => observerHigh.getAttribute("aria-valuenow").then(Number)
 
         // a target band well inside the extent, and a tolerance that absorbs server rounding
         const span = max - min
@@ -109,23 +101,19 @@ test.describe.serial("live client sync over the event stream", () => {
         // drive the change on the OTHER client
         await driver.evaluate(([s, b]) => window.qed.range.update(s, b), [slot, target] as const)
 
-        // the observer's thumbs move to the new band, pushed over the stream into its store
-        await expect.poll(async () => {
-            const [low, high] = await readBounds(observer)
-            return Math.max(Math.abs(low - target.low), Math.abs(high - target.high))
-        }, { timeout: 10_000 }).toBeLessThan(tol)
+        // the observer's high thumb moves to the new value, pushed over the stream into its store
+        await expect.poll(async () => Math.abs(await readNow() - target.high), { timeout: 10_000 })
+            .toBeLessThan(tol)
         // and it updated in place -- it never navigated or reloaded
         expect(
             await observer.evaluate(() => (window as typeof window & { synced?: boolean }).synced),
         ).toBe(true)
 
         // restore: reset returns the controller to its defaults, and the observer follows -- its
-        // high thumb leaves the target band, proving the reset propagated too
+        // high thumb leaves the target value, proving the reset propagated too
         await driver.evaluate(s => window.qed.range.reset(s), slot)
-        await expect.poll(async () => {
-            const [, high] = await readBounds(observer)
-            return Math.abs(high - target.high)
-        }, { timeout: 10_000 }).toBeGreaterThan(tol)
+        await expect.poll(async () => Math.abs(await readNow() - target.high), { timeout: 10_000 })
+            .toBeGreaterThan(tol)
 
         // tidy up the extra client
         await observer.close()

--- a/tests/qed.ux.playwright/behavior/local-controls.spec.ts
+++ b/tests/qed.ux.playwright/behavior/local-controls.spec.ts
@@ -16,7 +16,7 @@ import { test, expect } from "@playwright/test"
 
 test.describe("client-only controls (no server mutation)", () => {
     test("the detail toggle reveals higher-detail metadata rows", async ({ page }) => {
-        await page.goto("/controls", { waitUntil: "networkidle" })
+        await page.goto("/controls", { waitUntil: "load" })
         // the metadata table carries the detail control in its header
         const table = page.locator('table:has([data-qed-control="detail"])').first()
         await table.waitFor({ timeout: 10_000 })
@@ -33,7 +33,7 @@ test.describe("client-only controls (no server mutation)", () => {
     })
 
     test("a tray header collapses and reveals its panel", async ({ page }) => {
-        await page.goto("/controls", { waitUntil: "networkidle" })
+        await page.goto("/controls", { waitUntil: "load" })
         // the sync panel is always present on /controls; its tray renders its children only when open
         const tray = page.locator('[data-qed-panel="sync"] [data-qed-control="tray"]').first()
         await tray.waitFor({ timeout: 10_000 })
@@ -55,7 +55,7 @@ test.describe("client-only controls (no server mutation)", () => {
     })
 
     test("a nav-rail link routes to its view", async ({ page }) => {
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         // routing is pure client state -- no GraphQL
         await page.locator('[data-qed-nav="explore data archives"]').first().click()
         await expect(page).toHaveURL(/\/explore$/)

--- a/tests/qed.ux.playwright/behavior/markers.spec.ts
+++ b/tests/qed.ux.playwright/behavior/markers.spec.ts
@@ -45,7 +45,7 @@ const showMeasure = async (page: Page) => {
 // updates the live store, so the toggle then acts on a consistent state, with no reload
 const cleanup = async (browser: import("@playwright/test").Browser) => {
     const page = await browser.newPage()
-    await page.goto("/controls", { waitUntil: "networkidle" })
+    await page.goto("/controls", { waitUntil: "load" })
     await ensureQED(page)
     await page.evaluate(() => window.qed.measure.reset())
     const toggle = measureToggle(page)
@@ -68,7 +68,7 @@ test.describe.serial("measure markers carry verifiable identity", () => {
     test("placed markers read back by source coordinate at both ends", async ({ page }) => {
         // drop the points through the facade, then reveal the layer; the live store renders them with
         // no reload
-        await page.goto("/controls", { waitUntil: "networkidle" })
+        await page.goto("/controls", { waitUntil: "load" })
         for (const [col, row] of points) await place(page, col, row)
         await showMeasure(page)
 
@@ -92,7 +92,7 @@ test.describe.serial("measure markers carry verifiable identity", () => {
     })
 
     test("splitting a segment renumbers the vertices while sources verify the move", async ({ page }) => {
-        await page.goto("/controls", { waitUntil: "networkidle" })
+        await page.goto("/controls", { waitUntil: "load" })
         await showMeasure(page)
 
         // the second point's identity before the edit: ordinal 1, at its placed source
@@ -118,7 +118,7 @@ test.describe.serial("measure markers carry verifiable identity", () => {
     test("resetting through the control clears the rendered path live, with no reload", async ({ page }) => {
         // this serial block accumulates anchors across its tests, so start from a known-empty path
         // (the facade reset is a fine setup tool) then place exactly two and render them
-        await page.goto("/controls", { waitUntil: "networkidle" })
+        await page.goto("/controls", { waitUntil: "load" })
         await ensureQED(page)
         await page.evaluate(() => window.qed.measure.reset())
         for (const [col, row] of points.slice(0, 2)) await place(page, col, row)

--- a/tests/qed.ux.playwright/behavior/measure-selection.spec.ts
+++ b/tests/qed.ux.playwright/behavior/measure-selection.spec.ts
@@ -23,7 +23,7 @@ const measureToggle = (page: Page) =>
 
 // a clean three-anchor path with the layer shown
 const arrange = async (page: Page) => {
-    await page.goto("/controls", { waitUntil: "networkidle" })
+    await page.goto("/controls", { waitUntil: "load" })
     await ensureQED(page)
     await page.evaluate(async () => {
         await window.qed.measure.reset()
@@ -38,7 +38,7 @@ const arrange = async (page: Page) => {
 
 // reset the path and hide the layer
 const cleanup = async (page: Page) => {
-    await page.goto("/controls", { waitUntil: "networkidle" })
+    await page.goto("/controls", { waitUntil: "load" })
     await ensureQED(page)
     await page.evaluate(() => window.qed.measure.reset())
     const toggle = measureToggle(page)

--- a/tests/qed.ux.playwright/behavior/minimap.spec.ts
+++ b/tests/qed.ux.playwright/behavior/minimap.spec.ts
@@ -52,17 +52,17 @@ const waitForZoom = async (page: Page, horizontal: number) =>
 test.describe.serial("the minimap tracks the current zoom", () => {
     test.afterAll(async ({ browser }) => {
         const page = await browser.newPage()
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         await setZoom(page, 0, 0)
         await page.close()
     })
 
     test("a minimap click maps to the same scroll regardless of zoom history", async ({ page }) => {
         // a channel must be selected and the zoom at 0 to start
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         await setChannel(page, "amplitude")
         await setZoom(page, 0, 0)
-        await page.goto("/controls", { waitUntil: "networkidle" })
+        await page.goto("/controls", { waitUntil: "load" })
 
         // the minimap's data rect (Placemat, Data, Viewport -> the second one) and the horizontal
         // zoom slider (the slider with a horizontal thumb whose ticks include -6)

--- a/tests/qed.ux.playwright/behavior/raster.spec.ts
+++ b/tests/qed.ux.playwright/behavior/raster.spec.ts
@@ -32,7 +32,7 @@ const setChannel = async (page: Page, tag: string) => {
 
 // load the readers view and report the rendered mosaic's pixel extent
 const mosaicExtent = async (page: Page) => {
-    await page.goto("/", { waitUntil: "networkidle" })
+    await page.goto("/", { waitUntil: "load" })
     const box = page.locator('[data-pyre-widget="mosaic"]').first()
     await box.waitFor({ timeout: 10_000 })
     return box.evaluate(m => ({ w: (m as HTMLElement).offsetWidth, h: (m as HTMLElement).offsetHeight }))
@@ -43,14 +43,14 @@ test.describe.serial("the raster resizes with zoom", () => {
     test.afterAll(async ({ browser }) => {
         // leave the shared server at the default zoom for anything that reuses it
         const page = await browser.newPage()
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         await setZoom(page, 0, 0)
         await page.close()
     })
 
     test("the mosaic extent tracks the zoom level", async ({ page }) => {
         // make sure a channel is selected so the mosaic renders; the facade resolves the reader itself
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         await setChannel(page, "amplitude")
 
         // the extent at zoom 0

--- a/tests/qed.ux.playwright/behavior/resets.spec.ts
+++ b/tests/qed.ux.playwright/behavior/resets.spec.ts
@@ -19,7 +19,7 @@ const ensureQED = (page: Page) => page.waitForFunction(() => Boolean(window.qed)
 
 // drive the server back to a single, unsynced, zoom-0 viewport
 const restore = async (page: Page) => {
-    await page.goto("/", { waitUntil: "networkidle" })
+    await page.goto("/", { waitUntil: "load" })
     await ensureQED(page)
     await page.evaluate(async () => {
         for (let n = (await window.qed.viewports()).length; n > 1; n--) await window.qed.collapse(n - 1)
@@ -37,7 +37,7 @@ test.describe.serial("the reset and toggle-all commands", () => {
     })
 
     test("zoomReset returns the viewport to the default zoom", async ({ page }) => {
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         await ensureQED(page)
         const horizontal = () => page.evaluate(async () => (await window.qed.state())!.zoom!.horizontal)
 
@@ -48,7 +48,7 @@ test.describe.serial("the reset and toggle-all commands", () => {
     })
 
     test("sync toggleAll flips the aspect on every viewport; reset clears one", async ({ page }) => {
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         await ensureQED(page)
         const scroll = () => page.evaluate(async () => (await window.qed.viewports()).map(v => v.sync!.scroll))
 

--- a/tests/qed.ux.playwright/behavior/sync-scroll.spec.ts
+++ b/tests/qed.ux.playwright/behavior/sync-scroll.spec.ts
@@ -59,7 +59,7 @@ const sourceOrigin = async (region: Locator) => {
 test.describe.serial("synced scrolling lines up across mismatched zoom", () => {
     test.afterAll(async ({ browser }) => {
         const page = await browser.newPage()
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         // leave the store as the rest of the suite expects it: one viewport, unsynced, at zoom 0
         await collapseToOne(page)
         await setScrollSync(page, 0, false)
@@ -68,7 +68,7 @@ test.describe.serial("synced scrolling lines up across mismatched zoom", () => {
     })
 
     test("panning one viewport lands its peer on the same source pixel", async ({ page }) => {
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         // start from a single viewport, then split it so there are exactly two
         await collapseToOne(page)
         await page.evaluate(() => window.qed.split(0))
@@ -84,7 +84,7 @@ test.describe.serial("synced scrolling lines up across mismatched zoom", () => {
         await page.evaluate(([row, col]) => window.qed.sync.updateOffset(row, col, 1), [offset.y, offset.x])
 
         // load the two-viewport state fresh, so the client picks up the zoom/sync/offsets
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         const regions = page.locator('[data-qed-region="viewport"]')
         await expect(regions).toHaveCount(2)
         const [first, second] = [regions.nth(0), regions.nth(1)]

--- a/tests/qed.ux.playwright/behavior/zoom-retain.spec.ts
+++ b/tests/qed.ux.playwright/behavior/zoom-retain.spec.ts
@@ -61,10 +61,10 @@ const setHorizontalZoom = async (page: Page, level: number) => {
 
 // land at zoom 0 with the requested coupling, scrolled to the middle of the raster, on /controls
 const start = async (page: Page, { coupled }: { coupled: boolean }) => {
-    await page.goto("/", { waitUntil: "networkidle" })
+    await page.goto("/", { waitUntil: "load" })
     await setZoom(page, 0, 0)
     await setCoupled(page, coupled)
-    await page.goto("/controls", { waitUntil: "networkidle" })
+    await page.goto("/controls", { waitUntil: "load" })
     const region = page.locator('[data-qed-region="viewport"]').first()
     await region.waitFor({ timeout: 10_000 })
     // scroll to the middle, so there is room to clamp in either direction
@@ -86,7 +86,7 @@ const expectRetained = (after: Awaited<ReturnType<typeof readCenter>>, before: {
 test.describe.serial("an in-place zoom change retains the viewport position", () => {
     test.afterAll(async ({ browser }) => {
         const page = await browser.newPage()
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         // leave the store as the other specs expect it: coupled, at zoom 0
         await setCoupled(page, true)
         await setZoom(page, 0, 0)

--- a/tests/qed.ux.playwright/identity/actions.spec.ts
+++ b/tests/qed.ux.playwright/identity/actions.spec.ts
@@ -17,7 +17,7 @@ import { test, expect } from "@playwright/test"
 // renders on the controls view and carries its own client identity ({data-qed-panel}).
 test.describe("the viewport actions", () => {
     test.beforeEach(async ({ page }) => {
-        await page.goto("/controls", { waitUntil: "networkidle" })
+        await page.goto("/controls", { waitUntil: "load" })
         await page.locator('[data-qed-control="viewport"][data-qed-action="measure"]')
             .first().waitFor({ timeout: 10_000 })
     })

--- a/tests/qed.ux.playwright/identity/channels.spec.ts
+++ b/tests/qed.ux.playwright/identity/channels.spec.ts
@@ -15,7 +15,7 @@ import { test, expect } from "@playwright/test"
 test.describe("the channel selector", () => {
     // it renders on the readers view, beside the active reader
     test.beforeEach(async ({ page }) => {
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         await page.locator('[data-qed-control="channel"]').first().waitFor({ timeout: 10_000 })
     })
 

--- a/tests/qed.ux.playwright/identity/coordinates.spec.ts
+++ b/tests/qed.ux.playwright/identity/coordinates.spec.ts
@@ -18,7 +18,7 @@ import { test, expect } from "@playwright/test"
 // part of the read-only gate; the behavior project proves the live window tracks a scroll.
 test.describe("the viewport coordinate metadata", () => {
     test.beforeEach(async ({ page }) => {
-        await page.goto("/controls", { waitUntil: "networkidle" })
+        await page.goto("/controls", { waitUntil: "load" })
         await page.locator('[data-qed-region="viewport"]').first().waitFor({ timeout: 10_000 })
     })
 

--- a/tests/qed.ux.playwright/identity/detail.spec.ts
+++ b/tests/qed.ux.playwright/identity/detail.spec.ts
@@ -15,7 +15,7 @@ import { test, expect } from "@playwright/test"
 // ARIA ({aria-disabled}), never in a data attribute.
 test.describe("the detail toggle", () => {
     test.beforeEach(async ({ page }) => {
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         await page.locator('[data-qed-control="detail"]').first().waitFor({ timeout: 10_000 })
     })
 

--- a/tests/qed.ux.playwright/identity/doc.spec.ts
+++ b/tests/qed.ux.playwright/identity/doc.spec.ts
@@ -14,7 +14,7 @@ import { test, expect } from "@playwright/test"
 // page currently shown is marked with {aria-current} rather than a {data-*} state mirror.
 test.describe("the doc table of contents", () => {
     test.beforeEach(async ({ page }) => {
-        await page.goto("/doc", { waitUntil: "networkidle" })
+        await page.goto("/doc", { waitUntil: "load" })
         await page.locator('[data-qed-control="doc-topic"]').first().waitFor({ timeout: 10_000 })
     })
 

--- a/tests/qed.ux.playwright/identity/icons.spec.ts
+++ b/tests/qed.ux.playwright/identity/icons.spec.ts
@@ -15,7 +15,7 @@ import { test, expect } from "@playwright/test"
 // accessible name + identity live on the control.
 test.describe("icon controls", () => {
     test.beforeEach(async ({ page }) => {
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         await page.locator('[data-qed-nav]').first().waitFor({ timeout: 10_000 })
     })
 

--- a/tests/qed.ux.playwright/identity/slider.spec.ts
+++ b/tests/qed.ux.playwright/identity/slider.spec.ts
@@ -15,7 +15,7 @@ import { test, expect } from "@playwright/test"
 // group and the thumb stays in the accessible tree. the zoom slider renders on the controls view.
 test.describe("the slider scale", () => {
     test.beforeEach(async ({ page }) => {
-        await page.goto("/controls", { waitUntil: "networkidle" })
+        await page.goto("/controls", { waitUntil: "load" })
         await page.locator('[data-pyre-widget="slider"][data-pyre-widget-part="thumb"]')
             .first().waitFor({ timeout: 10_000 })
     })

--- a/tests/qed.ux.playwright/identity/sync.spec.ts
+++ b/tests/qed.ux.playwright/identity/sync.spec.ts
@@ -16,7 +16,7 @@ test.describe("the sync controls", () => {
     const aspects = ["channel", "zoom", "scroll", "path"]
 
     test.beforeEach(async ({ page }) => {
-        await page.goto("/controls", { waitUntil: "networkidle" })
+        await page.goto("/controls", { waitUntil: "load" })
         await page.locator('[data-qed-control="sync"]').first().waitFor({ timeout: 10_000 })
     })
 

--- a/tests/qed.ux.playwright/lib/routes.ts
+++ b/tests/qed.ux.playwright/lib/routes.ts
@@ -26,7 +26,7 @@ export const sweep = async (
     // sweep each route
     for (const route of routes) {
         // load it and let the client settle
-        await page.goto(route, { waitUntil: "networkidle" })
+        await page.goto(route, { waitUntil: "load" })
         // wait for the app shell to mount before inspecting
         await page.locator("[data-pyre-widget]").first().waitFor({ timeout: 10_000 })
         // run the read-only check and tag each problem with its route

--- a/tests/qed.ux.playwright/nisar/selectors.spec.ts
+++ b/tests/qed.ux.playwright/nisar/selectors.spec.ts
@@ -35,7 +35,7 @@ const group = (page: Page, reader: string, axis: string): Locator =>
 
 test.describe.serial("the NISAR axis selectors are tagged radiogroups", () => {
     test("each gslc axis is a radiogroup whose values are radios named by their text", async ({ page }) => {
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         // the readers panel renders both fixtures; wait for the gslc reader to mount
         await page.locator('[data-qed-reader="gslc"]').waitFor({ timeout: 10_000 })
 
@@ -56,11 +56,11 @@ test.describe.serial("the NISAR axis selectors are tagged radiogroups", () => {
 
     test("selecting a value checks exactly that radio, with the state living in ARIA", async ({ page }) => {
         // select the gslc reader, then pick frequency A, through the same endpoint the client uses
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
         await ensureQED(page)
         await page.evaluate(() => window.qed.selectReader("gslc"))
         await page.evaluate(() => window.qed.selectValue("frequency", "A"))
-        await page.goto("/", { waitUntil: "networkidle" })
+        await page.goto("/", { waitUntil: "load" })
 
         // exactly one radio in the frequency group is checked, and it is A -- state in ARIA, never
         // mirrored into a data attribute

--- a/tests/qed.ux.playwright/setup/render.setup.ts
+++ b/tests/qed.ux.playwright/setup/render.setup.ts
@@ -17,7 +17,7 @@ import { test, expect } from "@playwright/test"
 // persists for the {gate} pages.
 test("a viz view renders on load", async ({ page }) => {
     // load the app and wait for the facade to publish itself
-    await page.goto("/", { waitUntil: "networkidle" })
+    await page.goto("/", { waitUntil: "load" })
     await page.waitForFunction(() => Boolean((window as { qed?: unknown }).qed))
 
     // discover a channel the dataset offers, set it, and read back what the server confirms
@@ -34,7 +34,7 @@ test("a viz view renders on load", async ({ page }) => {
     expect(channel).toBeTruthy()
 
     // sanity: the viz widgets now render, so the gate inspects real controls, not an empty shell
-    await page.goto("/controls", { waitUntil: "networkidle" })
+    await page.goto("/controls", { waitUntil: "load" })
     await expect(page.locator('[data-pyre-widget="mosaic"]')).toHaveCount(1)
     await expect(
         page.locator('[data-pyre-widget="slider"][data-pyre-widget-part="thumb"]').first()

--- a/ux/client/automation/LiveSync.js
+++ b/ux/client/automation/LiveSync.js
@@ -1,0 +1,38 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// externals
+import { useEffect } from 'react'
+// relay
+import { fetchQuery } from 'react-relay'
+
+// local
+import { environment } from '../environment'
+import { query as stateQuery } from '../context/useFetchQED'
+import { subscribe } from './eventStream'
+
+
+// keep this client in step with the server: on every pushed event, refetch the application state so
+// a change made by any other client (or by automation) is reflected here without polling. it renders
+// nothing; mounting it ties the subscription to the app lifecycle
+export const LiveSync = () => {
+    // on mount
+    useEffect(() => {
+        // RELAY-SPECIFIC -- swap this body for the Houdini equivalent on migration; everything else
+        // in this feature is plain DOM. refetch the top-level state query straight from the network,
+        // which updates the relay store and re-renders every component reading from it
+        const refetch = () => fetchQuery(
+            environment, stateQuery, {}, { fetchPolicy: "network-only" },
+        ).toPromise()
+        // wire the portable event stream to the refetch and hand back its teardown
+        return subscribe(refetch)
+    }, [])
+    // render nothing
+    return null
+}
+
+
+// end of file

--- a/ux/client/automation/eventStream.js
+++ b/ux/client/automation/eventStream.js
@@ -1,0 +1,23 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// open the server's event stream and invoke {onChange} on every pushed event
+//
+// this is pure DOM: it knows nothing about the GraphQL client and survives the Relay -> Houdini
+// migration untouched. the one client-specific atom, "given an event, refetch the affected state",
+// is supplied by the caller as {onChange}
+export const subscribe = (onChange) => {
+    // subscribe to the server-sent event stream; the server holds this connection open and pushes
+    // a frame whenever its state changes. {EventSource} reconnects on its own if the link drops
+    const source = new EventSource("events")
+    // on each pushed event, let the caller react
+    source.onmessage = () => { onChange() }
+    // hand back a teardown that closes the stream
+    return () => source.close()
+}
+
+
+// end of file

--- a/ux/client/automation/index.js
+++ b/ux/client/automation/index.js
@@ -6,6 +6,8 @@
 
 // the mount component that publishes {window.qed}
 export { Automation } from './Automation'
+// the mount component that keeps this client in sync with the server over the event stream
+export { LiveSync } from './LiveSync'
 
 
 // end of file

--- a/ux/client/context/useFetchQED.js
+++ b/ux/client/context/useFetchQED.js
@@ -24,7 +24,8 @@ export const useFetchQED = () => {
 }
 
 
-const query = graphql`
+// the compiled operation is exported so the live-sync layer can refetch it imperatively
+export const query = graphql`
     query useFetchQEDQuery {
         qed {
             # the server side store id

--- a/ux/client/qed.js
+++ b/ux/client/qed.js
@@ -28,8 +28,8 @@ import 'lazysizes/plugins/native-loading/ls.native-loading'
 // context
 import { Provider, useQED } from './context'
 import { environment } from './environment'
-// the scriptable automation surface ({window.qed})
-import { Automation } from './automation'
+// the scriptable automation surface ({window.qed}) and the live server-sync mount
+import { Automation, LiveSync } from './automation'
 // components
 import { ErrorBoundary } from './boundary'
 // views
@@ -117,6 +117,8 @@ const Root = () => {
         <RelayEnvironmentProvider environment={environment}>
             {/* publish the scriptable automation surface */}
             <Automation />
+            {/* keep this client in sync with the server over the event stream */}
+            <LiveSync />
             <ErrorBoundary fallback={<Dead base={base} />}>
                 <Suspense fallback={< Loading />}>
                     <Router basename={base}>

--- a/ux/client/views/viz/controls/viz/range.js
+++ b/ux/client/views/viz/controls/viz/range.js
@@ -113,6 +113,9 @@ export const RangeController = ({ channel, configuration }) => {
     const opt = {
         value: [range.low, range.high],
         setValue: set,
+        // name the two thumbs after the server controller {slot}, so each is uniquely addressable
+        // by assistive tech and drivers alike
+        names: [`${slot} low`, `${slot} high`],
         min, max, major,
         direction: "row", labels: "bottom", arrows: "top", markers: true,
         height: 100, width: 250,
@@ -127,7 +130,7 @@ export const RangeController = ({ channel, configuration }) => {
                 <Save save={save} enabled={false} />
                 <Reset reset={reset} enabled={dirty} />
             </Header>
-            <Housing height={opt.height} width={opt.width}>
+            <Housing height={opt.height} width={opt.width} data-qed-control={slot}>
                 <Controller enabled={true} {...opt} />
             </Housing>
         </>

--- a/ux/client/views/viz/controls/viz/range.js
+++ b/ux/client/views/viz/controls/viz/range.js
@@ -33,10 +33,44 @@ export const RangeController = ({ channel, configuration }) => {
     } = useFragment(rangeVizGetControllerStateFragment, configuration)
     // get the active viewport
     const { activeViewport } = useViewports()
-    // initialize my range
+    // the slider is fully controlled, so local state drives the thumbs and lets them track the
+    // pointer smoothly during a drag; it is reconciled with the server below
     const [range, setRange] = React.useState({ low, high })
     // and my extent
     const [extent, setExtent] = React.useState({ min, max })
+    // true while the user is dragging THIS control; server updates are throttled, so the store
+    // trails the pointer and we must not let an in-flight echo of our own edit yank the thumb back
+    const interacting = React.useRef(false)
+
+    // adopt server-side values that arrive while we are not dragging: a reset, or -- the point of
+    // live sync -- a change another client made that the server pushed to us over the event stream
+    React.useEffect(() => {
+        // do not fight the pointer
+        if (interacting.current) {
+            return
+        }
+        // adopt the server range
+        setRange({ low, high })
+    }, [low, high])
+    React.useEffect(() => {
+        // do not fight the pointer
+        if (interacting.current) {
+            return
+        }
+        // adopt the server extent
+        setExtent({ min, max })
+    }, [min, max])
+    // a drag ends when the pointer is released anywhere; clear the flag so the next server value
+    // is reconciled. listen in the capture phase so a child that stops propagation cannot hide it
+    React.useEffect(() => {
+        const release = () => { interacting.current = false }
+        window.addEventListener("pointerup", release, true)
+        window.addEventListener("pointercancel", release, true)
+        return () => {
+            window.removeEventListener("pointerup", release, true)
+            window.removeEventListener("pointercancel", release, true)
+        }
+    }, [])
 
     // build the state reset handler
     const { reset: defaults } = useResetRangeController({ viewport: activeViewport, channel })
@@ -48,6 +82,8 @@ export const RangeController = ({ channel, configuration }) => {
     // and passes it as an argument a function that expects the current range and returns
     // the updated value
     const set = callback => {
+        // we are driving this control; suppress server reconciliation until the drag ends
+        interacting.current = true
         // get the updated values
         const [newLow, newHigh] = callback([range.low, range.high])
         // make a new range

--- a/ux/client/views/viz/controls/viz/useUpdateRangeController.js
+++ b/ux/client/views/viz/controls/viz/useUpdateRangeController.js
@@ -12,50 +12,43 @@ import { graphql, useMutation } from 'react-relay/hooks'
 // send the updated state of a range controller to the server side store
 export const useUpdateRangeController = ({ viewport, channel }) => {
     // updating the controller state mutates the server side store
-    const [commit, pending] = useMutation(useUpdateRangeControllerMutation)
+    const [commit] = useMutation(useUpdateRangeControllerMutation)
 
-    // leave this here, for now
-    // make some room for the performance stats
-    const [served, setServed] = React.useState(0)
-    const [dropped, setDropped] = React.useState(0)
-    // make a handler that updates the performance stats
-    const monitor = flag => {
-        // pick an updater
-        const update = flag ? setDropped : setServed
-        // and invoke it
-        update(old => old + 1)
-        // show me
-        // console.log(`viz.useUpdateRangeController: served: ${served}, dropped: ${dropped}`)
-        // all done
-        return
-    }
+    // a drag fires updates far faster than the server round trip, so we keep at most one mutation
+    // in flight and, while it is, remember only the LATEST update; when the in-flight one settles
+    // we send that latest value. this coalesces the storm yet guarantees the final resting value is
+    // never dropped (the bug fixed here), regardless of where in the round trip the drag ends
+    const inflight = React.useRef(false)
+    const queued = React.useRef(null)
 
-    // make the state update handler
-    const update = ({ controller, range, extent }) => {
-        // update the statistics
-        monitor(pending)
-        // if there is a pending operation
-        if (pending) {
-            // nothing to do
-            return
+    // send one update to the server
+    const send = args => {
+        // unpack
+        const { controller, range, extent } = args
+        // mark the channel busy
+        inflight.current = true
+        // flush whatever the in-flight commit left queued, once it settles either way
+        const settle = () => {
+            // the channel is free again
+            inflight.current = false
+            // if a later update arrived while we were busy, send the most recent one now
+            const next = queued.current
+            if (next) {
+                // consume it
+                queued.current = null
+                // and send it
+                send(next)
+            }
         }
-        // otherwise, send the mutation to the server
+        // commit the mutation
         commit({
-            // input
+            // the payload
             variables: {
-                // the payload
-                input: {
-                    // the viewport
-                    viewport,
-                    // the channel
-                    channel,
-                    // the controller
-                    controller,
-                    // the parameters
-                    ...range,
-                    ...extent,
-                }
+                input: { viewport, channel, controller, ...range, ...extent },
             },
+            // on success, flush the latest queued update
+            onCompleted: settle,
+            // on failure, report and still flush, so a transient error does not strand the value
             onError: errors => {
                 // show me
                 console.log(`viz.controls.viz.useUpdateRangeController:`)
@@ -65,12 +58,24 @@ export const useUpdateRangeController = ({ viewport, channel }) => {
                 console.log(`for channel ${channel}`)
                 console.log(errors)
                 console.groupEnd()
-                // all done
-                return
-            }
+                // still flush the latest
+                settle()
+            },
         })
-        // all done
-        return
+    }
+
+    // the public handler: send now if the channel is idle, otherwise hold only the latest update
+    // and let the in-flight commit's completion flush it
+    const update = args => {
+        // if a commit is in flight
+        if (inflight.current) {
+            // remember only the most recent request
+            queued.current = args
+            // and wait for the in-flight one to flush it
+            return
+        }
+        // otherwise, send it right away
+        send(args)
     }
 
     // all done

--- a/ux/client/views/viz/controls/viz/useUpdateValueController.js
+++ b/ux/client/views/viz/controls/viz/useUpdateValueController.js
@@ -9,53 +9,46 @@ import React from 'react'
 import { graphql, useMutation } from 'react-relay/hooks'
 
 
-// send the updated state of a vale controller to the server side store
+// send the updated state of a value controller to the server side store
 export const useUpdateValueController = ({ viewport, channel }) => {
     // updating the controller state mutates the server side store
-    const [commit, pending] = useMutation(useUpdateValueControllerMutation)
+    const [commit] = useMutation(useUpdateValueControllerMutation)
 
-    // leave this here, for now
-    // make some room for the performance stats
-    const [served, setServed] = React.useState(0)
-    const [dropped, setDropped] = React.useState(0)
-    // make a handler that updates the performance stats
-    const monitor = flag => {
-        // pick an updater
-        const update = flag ? setDropped : setServed
-        // and invoke it
-        update(old => old + 1)
-        // show me
-        // console.log(`viz.useUpdateValueController: served: ${served}, dropped: ${dropped}`)
-        // all done
-        return
-    }
+    // a drag fires updates far faster than the server round trip, so we keep at most one mutation
+    // in flight and, while it is, remember only the LATEST update; when the in-flight one settles
+    // we send that latest value. this coalesces the storm yet guarantees the final resting value is
+    // never dropped (the bug fixed here), regardless of where in the round trip the drag ends
+    const inflight = React.useRef(false)
+    const queued = React.useRef(null)
 
-    // make the state update handler
-    const update = ({ controller, value, extent }) => {
-        // update the statistics
-        monitor(pending)
-        // if there is a pending operation
-        if (pending) {
-            // nothing to do
-            return
+    // send one update to the server
+    const send = args => {
+        // unpack
+        const { controller, value, extent } = args
+        // mark the channel busy
+        inflight.current = true
+        // flush whatever the in-flight commit left queued, once it settles either way
+        const settle = () => {
+            // the channel is free again
+            inflight.current = false
+            // if a later update arrived while we were busy, send the most recent one now
+            const next = queued.current
+            if (next) {
+                // consume it
+                queued.current = null
+                // and send it
+                send(next)
+            }
         }
-        // otherwise, send the mutation to the server
+        // commit the mutation
         commit({
-            // input
+            // the payload
             variables: {
-                // the payload
-                input: {
-                    // the viewport
-                    viewport,
-                    // the channel
-                    channel,
-                    // the controller
-                    controller,
-                    // the parameters
-                    value,
-                    ...extent,
-                }
+                input: { viewport, channel, controller, value, ...extent },
             },
+            // on success, flush the latest queued update
+            onCompleted: settle,
+            // on failure, report and still flush, so a transient error does not strand the value
             onError: errors => {
                 // show me
                 console.log(`viz.controls.viz.useUpdateValueController:`)
@@ -65,12 +58,24 @@ export const useUpdateValueController = ({ viewport, channel }) => {
                 console.log(`for channel ${channel}`)
                 console.log(errors)
                 console.groupEnd()
-                // all done
-                return
-            }
+                // still flush the latest
+                settle()
+            },
         })
-        // all done
-        return
+    }
+
+    // the public handler: send now if the channel is idle, otherwise hold only the latest update
+    // and let the in-flight commit's completion flush it
+    const update = args => {
+        // if a commit is in flight
+        if (inflight.current) {
+            // remember only the most recent request
+            queued.current = args
+            // and wait for the in-flight one to flush it
+            return
+        }
+        // otherwise, send it right away
+        send(args)
     }
 
     // all done

--- a/ux/client/views/viz/controls/viz/value.js
+++ b/ux/client/views/viz/controls/viz/value.js
@@ -33,10 +33,44 @@ export const ValueController = ({ channel, configuration }) => {
     } = useFragment(valueVizGetControllerStateFragment, configuration)
     // get the active viewport
     const { activeViewport } = useViewports()
-    // initialize my local value
+    // the slider is fully controlled, so local state drives the marker and lets it track the
+    // pointer smoothly during a drag; it is reconciled with the server below
     const [marker, setMarker] = React.useState(value)
     // and my extent
     const [extent, setExtent] = React.useState({ min, max })
+    // true while the user is dragging THIS control; server updates are throttled, so the store
+    // trails the pointer and we must not let an in-flight echo of our own edit yank the marker back
+    const interacting = React.useRef(false)
+
+    // adopt server-side values that arrive while we are not dragging: a reset, or -- the point of
+    // live sync -- a change another client made that the server pushed to us over the event stream
+    React.useEffect(() => {
+        // do not fight the pointer
+        if (interacting.current) {
+            return
+        }
+        // adopt the server value
+        setMarker(value)
+    }, [value])
+    React.useEffect(() => {
+        // do not fight the pointer
+        if (interacting.current) {
+            return
+        }
+        // adopt the server extent
+        setExtent({ min, max })
+    }, [min, max])
+    // a drag ends when the pointer is released anywhere; clear the flag so the next server value
+    // is reconciled. listen in the capture phase so a child that stops propagation cannot hide it
+    React.useEffect(() => {
+        const release = () => { interacting.current = false }
+        window.addEventListener("pointerup", release, true)
+        window.addEventListener("pointercancel", release, true)
+        return () => {
+            window.removeEventListener("pointerup", release, true)
+            window.removeEventListener("pointercancel", release, true)
+        }
+    }, [])
 
     // build the state reset handler
     const { reset: defaults } = useResetValueController({ viewport: activeViewport, channel })
@@ -48,6 +82,8 @@ export const ValueController = ({ channel, configuration }) => {
     // and passes it as an argument a function that expects the current value and returns
     // the updated value
     const set = value => {
+        // we are driving this control; suppress server reconciliation until the drag ends
+        interacting.current = true
         // store it
         setMarker(value)
         // attempt to update the server side store

--- a/ux/client/views/viz/controls/viz/value.js
+++ b/ux/client/views/viz/controls/viz/value.js
@@ -109,6 +109,8 @@ export const ValueController = ({ channel, configuration }) => {
     const opt = {
         value: marker,
         setValue: set,
+        // name the single thumb after the server controller {slot}, so it is uniquely addressable
+        label: slot,
         min, max, major,
         direction: "row", labels: "bottom", arrows: "top", markers: true,
         height: 100, width: 250,
@@ -123,7 +125,7 @@ export const ValueController = ({ channel, configuration }) => {
                 <Save save={save} enabled={false} />
                 <Reset reset={reset} enabled={dirty} />
             </Header>
-            <Housing height={opt.height} width={opt.width}>
+            <Housing height={opt.height} width={opt.width} data-qed-control={slot}>
                 <Controller enabled={true} {...opt} />
             </Housing>
         </>

--- a/ux/client/views/viz/controls/zoom/useSetLevel.js
+++ b/ux/client/views/viz/controls/zoom/useSetLevel.js
@@ -5,33 +5,44 @@
 
 
 // externals
+import React from 'react'
 import { graphql, useMutation } from 'react-relay/hooks'
 
 // adjust the zoom levels
 export const useSetLevel = viewport => {
     // adjusting the zoom levels mutates the server side store
-    const [commit, pending] = useMutation(useSetLevelZoomMutation)
+    const [commit] = useMutation(useSetLevelZoomMutation)
 
-    // make the handler
-    const set = ({ horizontal, vertical }) => {
-        // if there is already a pending operation
-        if (pending) {
-            // nothing to do
-            return
+    // a drag fires far faster than the server round trip, so we keep at most one mutation in flight
+    // and, while one is, remember only the LATEST level; when the in-flight one settles we send that
+    // latest value. this coalesces the storm yet guarantees the final resting level is never dropped
+    const inflight = React.useRef(false)
+    const queued = React.useRef(null)
+
+    // send one level to the server
+    const send = ({ horizontal, vertical }) => {
+        // mark the channel busy
+        inflight.current = true
+        // flush whatever was queued once this commit settles either way
+        const settle = () => {
+            // free again
+            inflight.current = false
+            // send the most recent level that arrived while we were busy
+            const next = queued.current
+            if (next) {
+                queued.current = null
+                send(next)
+            }
         }
-        // otherwise, send the request to the server
+        // send the request to the server
         commit({
             // input
             variables: {
-                input: {
-                    // the payload
-                    // the viewport
-                    viewport,
-                    // the zoom levels
-                    horizontal,
-                    vertical,
-                }
+                input: { viewport, horizontal, vertical },
             },
+            // on success, flush the latest queued level
+            onCompleted: settle,
+            // on failure, report and still flush, so a transient error does not strand the level
             onError: errors => {
                 // show me
                 console.log(`viz.zoom.useLevel:`)
@@ -39,12 +50,23 @@ export const useSetLevel = viewport => {
                 console.log(`ERROR while setting the zoom level for viewport ${viewport}`)
                 console.log(errors)
                 console.groupEnd()
-                // all done
-                return
-            }
+                // still flush the latest
+                settle()
+            },
         })
-        // all done
-        return
+    }
+
+    // the public handler: send now if idle, otherwise hold only the latest level
+    const set = level => {
+        // if a commit is in flight
+        if (inflight.current) {
+            // remember only the most recent level
+            queued.current = level
+            // and let the in-flight commit flush it
+            return
+        }
+        // otherwise, send it right away
+        send(level)
     }
 
     // return the handler

--- a/ux/client/views/viz/controls/zoom/zoom.js
+++ b/ux/client/views/viz/controls/zoom/zoom.js
@@ -80,12 +80,16 @@ export const Zoom = ({ viewport, view, min = -6, max = 4, ils = 200 }) => {
     // slider configuration
     const xSlider = {
         value: zoom.horizontal, setValue: setHorizontalZoom,
+        // name the thumb after the axis it controls, so it is uniquely addressable
+        label: "zoom horizontal",
         min, max, major, minor, tickPrecision: 0, markerPrecision: 1,
         direction: "row", labels: "top", arrows: "bottom", markers: true,
         height: ils / 2, width: ils,
     }
     const ySlider = {
         value: zoom.vertical, setValue: setVerticalZoom,
+        // name the thumb after the axis it controls, so it is uniquely addressable
+        label: "zoom vertical",
         min, max, major, minor, tickPrecision: 0, markerPrecision: 1,
         direction: "column", flipped: true, labels: "right", arrows: "left", markers: true,
         height: ils, width: ils / 2,
@@ -105,7 +109,7 @@ export const Zoom = ({ viewport, view, min = -6, max = 4, ils = 200 }) => {
                 <Reset reset={reset} enabled={zoom.dirty} />
             </Header>
             {/* the control housing */}
-            <Housing height={height} width={width}>
+            <Housing height={height} width={width} data-qed-control="zoom">
                 {/* the vertical slider */}
                 <g transform="translate(10 0)">
                     <Controller enabled={enabled} {...ySlider} />

--- a/ux/client/widgets/slider/context.js
+++ b/ux/client/widgets/slider/context.js
@@ -18,8 +18,9 @@ export const Provider = ({ config, children }) => {
 
     // state
     const { enabled } = config
-    // the accessible name the client gives this control
-    const { label } = config
+    // the accessible name the client gives this control: {label} names a single-thumb control,
+    // {names} carries one accessible name per thumb for a multi-thumb control (a range's low/high)
+    const { label, names } = config
     // directional configuration
     const { direction, flipped = false, arrows, labels, markers } = config
     // the layout of the controller in client coordinates
@@ -196,8 +197,8 @@ export const Provider = ({ config, children }) => {
 
         // state
         enabled,
-        // the accessible name
-        label,
+        // the accessible name(s)
+        label, names,
         // directional configuration
         direction, arrows, labels, markers,
         // the layout of the controller in client coordinates
@@ -257,8 +258,8 @@ export const Context = React.createContext(
 
         // state
         enabled: null,
-        // the accessible name
-        label: null,
+        // the accessible name(s)
+        label: null, names: null,
         // directional configuration
         direction: null, arrows: null, labels: null, markers: null,
         // the layout of the controller in client coordinates

--- a/ux/client/widgets/slider/marker.js
+++ b/ux/client/widgets/slider/marker.js
@@ -19,7 +19,7 @@ import { useStartSliding } from './useStartSliding'
 
 
 // render the value indicator
-export const Marker = ({ value, id = 0, ...rest }) => {
+export const Marker = ({ value, id = 0, name, ...rest }) => {
     // make a handler that indicates the user is dragging the marker to pick a new value
     const startSliding = useStartSliding()
 
@@ -55,7 +55,8 @@ export const Marker = ({ value, id = 0, ...rest }) => {
         "aria-valuenow": value,
         "aria-valuemin": min,
         "aria-valuemax": max,
-        "aria-label": label,
+        // a per-thumb {name} (a range's low/high) wins over the control-wide {label} (one thumb)
+        "aria-label": name ?? label,
         "aria-disabled": enabled ? undefined : true,
         "data-pyre-widget": "slider",
         "data-pyre-widget-part": "thumb",

--- a/ux/client/widgets/slider/range.js
+++ b/ux/client/widgets/slider/range.js
@@ -10,6 +10,8 @@ import React from 'react'
 // locals
 // context
 import { Provider } from './context'
+// hooks
+import { useConfig } from './useConfig'
 // components
 import { Axis } from './axis'
 import { Interval } from './interval'
@@ -34,6 +36,8 @@ export const Range = ({ value, setValue, ...config }) => {
 
 // render the controller
 const Controller = ({ value, setValue }) => {
+    // the client names the two thumbs (e.g. "linear low" / "linear high"); fall back to nothing
+    const { names = [] } = useConfig()
     // render; the axis, ticks, and tick labels are a decorative scale that duplicates the
     // accessible thumbs (role=slider, aria-valuenow), so they are hidden from assistive tech
     return (
@@ -45,9 +49,9 @@ const Controller = ({ value, setValue }) => {
                 <Labels />
             </g>
             <Interval value={value} />
-            <Marker id={0} value={value[0]} />
+            <Marker id={0} value={value[0]} name={names[0]} />
             <MarkerLabel value={value[0]} />
-            <Marker id={1} value={value[1]} />
+            <Marker id={1} value={value[1]} name={names[1]} />
             <MarkerLabel value={value[1]} />
         </Rangemat>
     )

--- a/ux/client/widgets/slider/useConfig.js
+++ b/ux/client/widgets/slider/useConfig.js
@@ -17,7 +17,7 @@ import { Context } from "./context"
 export const useConfig = () => {
     // pull what i need from {context}
     const {
-        enabled, label, direction,
+        enabled, label, names, direction,
         arrows, labels, markers,
         min, max, major, minor, tickPrecision, markerPrecision,
         intervalPosition,
@@ -26,7 +26,7 @@ export const useConfig = () => {
 
     // and publish
     return {
-        enabled, label, direction,
+        enabled, label, names, direction,
         arrows, labels, markers,
         min, max, major, minor, tickPrecision, markerPrecision,
         intervalPosition, labelPosition, majorPosition, minorPosition,


### PR DESCRIPTION
Wires qed onto the new `pyre.http` SSE capability (pyre PR #177) so a change made by one client — through the UI or `window.qed` automation — is reflected in every other connected client without polling.

**Depends on pyre#177.** Build with `mm` from the qed scope against the pyre `sse` branch.

## Server

- **`pkg/ux/Dispatcher.py`** — a `/events` route whose handler returns an `EventStream`, subscribing that browser to the hub.
- **`pkg/ux/GraphQL.py`** — the single broadcast choke point. Every state change arrives as a GraphQL mutation POST, and they all funnel through `GraphQL.respond`, which already holds `server.hub`. After `schema.execute`, when the operation is a mutation (`graphql.parse` + `OperationType.MUTATION`) and there are no errors, it publishes one minimal `{"type": "change"}` frame on the global topic. (The original plan put this at the `Store` mutators, but those have ~30 methods with no shared funnel — that was the *scattered* option.)

## Client

- **`automation/eventStream.js`** — portable DOM half: `subscribe(onChange)` opens `EventSource('events')` and returns a teardown. Survives the planned Relay→Houdini migration untouched.
- **`automation/LiveSync.js`** — the React + Relay glue, holding the one `// RELAY-SPECIFIC` atom: a `network-only` `fetchQuery` of the top-level state query, which updates the store and re-renders every component reading it. Mounted next to `<Automation/>`.
- **`context/useFetchQED.js`** — exports the `useFetchQEDQuery` taggedNode for that refetch.

## Tests

- The always-open `EventSource` means `waitUntil: "networkidle"` can never fire, so the Playwright suite's 47 such waits (24 files) are switched to `"load"` (not blocked by a JS-opened `EventSource`; specs already follow up with explicit widget waits). One follow-on: `facade.spec.ts`'s `centerOn` test gains an explicit "region scrollable" wait it had been getting implicitly from `networkidle`.
- New `behavior/live-sync.spec.ts`: two clients on one server; the driver mutates zoom via `window.qed`; the observer's **DOM** updates with a no-reload probe. It asserts the DOM, not `window.qed.state()` (which re-fetches and would pass even without the push).
- Full suite green: **49 passed**.

## Follow-ups (not in this PR)

- Migrate client-only interactions (scroll/center position, panel nav) to server state so they sync too.
- The generator-returning `Store` mutators apply their effects only when the GraphQL payload field is selected; harden against an unconsumed-generator no-op.

---
Also fixes #78 — controller drags now send their final value via a trailing-edge throttle.