### PR TITLE
Sync the viewport scroll position across clients

### DIFF
--- a/pkg/gql/Mutation.py
+++ b/pkg/gql/Mutation.py
@@ -61,6 +61,9 @@ class Mutation(graphene.ObjectType):
     viewSyncToggleAll = views.viewSyncToggleAll.Field()
     viewSyncReset = views.viewSyncReset.Field()
 
+    # look-at center
+    viewLookAt = views.viewLookAt.Field()
+
     # zoom
     viewZoomSetLevel = views.viewZoomSetLevel.Field()
     viewZoomToggleCoupled = views.viewZoomToggleCoupled.Field()

--- a/pkg/gql/views/View.py
+++ b/pkg/gql/views/View.py
@@ -16,6 +16,7 @@ from ..datasets.Dataset import Dataset
 from ..readers.Reader import Reader
 from ..readers.Selector import Selector
 from ..readers.SelectorAxis import SelectorAxis
+from .ViewCenter import ViewCenter
 from .ViewMeasure import ViewMeasure
 from .ViewSync import ViewSync
 from .ViewZoom import ViewZoom
@@ -43,6 +44,7 @@ class View(graphene.ObjectType):
     dataset = graphene.Field(Dataset)
     channel = graphene.Field(Channel)
     # dataset specific configuration
+    center = graphene.Field(ViewCenter)
     measure = graphene.Field(ViewMeasure)
     sync = graphene.Field(ViewSync)
     zoom = graphene.Field(ViewZoom)

--- a/pkg/gql/views/ViewCenter.py
+++ b/pkg/gql/views/ViewCenter.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import graphene
+
+# my interface
+from ..Node import Node
+
+
+# my node type
+class ViewCenter(graphene.ObjectType):
+    """
+    A view's look-at center
+    """
+
+    # {graphene} metadata
+    class Meta:
+        # register my interface
+        interfaces = (Node,)
+
+    # my fields
+    id = graphene.ID()
+    name = graphene.String()
+
+    dirty = graphene.Boolean()
+    row = graphene.Float()
+    col = graphene.Float()
+
+    # resolvers
+    @staticmethod
+    def resolve_id(center, *_):
+        """
+        Get the {center} id
+        """
+        # splice together the {family} and {name} of the {center}
+        return f"{center.pyre_family()}:{center.pyre_name}"
+
+    @staticmethod
+    def resolve_name(center, *_):
+        """
+        Get the name of the {center}
+        """
+        # easy enough
+        return center.pyre_name
+
+
+# end of file

--- a/pkg/gql/views/ViewLookAt.py
+++ b/pkg/gql/views/ViewLookAt.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import graphene
+
+# the request payload
+from .ViewLookAtInput import ViewLookAtInput
+
+# the result types
+from .ViewCenter import ViewCenter
+
+
+# set the look-at center
+class ViewLookAt(graphene.Mutation):
+    """
+    Set the source pixel that sits at the center of the viewport
+    """
+
+    # inputs
+    class Arguments:
+        # the request payload
+        input = ViewLookAtInput(required=True)
+
+    # the result is the affected center state
+    center = graphene.Field(ViewCenter)
+
+    # the mutator
+    @staticmethod
+    def mutate(root, info, input):
+        """
+        Set the look-at center for {input.viewport}
+        """
+        # get the store
+        store = info.context["store"]
+        # set the center
+        center = store.lookAt(
+            viewport=input.viewport,
+            row=input.row,
+            col=input.col,
+        )
+        # form the mutation resolution context
+        context = {"center": center}
+        # and resolve the mutation
+        return context
+
+
+# end of file

--- a/pkg/gql/views/ViewLookAtInput.py
+++ b/pkg/gql/views/ViewLookAtInput.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import graphene
+
+
+# the request payload for setting the look-at center
+class ViewLookAtInput(graphene.InputObjectType):
+    """
+    The payload to set the look-at center
+    """
+
+    # the viewport
+    viewport = graphene.Int(required=True)
+    # the source row under the viewport center
+    row = graphene.Float(required=True)
+    # the source column under the viewport center
+    col = graphene.Float(required=True)
+
+
+# end of file

--- a/pkg/gql/views/__init__.py
+++ b/pkg/gql/views/__init__.py
@@ -41,6 +41,9 @@ from .ViewSyncToggleViewport import ViewSyncToggleViewport as viewSyncToggleView
 from .ViewSyncToggleAll import ViewSyncToggleAll as viewSyncToggleAll
 from .ViewSyncReset import ViewSyncReset as viewSyncReset
 
+# look-at center
+from .ViewLookAt import ViewLookAt as viewLookAt
+
 # zoom
 from .ViewZoomSetLevel import ViewZoomSetLevel as viewZoomSetLevel
 from .ViewZoomToggleCoupled import ViewZoomToggleCoupled as viewZoomToggleCoupled

--- a/pkg/protocols/ux/Center.py
+++ b/pkg/protocols/ux/Center.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# support
+import qed
+
+
+# the look-at control
+class Center(qed.protocol, family="qed.ux.center"):
+    """
+    The source pixel that sits at the center of the viewport
+    """
+
+    # user configurable state
+    row = qed.properties.float()
+    row.doc = "the source row under the viewport center"
+
+    col = qed.properties.float()
+    col.doc = "the source column under the viewport center"
+
+    # framework hooks
+    @classmethod
+    def pyre_default(cls, **kwds):
+        """
+        Pick a default implementation
+        """
+        # use the center base
+        return qed.ux.center
+
+
+# end of file

--- a/pkg/protocols/ux/__init__.py
+++ b/pkg/protocols/ux/__init__.py
@@ -16,6 +16,7 @@ from .Source import Source as source
 from .Channel import Channel as channel
 
 # controls
+from .Center import Center as center
 from .Measure import Measure as measure
 from .Sync import Sync as sync
 from .Zoom import Zoom as zoom

--- a/pkg/ux/Center.py
+++ b/pkg/ux/Center.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# support
+import qed
+import journal
+import uuid
+
+
+# the look-at control
+class Center(
+    qed.component, family="qed.ux.center.center", implements=qed.protocols.ux.center
+):
+    """
+    The source pixel that sits at the center of the viewport
+    """
+
+    # user configurable state
+    row = qed.properties.float()
+    row.default = 0
+    row.doc = "the source row under the viewport center"
+
+    col = qed.properties.float()
+    col.default = 0
+    col.doc = "the source column under the viewport center"
+
+    # support
+    def clone(self, name=None):
+        """
+        Make a copy
+        """
+        # make a name, if necessary
+        name = str(uuid.uuid1()) if name is None else name
+        # build a new instance and return it
+        return type(self)(
+            name=name,
+            row=self.row,
+            col=self.col,
+        )
+
+    def reset(self, defaults):
+        """
+        Reset my state
+        """
+        # reset my state
+        self.row = defaults.row
+        self.col = defaults.col
+        # mark me as clean
+        self.dirty = False
+        # all done
+        return self
+
+    # metamethods
+    def __init__(self, **kwds):
+        # chain up
+        super().__init__(**kwds)
+        # initially, i'm clean
+        self.dirty = False
+        # all done
+        return
+
+    # framework hooks
+    def pyre_traitModified(self, **kwds):
+        """
+        Hook that gets invoked by the framework right after a trait value has been modified.
+        """
+        # chain up
+        super().pyre_traitModified(**kwds)
+        # mark me as dirty
+        self.dirty = True
+        # all done
+        return self
+
+    # debugging support
+    def pyre_dump(self):
+        """
+        Render my state
+        """
+        # make a channel
+        channel = journal.info("qed.ux.measure")
+        # sign in
+        channel.line(f"center: {self}")
+        # my contents
+        channel.indent()
+        channel.line(f"row: {self.row}")
+        channel.line(f"col: {self.col}")
+        channel.outdent()
+        # flush
+        channel.log()
+        # all done
+        return
+
+
+# end of file

--- a/pkg/ux/Source.py
+++ b/pkg/ux/Source.py
@@ -15,6 +15,9 @@ class Source(qed.component, family="qed.ux.sources.source"):
     """
 
     # configurable state
+    center = qed.protocols.ux.center()
+    center.doc = "the look-at center"
+
     measure = qed.protocols.ux.measure()
     measure.doc = "the measure layer indicator"
 

--- a/pkg/ux/Store.py
+++ b/pkg/ux/Store.py
@@ -558,6 +558,18 @@ class Store(qed.shells.command, family="qed.cli.ux"):
         # and delegate
         return port.vizUpdateController(**kwds)
 
+    def lookAt(self, viewport, row, col):
+        """
+        Set the source pixel at the center of {viewport}
+        """
+        # get the viewport configuration; the look-at is per-viewport, so unlike scroll-sync
+        # across a user's own viewports (handled client side) nothing else is touched here
+        port = self._viewports[viewport]
+        # set the center
+        view = port.lookAt(row=row, col=col)
+        # hand off the center
+        return view.center
+
     def zoomSetLevel(self, viewport, horizontal, vertical):
         """
         Set the zoom levels

--- a/pkg/ux/View.py
+++ b/pkg/ux/View.py
@@ -40,6 +40,9 @@ class View(qed.component, family="qed.ux.views.view", implements=qed.protocols.u
     selections.default = {}
     selections.doc = "a key/value store of the user choices towards a dataset selection"
 
+    center = qed.protocols.ux.center()
+    center.doc = "the look-at center"
+
     measure = qed.protocols.ux.measure()
     measure.doc = "the measure layer indicator"
 
@@ -475,6 +478,37 @@ class View(qed.component, family="qed.ux.views.view", implements=qed.protocols.u
         # all done
         return self
 
+    def lookAt(self, row, col):
+        """
+        Set the source pixel that sits at the center of the viewport
+        """
+        # get the center
+        center = self.center
+        # set
+        center.row = row
+        center.col = col
+        # all done
+        return self
+
+    def lookAtReset(self):
+        """
+        Reset the state of the look-at configuration
+        """
+        # get my reader
+        reader = self.reader
+        # if i don't have on
+        if not reader:
+            # nothing more to do
+            return
+        # get the reader name
+        sourceName = reader.pyre_name
+        # pull its configuration
+        config = Source(name=f"{sourceName}.view")
+        # use it to adjust mine
+        self.center.reset(defaults=config.center)
+        # all done
+        return self
+
     def setMembers(self, members):
         """
         Set my per-member participation mask; at least one member must stay active
@@ -628,6 +662,7 @@ class View(qed.component, family="qed.ux.views.view", implements=qed.protocols.u
             dataset=self.dataset,
             channel=self.channel.pyre_family() if self.channel else None,
             selections=dict(self.selections),
+            center=self.center.clone(),
             measure=self.measure.clone(),
             sync=self.sync.clone(),
             zoom=self.zoom.clone(),
@@ -817,6 +852,7 @@ class View(qed.component, family="qed.ux.views.view", implements=qed.protocols.u
         # pull its configuration
         config = Source(name=f"{sourceName}.view")
         # clone the persistent state
+        self.center = config.center.clone(name=f"{name}.center")
         self.measure = config.measure.clone(name=f"{name}.measure")
         self.sync = config.sync.clone(name=f"{name}.sync")
         self.zoom = config.zoom.clone(name=f"{name}.zoom")

--- a/pkg/ux/Viewport.py
+++ b/pkg/ux/Viewport.py
@@ -248,6 +248,15 @@ class Viewport(
         # and hand off the pair
         return view, controller
 
+    def lookAt(self, row, col):
+        """
+        Set the source pixel that sits at the center of the viewport
+        """
+        # get the view
+        view = self._view
+        # and delegate
+        return view.lookAt(row=row, col=col)
+
     def zoomSetLevel(self, horizontal, vertical):
         """
         Set the zoom levels

--- a/pkg/ux/__init__.py
+++ b/pkg/ux/__init__.py
@@ -16,6 +16,7 @@ from .View import View as view
 from .Source import Source as source
 
 # controls
+from .Center import Center as center
 from .Measure import Measure as measure
 from .Sync import Sync as sync
 from .Zoom import Zoom as zoom

--- a/tests/qed.pkg/lookat.py
+++ b/tests/qed.pkg/lookat.py
@@ -1,0 +1,144 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Exercise the look-at center that a view carries and that the store mutates per viewport
+"""
+
+# externals
+import types
+
+# support
+import qed
+
+
+# check the {Center} component's state, dirty tracking, clone, and reset
+def center():
+    """
+    Exercise {Center}: defaults, dirty on modification, a faithful clone, and a reset to defaults
+    """
+    # a fresh center sits at the origin and is clean
+    point = qed.ux.center(name="lookat.center")
+    assert point.row == 0
+    assert point.col == 0
+    assert point.dirty is False
+
+    # moving it marks it dirty
+    point.row = 12.5
+    point.col = 34.0
+    assert point.dirty is True
+
+    # a clone carries the same place
+    twin = point.clone()
+    assert twin.row == 12.5
+    assert twin.col == 34.0
+
+    # a reset to a set of defaults restores the place and marks it clean
+    defaults = types.SimpleNamespace(row=0, col=0)
+    point.reset(defaults=defaults)
+    assert point.row == 0
+    assert point.col == 0
+    assert point.dirty is False
+
+    # all done
+    return
+
+
+# check that a view records the look-at center it is told to
+def lookAt():
+    """
+    Exercise {View.lookAt}: the (row, col) are written through to the view's center
+    """
+    # the mutator, borrowed from the view class
+    setter = qed.ux.view.lookAt
+    # a stand-in view with just a center
+    standin = types.SimpleNamespace(center=types.SimpleNamespace(row=0, col=0))
+    # aim it
+    result = setter(standin, row=42.0, col=7.0)
+    # the center moved
+    assert standin.center.row == 42.0
+    assert standin.center.col == 7.0
+    # and the mutator returns the view, for chaining
+    assert result is standin
+    # all done
+    return
+
+
+# check that the store aims only the addressed viewport and hands back its center
+def storeLookAt():
+    """
+    Exercise {Store.lookAt}: only the addressed viewport is moved; its center is returned
+    """
+    # the mutator, borrowed from the store class
+    setter = qed.ux.store.lookAt
+
+    # a record of which viewport was aimed
+    calls = []
+
+    # a stand-in viewport that delegates to a view carrying a center
+    def makePort(tag):
+        # the view this port wraps
+        view = types.SimpleNamespace(
+            center=types.SimpleNamespace(row=0, col=0, tag=tag)
+        )
+
+        # its look-at delegate records the call and moves the center
+        def portLookAt(row, col):
+            calls.append(tag)
+            view.center.row = row
+            view.center.col = col
+            return view
+
+        # hand back the port
+        return types.SimpleNamespace(lookAt=portLookAt, _view=view)
+
+    # a store stand-in with two viewports
+    ports = [makePort(0), makePort(1)]
+    standin = types.SimpleNamespace(_viewports=ports)
+
+    # aim the second viewport
+    result = setter(standin, viewport=1, row=100.0, col=200.0)
+
+    # only the second viewport was touched
+    assert calls == [1]
+    # the first viewport stayed at the origin
+    assert ports[0]._view.center.row == 0
+    assert ports[0]._view.center.col == 0
+    # the second viewport moved
+    assert ports[1]._view.center.row == 100.0
+    assert ports[1]._view.center.col == 200.0
+    # and the returned center is the second viewport's
+    assert result is ports[1]._view.center
+
+    # all done
+    return
+
+
+# the driver
+def test():
+    """
+    Check the look-at center component and its view/store mutators in isolation
+    """
+    # the component
+    center()
+    # the view mutator
+    lookAt()
+    # the store mutator
+    storeLookAt()
+    # all done
+    return 0
+
+
+# bootstrap
+if __name__ == "__main__":
+    # invoke the driver
+    status = test()
+    # and share the status with the shell
+    raise SystemExit(status)
+
+
+# end of file

--- a/tests/qed.ux.playwright/behavior/scroll-sync.spec.ts
+++ b/tests/qed.ux.playwright/behavior/scroll-sync.spec.ts
@@ -1,0 +1,136 @@
+// -*- web -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// support
+import { test, expect } from "@playwright/test"
+import type { Page, Locator } from "@playwright/test"
+
+
+// the viewport scroll position is now server state: a viewport carries a look-at center -- the source
+// pixel under the middle of its window, row-major -- and any move pushes it through the {viewLookAt}
+// mutation, so it reflects on every connected client over the SSE event stream (like zoom, channel,
+// or the controllers). each client converts that resolution-independent center to its own scroll via
+// its own geometry, so two clients of the same size land on the same source pixel. we drive two
+// independent pages on the one shared server: the {driver} moves viewport 0, the {observer} only
+// watches its own DOM scroll -- never {window.qed.state()}, which would re-fetch and pass even if the
+// push never arrived. one test exercises the deterministic facade path ({window.qed.lookAt}); the
+// other exercises the real path -- a raw DOM scroll the viewport handler turns into the mutation.
+
+
+// drive the client's automation surface from inside the page
+const ensureQED = (page: Page) => page.waitForFunction(() => Boolean(window.qed))
+
+// the source pixel under the center of {region}, from its live scroll, size, and published zoom;
+// the same mapping the viewport handler and {window.qed.centerOn} use
+const sourceCenter = async (region: Locator) => {
+    const { left, top, w, h } = await region.evaluate(el => ({
+        left: el.scrollLeft, top: el.scrollTop, w: el.clientWidth, h: el.clientHeight,
+    }))
+    const [zv, zh] = (await region.getAttribute("data-qed-zoom"))!.split(",").map(Number)
+    return { col: (left + w / 2) * 2 ** -zh, row: (top + h / 2) * 2 ** -zv }
+}
+
+// bring a client up on the viz page and wait for its rendered viewport region
+const open = async (client: Page) => {
+    await client.goto("/controls", { waitUntil: "load" })
+    await ensureQED(client)
+    await client.locator('[data-qed-region="viewport"]').first().waitFor()
+}
+
+
+test.describe.serial("viewport scroll syncs across clients", () => {
+    test.afterAll(async ({ browser }) => {
+        // leave viewport 0 looking at the origin, as the rest of the suite expects
+        const page = await browser.newPage()
+        await page.goto("/controls", { waitUntil: "load" })
+        await ensureQED(page)
+        await page.evaluate(() => window.qed.lookAt(0, 0, 0))
+        await page.close()
+    })
+
+    test("a look-at set on one client recenters another", async ({ page, context }) => {
+        // the client that makes the change
+        const driver = page
+        // a second, independent client on the same server
+        const observer = await context.newPage()
+        // bring both up
+        await open(driver)
+        await open(observer)
+
+        // the observer's region; its scroll mirrors the store's look-at and moves when it updates
+        const region = observer.locator('[data-qed-region="viewport"]').first()
+        // the raster center is always a reachable look-at, and (for a zoomable raster) well away from
+        // the initial top-left view, so the move is real rather than a no-op against a clamped edge
+        const [rows, cols] = (await region.getAttribute("data-qed-shape"))!.split(",").map(Number)
+        const target = { row: Math.round(rows / 2), col: Math.round(cols / 2) }
+
+        // mark the observer so we can later prove it never reloaded
+        await observer.evaluate(() => {
+            ;(window as typeof window & { synced?: boolean }).synced = true
+        })
+
+        // the driver aims viewport 0 through the server; nothing happens on the observer's side
+        await driver.evaluate(t => window.qed.lookAt(t.row, t.col, 0), target)
+
+        // the observer's own scroll converges on that source pixel, pushed over the stream
+        await expect.poll(async () => {
+            const { row, col } = await sourceCenter(region)
+            return Math.max(Math.abs(row - target.row), Math.abs(col - target.col))
+        }, { timeout: 10_000 }).toBeLessThan(2)
+        // and it got there in place -- it never navigated or reloaded
+        expect(
+            await observer.evaluate(() => (window as typeof window & { synced?: boolean }).synced),
+        ).toBe(true)
+
+        // tidy up the extra client
+        await observer.close()
+    })
+
+    test("a raw scroll on one client recenters another", async ({ page, context }) => {
+        // the client that makes the change
+        const driver = page
+        // a second, independent client on the same server
+        const observer = await context.newPage()
+        // bring both up
+        await open(driver)
+        await open(observer)
+
+        // both regions; the driver scrolls its own, the observer must follow
+        const driverRegion = driver.locator('[data-qed-region="viewport"]').first()
+        const observerRegion = observer.locator('[data-qed-region="viewport"]').first()
+
+        // where the observer is looking before anything moves
+        const before = await sourceCenter(observerRegion)
+
+        // a plain user-style scroll on the driver: the viewport handler converts it to a look-at and
+        // pushes it. kept modest so neither client clamps at an edge
+        await driverRegion.evaluate(el => { el.scrollLeft = 500; el.scrollTop = 400 })
+        // the source pixel the driver now looks at, after its own scroll
+        let aim = { row: 0, col: 0 }
+        await expect.poll(async () => {
+            aim = await sourceCenter(driverRegion)
+            return Math.max(Math.abs(aim.row - before.row), Math.abs(aim.col - before.col))
+        }).toBeGreaterThan(2)
+
+        // two clients of the same size resolve the same look-at center to the same scroll, so the
+        // observer must converge on exactly the source pixel the driver scrolled to
+        await expect.poll(async () => {
+            const here = await sourceCenter(observerRegion)
+            return Math.max(Math.abs(here.row - aim.row), Math.abs(here.col - aim.col))
+        }, { timeout: 10_000 }).toBeLessThan(2)
+        // and the observer genuinely moved from where it started
+        const after = await sourceCenter(observerRegion)
+        expect(Math.max(Math.abs(after.row - before.row), Math.abs(after.col - before.col)))
+            .toBeGreaterThan(2)
+
+        // tidy up the extra client
+        await observer.close()
+    })
+})
+
+
+/* end of file */

--- a/ux/client/automation/qed.js
+++ b/ux/client/automation/qed.js
@@ -16,6 +16,7 @@ import { resetMeasureMutation } from '~/views/viz/controls/measure/useReset'
 import { useSetLevelZoomMutation as setLevelZoomMutation } from '~/views/viz/controls/zoom/useSetLevel'
 import { useToggleCoupledZoomMutation as toggleCoupledZoomMutation } from '~/views/viz/controls/zoom/useToggleCoupled'
 import { useResetZoomMutation as resetZoomMutation } from '~/views/viz/controls/zoom/useReset'
+import { useLookAtMutation as lookAtMutation } from '~/views/viz/viewer/useLookAt'
 import { useSyncToggleAllMutation as syncToggleAllMutation } from '~/views/viz/controls/sync/useSyncToggleAll'
 import { useUpdateRangeControllerMutation as updateRangeControllerMutation } from '~/views/viz/controls/viz/useUpdateRangeController'
 import { useResetRangeControllerMutation as resetRangeControllerMutation } from '~/views/viz/controls/viz/useResetRangeController'
@@ -213,8 +214,9 @@ export const makeQED = () => ({
     setActive: viewport => activate(viewport),
 
     // scroll {viewport} so the source pixel {row,col} sits at the center of the visible window. this
-    // is a pure client-side scroll -- like a user dragging -- not a server mutation, so it reads the
-    // rendered zoom off the region markup and converts source pixels to rendered ones
+    // moves the local DOM scroll directly -- like a user dragging -- reading the rendered zoom off the
+    // region markup and converting source pixels to rendered ones. the viewport's scroll handler turns
+    // that into a {viewLookAt} mutation, so the move now also syncs to every other client
     centerOn: (row, col, viewport = getActiveViewport()) => new Promise(resolve => {
         const region = document.querySelectorAll('[data-qed-region="viewport"]')[viewport]
         if (region == null) {
@@ -227,6 +229,12 @@ export const makeQED = () => ({
         // resolve once the scroll has had a frame to apply and notify the pan dispatcher
         requestAnimationFrame(() => resolve())
     }),
+
+    // set the look-at center of {viewport} to the source pixel {row,col} directly through the server,
+    // bypassing the local scroll; every client (this one included, over live sync) recenters there.
+    // this is the deterministic path for automation -- no scroll throttle to wait on
+    lookAt: (row, col, viewport = getActiveViewport()) =>
+        command(lookAtMutation, { viewport, row, col }),
 
     // split {viewport} in two; the new view lands after it and becomes active, as in the ui
     split: async (viewport = getActiveViewport()) => {

--- a/ux/client/views/viz/viewer/useLookAt.js
+++ b/ux/client/views/viz/viewer/useLookAt.js
@@ -1,0 +1,91 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// externals
+import React from 'react'
+import { graphql, useMutation } from 'react-relay/hooks'
+
+// adjust the look-at center
+export const useLookAt = viewport => {
+    // adjusting the look-at center mutates the server side store
+    const [commit] = useMutation(useLookAtMutation)
+
+    // a scroll fires far faster than the server round trip, so we keep at most one mutation in
+    // flight and, while one is, remember only the LATEST center; when the in-flight one settles we
+    // send that latest value. this coalesces the storm yet guarantees the final center is not dropped
+    const inflight = React.useRef(false)
+    const queued = React.useRef(null)
+
+    // send one center to the server
+    const send = ({ row, col }) => {
+        // mark the channel busy
+        inflight.current = true
+        // flush whatever was queued once this commit settles either way
+        const settle = () => {
+            // free again
+            inflight.current = false
+            // send the most recent center that arrived while we were busy
+            const next = queued.current
+            if (next) {
+                queued.current = null
+                send(next)
+            }
+        }
+        // send the request to the server
+        commit({
+            // input
+            variables: {
+                input: { viewport, row, col },
+            },
+            // on success, flush the latest queued center
+            onCompleted: settle,
+            // on failure, report and still flush, so a transient error does not strand the center
+            onError: errors => {
+                // show me
+                console.log(`viz.viewer.useLookAt:`)
+                console.group()
+                console.log(`ERROR while setting the look-at center for viewport ${viewport}`)
+                console.log(errors)
+                console.groupEnd()
+                // still flush the latest
+                settle()
+            },
+        })
+    }
+
+    // the public handler: send now if idle, otherwise hold only the latest center
+    const set = center => {
+        // if a commit is in flight
+        if (inflight.current) {
+            // remember only the most recent center
+            queued.current = center
+            // and let the in-flight commit flush it
+            return
+        }
+        // otherwise, send it right away
+        send(center)
+    }
+
+    // return the handler
+    return { set }
+}
+
+
+// the mutation that sets the look-at center of a viewport
+export const useLookAtMutation = graphql`
+    mutation useLookAtMutation($input: ViewLookAtInput!) {
+        viewLookAt(input: $input) {
+            center {
+                dirty
+                row
+                col
+            }
+        }
+    }
+`
+
+
+// end of file

--- a/ux/client/views/viz/viewer/viewport.js
+++ b/ux/client/views/viz/viewer/viewport.js
@@ -19,20 +19,60 @@ import { useViewports, useCenterViewport } from '~/views/viz'
 
 // locals
 import { tileURI } from '.'
+// hooks
+import { useLookAt } from './useLookAt'
 // components
 import { Measure } from '../measure'
+
+
+// how close two look-at centers must be, in source pixels, to count as the same place; this absorbs
+// float noise and the sub-pixel drift of the zoom rescale, so a programmatic scroll does not echo
+const EPSILON = 0.5
+
+// the source pixel under the center of {placemat}, derived from its rendered zoom and size; the
+// inverse of {lookAtCenter}, and the same mapping {window.qed.centerOn} and the minimap use
+const centerOf = placemat => {
+    // read the rendered zoom off the markup, as "vertical,horizontal"
+    const [vertical, horizontal] = placemat.getAttribute("data-qed-zoom").split(",").map(Number)
+    // scroll offsets are in rendered pixels, which grow as 2**zoom; convert the center to source
+    return {
+        row: (placemat.scrollTop + placemat.clientHeight / 2) * 2 ** -vertical,
+        col: (placemat.scrollLeft + placemat.clientWidth / 2) * 2 ** -horizontal,
+    }
+}
+
+// scroll {placemat} so the source pixel {row, col} sits at the center of the visible window
+const lookAtCenter = (placemat, { row, col }) => {
+    // read the rendered zoom off the markup, as "vertical,horizontal"
+    const [vertical, horizontal] = placemat.getAttribute("data-qed-zoom").split(",").map(Number)
+    // convert source pixels to rendered ones and place the target at the center
+    placemat.scrollLeft = col * 2 ** horizontal - placemat.clientWidth / 2
+    placemat.scrollTop = row * 2 ** vertical - placemat.clientHeight / 2
+}
+
+// whether two look-at centers point at the same source pixel, within {EPSILON}
+const same = (a, b) =>
+    a != null && b != null && Math.abs(a.row - b.row) < EPSILON && Math.abs(a.col - b.col) < EPSILON
+
+// ask lazysizes to load whatever is now visible. it defers loads during a fast scroll and keys off
+// its own scroll detection; when we move the view -- the originator coming to rest, or a peer being
+// recentered from the server -- that detection can be outrun, leaving freshly-revealed tiles blank.
+// nudging it once the view is settled loads them without waiting for another scroll
+const loadVisibleTiles = () => window.lazySizes?.loader?.checkElems?.()
 
 
 // export the data viewport
 export const Viewport = ({ viewport, view, registrar, ...rest }) => {
     // unpack the view
     const {
-        session, reader, dataset, channel, measure, zoom
+        session, reader, dataset, channel, measure, zoom, center: serverCenter
     } = useFragment(viewportViewerGetViewFragment, view)
     // get the pile of registered {viewports}; i'm at {viewport}
     const { activeViewport, viewports } = useViewports()
     // make a handler that centers my viewport
     const centerViewport = useCenterViewport(viewport)
+    // a handler that pushes my look-at center to the server, so my scroll syncs to every client
+    const { set: lookAt } = useLookAt(viewport)
     // get the base URI for tiles
     const uri = tileURI({ reader, dataset, channel, zoom, viewport })
     // unpack what i need from the dataset
@@ -51,6 +91,18 @@ export const Viewport = ({ viewport, view, registrar, ...rest }) => {
     // could read it, so we cannot trust the post-resize value; track the live offset here, while it
     // is still valid for the current zoom, and rescale that
     const lastScroll = React.useRef({ left: 0, top: 0 })
+    // the look-at center we last sent to, or adopted from, the server; a scroll that lands here is an
+    // echo of our own push or of a programmatic scroll, and must not bounce back out to the server
+    const lastCenter = React.useRef(null)
+    // raised while the user is actively scrolling, so a server echo cannot yank the view mid-gesture;
+    // a scroll has no clean "pointer up", so we lower it on a short idle timer instead
+    const interacting = React.useRef(false)
+    // the latest center seen while scrolling, flushed to the server only once the scroll settles
+    const pendingCenter = React.useRef(null)
+    const settleTimer = React.useRef(null)
+    // {lookAt} is a fresh closure each render; keep it in a ref so the scroll listener stays stable
+    const lookAtRef = React.useRef(lookAt)
+    React.useEffect(() => { lookAtRef.current = lookAt })
     React.useEffect(() => {
         // get my scrolling container
         const placemat = viewports[viewport]
@@ -59,18 +111,64 @@ export const Viewport = ({ viewport, view, registrar, ...rest }) => {
             // bail
             return
         }
-        // record the offset whenever it changes, so we always have its pre-resize value on hand
-        const track = () => {
-            // stash the live offset
-            lastScroll.current = { left: placemat.scrollLeft, top: placemat.scrollTop }
+        // every scroll event fires a mutation, and every mutation triggers a full-state refetch on
+        // every client over live sync; pushing on each tick of a drag would be a refetch storm that
+        // re-renders the viewport faster than its tiles can lazy-load. so we track the position live
+        // but flush only the FINAL center, once the scroll has been still for a beat -- the look-at
+        // sync cares where you land, not the path you took to get there
+        const flush = () => {
+            // the scroll has settled
+            interacting.current = false
+            // the place we came to rest
+            const center = pendingCenter.current
+            pendingCenter.current = null
+            // push the final center, unless there is nothing pending or it is where we already are
+            if (center != null && !same(center, lastCenter.current)) {
+                // remember it as ours and push it
+                lastCenter.current = center
+                lookAtRef.current(center)
+            }
+            // the view has come to rest; load whatever scrolled into view but lazysizes deferred
+            loadVisibleTiles()
             // all done
             return
         }
-        // seed it, then follow along
+        const track = () => {
+            // stash the live offset, so the zoom rescale below has its pre-resize value
+            lastScroll.current = { left: placemat.scrollLeft, top: placemat.scrollTop }
+            // where am i looking now, in source pixels?
+            const here = centerOf(placemat)
+            // the first observation is just a baseline; adopt it silently and never push it
+            if (lastCenter.current == null) {
+                lastCenter.current = here
+                return
+            }
+            // a programmatic scroll (the reconcile effect or the zoom rescale) lands on the
+            // remembered center; recognize it as an echo and leave the server alone
+            if (same(here, lastCenter.current)) {
+                return
+            }
+            // a real move: hold off server echoes, remember the latest spot, and (re)arm the flush
+            // so the push lands only after the scroll goes quiet
+            interacting.current = true
+            pendingCenter.current = here
+            if (settleTimer.current) {
+                clearTimeout(settleTimer.current)
+            }
+            settleTimer.current = setTimeout(flush, 150)
+            // all done
+            return
+        }
+        // seed it, then follow along; passive, so we never delay the scroll or starve lazysizes
         track()
-        placemat.addEventListener("scroll", track)
-        // clean up
-        return () => placemat.removeEventListener("scroll", track)
+        placemat.addEventListener("scroll", track, { passive: true })
+        // clean up; drop any pending flush so it cannot fire after unmount
+        return () => {
+            placemat.removeEventListener("scroll", track)
+            if (settleTimer.current) {
+                clearTimeout(settleTimer.current)
+            }
+        }
     }, [viewport, viewports])
 
     // rescale the tracked offset when the zoom level changes, holding the centered source pixel put
@@ -97,9 +195,40 @@ export const Viewport = ({ viewport, view, registrar, ...rest }) => {
         // rescale each offset about the viewport center, so the centered source pixel stays put
         placemat.scrollLeft = (left + box.width / 2) * ratioX - box.width / 2
         placemat.scrollTop = (top + box.height / 2) * ratioY - box.height / 2
+        // the rescale holds the look-at center fixed; record where we actually landed (the offset may
+        // clamp at an edge) so the scroll event it triggers is recognized as an echo, not pushed out
+        lastCenter.current = centerOf(placemat)
         // all done
         return
     }, [viewport, viewports, zoom.horizontal, zoom.vertical])
+
+    // adopt a look-at center pushed from the server -- a peer panned, or this is our first sync on
+    // load. skip while the user is actively scrolling so we never fight the pointer
+    React.useEffect(() => {
+        // get my scrolling container
+        const placemat = viewports[viewport]
+        // if there is none yet, or i have none to adopt, or the user is mid-gesture, leave it be
+        if (!placemat || !serverCenter || interacting.current) {
+            // bail
+            return
+        }
+        // the center the server wants me to look at
+        const target = { row: serverCenter.row, col: serverCenter.col }
+        // if it already matches where i am looking, there is nothing to do
+        if (same(target, lastCenter.current)) {
+            // bail
+            return
+        }
+        // scroll there
+        lookAtCenter(placemat, target)
+        // record where i actually landed (the scroll may clamp at an edge) so the scroll event this
+        // triggers is recognized as an echo rather than pushed back to the server
+        lastCenter.current = centerOf(placemat)
+        // load whatever this recenter brought into view
+        loadVisibleTiles()
+        // all done
+        return
+    }, [viewport, viewports, serverCenter?.row, serverCenter?.col])
     // center the viewport at the cursor position
     const center = ({ clientX, clientY }) => {
         // get my placemat
@@ -234,6 +363,10 @@ const viewportViewerGetViewFragment = graphql`
         zoom {
             horizontal
             vertical
+        }
+        center {
+            row
+            col
         }
     }
 `


### PR DESCRIPTION
## Summary

The viewport scroll position is now **server state**. A view carries a resolution-independent **look-at center** — the source pixel `(row, col)` under the middle of the window, row-major — and any scroll publishes it through a throttled `viewLookAt` mutation, so it reflects on every connected client over the SSE event stream, exactly the way zoom / channel / selections already do. Each client converts that center to its own scroll via its own geometry (window size + zoom), so clients of different sizes land on the same source pixel. Built on top of the merged SSE live-sync (pyre #177 / qed #77).

## Design

- **Look-at center, not DOM scroll.** We store the source-pixel center, not `scrollLeft/Top` (which depends on each client's window size and zoom). That keeps it resolution-independent — the same mapping `window.qed.centerOn` and the minimap already use.
- **Mirrors the zoom aspect exactly.** New `Center` component + protocol, persisted via `Source` (so `viewPersist` saves it); `View.lookAt` / `Viewport.lookAt` / `Store.lookAt`; GraphQL `ViewCenter` + `viewLookAt` mutation + `View.center`. The client `useLookAt` hook is a copy of zoom's trailing-edge `useSetLevel` throttle.
- **Per-viewport, no server-side fan-out.** `viewLookAt` sets only the addressed viewport. Cross-*viewport* scroll-sync (a user's own panes) stays client-side in the existing pan dispatcher with its `sync.offsets`; the server only carries each viewport's own absolute center, so the two compose instead of conflicting.
- **Echo suppression by value-equality.** A `lastCenter` ref holds the last value sent-or-adopted; a scroll within 0.5 source px of it is treated as an echo (our own push, a programmatic reconcile, or the zoom-rescale) and is not bounced back. Programmatic scrolls set `lastCenter` to their post-clamp center *before* their async scroll event fires, so they self-suppress; an `interacting` guard keeps a server push from yanking the view mid-gesture.

## Why followers sync only when the originator stops panning

The first working version pushed the look-at on **every scroll tick**. Because every mutation broadcasts an SSE "change" that makes *every* client refetch the full state query, a continuous drag became a refetch storm: the viewport re-rendered faster than its lazysizes tiles could load, leaving blank `<img>` tiles, plus a per-scroll Relay normalizer warning.

So the push now **debounces** — the client tracks the center live but flushes a single `viewLookAt` ~150 ms after the scroll goes still. Rationale beyond fixing the storm: a look-at sync cares about **where you land, not the path you took**, and (measured during this work) every push also fans tile re-renders out to all the other clients — so per-tick pushing multiplies server load. Debouncing collapses a gesture to one push: the originator scrolls smoothly and locally; followers snap to the resting place once it settles. Verified that a follower converges on the originator's exact center (gap `0.00`) after settle, with no refetch storm.

## Blank-tile fix (originator only)

After debouncing, the *scroll originator* still missed some tiles while subscribers were fine. Cause: lazysizes defers loads during a fast scroll and relies on its own scroll detection; a subscriber self-heals because its reconcile does a *programmatic* scroll that re-triggers lazysizes, but the originator gets no such trigger once it settles. Fix: call `window.lazySizes.loader.checkElems()` when the view comes to rest (originator) and after a programmatic recenter (subscriber), and made the scroll listener passive. (Confirmed the refetch does **not** remount tiles — `viewLookAt` doesn't bump the view `session`, so the Mosaic memo holds and loaded tiles keep their `src`.)

## Commits (4 waves)

1. **store** — `Center` component/protocol, `View`/`Viewport`/`Store` look-at, persistence
2. **gql** — `viewLookAt` mutation + `ViewCenter` + `View.center`
3. **client** — `useLookAt` hook, viewport scroll→push + reconcile, `window.qed.lookAt` facade
4. **tests**

## Testing

- `tests/qed.pkg/lookat.py` — `Center` clone/reset/dirty + `View.lookAt` + `Store.lookAt` (single-viewport).
- GraphQL path validated in-process (`schema.execute` of `viewLookAt` → `ViewCenter` resolves `row/col/dirty`).
- Two-client headless probe: follower converges to the driver's center exactly, with no echo loop.
- `tests/qed.ux.playwright/behavior/scroll-sync.spec.ts` — facade-`lookAt` path + raw-scroll→peer path.

> **Note on the Playwright suite:** I could not run the full suite in my sandbox due to a pre-existing pyre/h5 environment mismatch (`pyre.h5.memtypes`), unrelated to this change. The behavior was validated via the headless probe + in-process GraphQL, and exercised end-to-end against a live server with three real browsers. Please confirm whether CI runs this suite.

## Follow-up (separate `perf` branch — not this PR)

Driving three real browsers + a probe against a live GSLC server surfaced that the **server**, not this feature, is the limiter: each NISAR tile renders in ~100 ms and the HTTP server is synchronous with the GIL held, so renders serialize. Because synced clients converge on the **same** tiles, 40–50% of renders in the multi-client workload are duplicates, and one user scrolling drags everyone's renders along (~4× load). This is a server-architecture limitation, not a scroll-sync defect; it motivates the need for building an actual performance model to anchor the necessary server side architectural improvements.
