### PR TITLE
qed.ux: new button on the viewport bar to toggle live sync

### DIFF
--- a/ux/client/views/viz/index.js
+++ b/ux/client/views/viz/index.js
@@ -11,7 +11,7 @@ export { Controls } from './controls'
 export { Readers } from './readers'
 
 // hooks
-export { useViewports, useCenterViewport } from './viz'
+export { useViewports, useCenterViewport, useLive } from './viz'
 
 // functions
 export { tileURI } from './viewer'

--- a/ux/client/views/viz/viewer/Live.js
+++ b/ux/client/views/viz/viewer/Live.js
@@ -1,0 +1,61 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// externals
+import React from 'react'
+
+// project
+// shapes
+import { Live as Shape } from '~/shapes'
+// widgets
+import { Badge } from '~/widgets'
+
+// locals
+// hooks
+import { useLive } from '~/views/viz'
+// styles
+import styles from './styles'
+
+
+// opt this viewport into live sync: a client-only preference that pushes its interactions to the
+// server on every tick, so peers follow smoothly, instead of once the gesture settles
+export const Live = ({ viewport }) => {
+    // read this viewport's opt-in and its toggle
+    const { enabled, toggle } = useLive(viewport)
+    // turn the toggle into an event handler
+    const onClick = evt => {
+        // keep the click from bubbling up to the bar
+        evt.stopPropagation()
+        // and from doing anything default
+        evt.preventDefault()
+        // flip the opt-in
+        toggle()
+        // all done
+        return
+    }
+
+    // my event handlers
+    const behaviors = {
+        // toggle the opt-in on a single click
+        onClick,
+    }
+
+    // reflect the opt-in in the badge state
+    const state = enabled ? "selected" : "enabled"
+    // mix my paint
+    const paint = styles.live
+    // render
+    return (
+        <Badge size={18} state={state} behaviors={behaviors} style={paint}
+            aria-label="toggle live sync" aria-pressed={enabled}
+            data-qed-control="viewport" data-qed-action="live" >
+            <Shape />
+        </Badge >
+    )
+}
+
+
+// end of file

--- a/ux/client/views/viz/viewer/styles.js
+++ b/ux/client/views/viz/viewer/styles.js
@@ -274,6 +274,49 @@ const sync = {
 }
 
 
+// the button that opts a data viewport into live sync
+const live = {
+    // inherit
+    ...badge,
+
+    // the icon container
+    badge: {
+        ...badge.badge,
+        base: {
+            ...badge.badge.base,
+            // for me
+            justifySelf: "end",
+        },
+    },
+
+    icon: {
+        ...badge.icon,
+        selected: {
+            ...badge.icon.selected,
+            stroke: theme.page.highlight,
+        },
+        available: {
+            ...badge.icon.available,
+            stroke: theme.page.highlight,
+        },
+    },
+
+    decoration: {
+        ...badge.decoration,
+
+        selected: {
+            ...badge.decoration.selected,
+            fill: theme.page.highlight,
+            stroke: theme.page.highlight,
+        },
+        available: {
+            ...badge.decoration.available,
+            stroke: theme.page.highlight,
+        },
+    }
+}
+
+
 // the button that prints the screen
 const print = {
     // inherit
@@ -352,6 +395,7 @@ const blank = {
 export default {
     blank,
     collapse,
+    live,
     measure,
     print,
     selector,

--- a/ux/client/views/viz/viewer/tab.js
+++ b/ux/client/views/viz/viewer/tab.js
@@ -16,6 +16,7 @@ import { Spacer } from '~/widgets'
 import { useViewports } from '~/views/viz'
 // components
 import { Collapse } from './collapse'
+import { Live } from './Live'
 import { Measure } from './measure'
 import { Print } from './print'
 import { Selector } from './selector'
@@ -46,6 +47,8 @@ export const Tab = ({ viewport, view, behaviors }) => {
             {view && <Measure viewport={viewport} view={view} />}
             {/* the button that toggles the sync status of the data viewport */}
             {view && <Sync viewport={viewport} view={view} />}
+            {/* the button that opts this viewport into live sync */}
+            {view && <Live viewport={viewport} />}
             {/* the button that prints the viewport */}
             {view && <Print viewport={viewport} view={view} />}
             {/* the button that adds a new view to the {viz} panel */}

--- a/ux/client/views/viz/viewer/viewport.js
+++ b/ux/client/views/viz/viewer/viewport.js
@@ -15,7 +15,7 @@ import { Mosaic } from '~/widgets'
 // colors
 import { theme } from "~/palette"
 // hooks
-import { useViewports, useCenterViewport } from '~/views/viz'
+import { useViewports, useCenterViewport, useLive } from '~/views/viz'
 
 // locals
 import { tileURI } from '.'
@@ -54,13 +54,6 @@ const lookAtCenter = (placemat, { row, col }) => {
 const same = (a, b) =>
     a != null && b != null && Math.abs(a.row - b.row) < EPSILON && Math.abs(a.col - b.col) < EPSILON
 
-// ask lazysizes to load whatever is now visible. it defers loads during a fast scroll and keys off
-// its own scroll detection; when we move the view -- the originator coming to rest, or a peer being
-// recentered from the server -- that detection can be outrun, leaving freshly-revealed tiles blank.
-// nudging it once the view is settled loads them without waiting for another scroll
-const loadVisibleTiles = () => window.lazySizes?.loader?.checkElems?.()
-
-
 // export the data viewport
 export const Viewport = ({ viewport, view, registrar, ...rest }) => {
     // unpack the view
@@ -73,6 +66,8 @@ export const Viewport = ({ viewport, view, registrar, ...rest }) => {
     const centerViewport = useCenterViewport(viewport)
     // a handler that pushes my look-at center to the server, so my scroll syncs to every client
     const { set: lookAt } = useLookAt(viewport)
+    // whether this viewport is opted into live sync: push on every tick vs once the gesture settles
+    const { enabled: live } = useLive(viewport)
     // get the base URI for tiles
     const uri = tileURI({ reader, dataset, channel, zoom, viewport })
     // unpack what i need from the dataset
@@ -97,12 +92,17 @@ export const Viewport = ({ viewport, view, registrar, ...rest }) => {
     // raised while the user is actively scrolling, so a server echo cannot yank the view mid-gesture;
     // a scroll has no clean "pointer up", so we lower it on a short idle timer instead
     const interacting = React.useRef(false)
-    // the latest center seen while scrolling, flushed to the server only once the scroll settles
+    // the latest center seen while scrolling; in the debounced default it is flushed to the server
+    // once the scroll settles, in live mode it has already been pushed and is used only to settle
     const pendingCenter = React.useRef(null)
+    // the settle timer: fires once a scroll goes quiet, to flush the final center (debounced default)
+    // and lower the {interacting} guard
     const settleTimer = React.useRef(null)
-    // {lookAt} is a fresh closure each render; keep it in a ref so the scroll listener stays stable
+    // {lookAt} and the live flag are fresh each render; keep them in refs so the listener stays stable
     const lookAtRef = React.useRef(lookAt)
     React.useEffect(() => { lookAtRef.current = lookAt })
+    const liveRef = React.useRef(live)
+    React.useEffect(() => { liveRef.current = live })
     React.useEffect(() => {
         // get my scrolling container
         const placemat = viewports[viewport]
@@ -111,25 +111,23 @@ export const Viewport = ({ viewport, view, registrar, ...rest }) => {
             // bail
             return
         }
-        // every scroll event fires a mutation, and every mutation triggers a full-state refetch on
-        // every client over live sync; pushing on each tick of a drag would be a refetch storm that
-        // re-renders the viewport faster than its tiles can lazy-load. so we track the position live
-        // but flush only the FINAL center, once the scroll has been still for a beat -- the look-at
-        // sync cares where you land, not the path you took to get there
+        // a scroll pushes the look-at center so every client follows. by default we flush only the
+        // FINAL center, once the scroll has been still for a beat -- one mutation per gesture, sync
+        // where you land. when this viewport is opted into live sync, we push on every tick instead,
+        // so peers follow the motion smoothly ({useLookAt} already caps the in-flight mutation rate)
         const flush = () => {
-            // the scroll has settled
+            // the scroll has settled; lower the guard so a server echo can adopt again
             interacting.current = false
             // the place we came to rest
             const center = pendingCenter.current
             pendingCenter.current = null
-            // push the final center, unless there is nothing pending or it is where we already are
+            // in the debounced default the final center has not been pushed yet, so push it now; in
+            // live mode the last tick already pushed it, so {same} short-circuits and this is a no-op
             if (center != null && !same(center, lastCenter.current)) {
                 // remember it as ours and push it
                 lastCenter.current = center
                 lookAtRef.current(center)
             }
-            // the view has come to rest; load whatever scrolled into view but lazysizes deferred
-            loadVisibleTiles()
             // all done
             return
         }
@@ -148,10 +146,16 @@ export const Viewport = ({ viewport, view, registrar, ...rest }) => {
             if (same(here, lastCenter.current)) {
                 return
             }
-            // a real move: hold off server echoes, remember the latest spot, and (re)arm the flush
-            // so the push lands only after the scroll goes quiet
+            // a real move: hold off server echoes and remember the latest spot
             interacting.current = true
             pendingCenter.current = here
+            // in live mode, push it right away so peers follow this tick
+            if (liveRef.current) {
+                lastCenter.current = here
+                lookAtRef.current(here)
+            }
+            // (re)arm the settle timer: it flushes the final center in the debounced default, and
+            // only lowers the interacting guard in live mode
             if (settleTimer.current) {
                 clearTimeout(settleTimer.current)
             }
@@ -159,10 +163,10 @@ export const Viewport = ({ viewport, view, registrar, ...rest }) => {
             // all done
             return
         }
-        // seed it, then follow along; passive, so we never delay the scroll or starve lazysizes
+        // seed it, then follow along; passive, so we never delay the scroll
         track()
         placemat.addEventListener("scroll", track, { passive: true })
-        // clean up; drop any pending flush so it cannot fire after unmount
+        // clean up; drop any pending idle timer so it cannot fire after unmount
         return () => {
             placemat.removeEventListener("scroll", track)
             if (settleTimer.current) {
@@ -224,8 +228,6 @@ export const Viewport = ({ viewport, view, registrar, ...rest }) => {
         // record where i actually landed (the scroll may clamp at an edge) so the scroll event this
         // triggers is recognized as an echo rather than pushed back to the server
         lastCenter.current = centerOf(placemat)
-        // load whatever this recenter brought into view
-        loadVisibleTiles()
         // all done
         return
     }, [viewport, viewports, serverCenter?.row, serverCenter?.col])

--- a/ux/client/views/viz/viz/context.js
+++ b/ux/client/views/viz/viz/context.js
@@ -18,6 +18,25 @@ export const VizProvider = ({ children }) => {
     // the corresponding entry in the array of {viewports}; each panel gets its own registrar
     // that knows its positioning in the flex container
     const viewportRegistrar = idx => ref => viewports.current[idx] = ref
+    // the per-viewport opt-in to live sync: a client-only preference that makes a viewport push its
+    // interactions to the server live -- on every scroll tick, so peers follow smoothly -- instead
+    // of once the gesture settles. off by default; a fast link can turn it on from the viewport bar
+    const [live, setLive] = React.useState(() => new Set())
+    // flip a viewport's opt-in
+    const toggleLive = viewport => setLive(prev => {
+        // copy the set so react sees a new reference
+        const next = new Set(prev)
+        // if the viewport is currently opted in
+        if (next.has(viewport)) {
+            // opt it out
+            next.delete(viewport)
+        } else {
+            // otherwise, opt it in
+            next.add(viewport)
+        }
+        // hand back the updated set
+        return next
+    })
 
     // build the current value of the context
     const context = {
@@ -25,6 +44,8 @@ export const VizProvider = ({ children }) => {
         activeViewport, setActiveViewport,
         // the set of active viewports (actually, the {mosaic} placemats)
         viewports, viewportRegistrar,
+        // the per-viewport live-sync opt-in and its toggle
+        live, toggleLive,
     }
     // provide for my children
     return (
@@ -46,6 +67,9 @@ export const Context = React.createContext(
         viewports: null,
         // the registrar
         viewportRegistrar: () => { throw new Error(complaint) },
+        // the per-viewport live-sync opt-in and its toggle
+        live: new Set(),
+        toggleLive: () => { throw new Error(complaint) },
     }
 )
 

--- a/ux/client/views/viz/viz/index.js
+++ b/ux/client/views/viz/viz/index.js
@@ -10,6 +10,7 @@ export { Viz } from './viz'
 // hooks
 export { useViewports } from './useViewports'
 export { useCenterViewport } from './useCenterViewport'
+export { useLive } from './useLive'
 
 
 // end of file

--- a/ux/client/views/viz/viz/useLive.js
+++ b/ux/client/views/viz/viz/useLive.js
@@ -1,0 +1,28 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// externals
+import React from 'react'
+
+// local
+// context
+import { Context } from './context'
+
+
+// read and toggle a viewport's opt-in to live sync, a client-only preference
+export const useLive = (viewport) => {
+    // grab the live-sync state from my context
+    const { live, toggleLive } = React.useContext(Context)
+    // whether this viewport is opted in
+    const enabled = live.has(viewport)
+    // a handler that flips this viewport's opt-in
+    const toggle = () => toggleLive(viewport)
+    // hand them back
+    return { enabled, toggle }
+}
+
+
+// end of file


### PR DESCRIPTION
## Summary

This adds a per-viewport opt-in to live sync: a button on each viewport's bar that controls how that
viewport publishes its look-at position to the other connected clients. By default a viewport pushes
once a scroll settles, which keeps the followers in step with where you land while issuing a single
mutation per gesture. With the button on, the viewport pushes on every scroll tick, so the other
clients follow the motion continuously.

## Details

- The opt-in is client-only React state, held per viewport in the viz context. It is deliberately not
  server state, because whether to push live is a per-user, per-connection performance choice rather
  than shared workspace state. A fast link can afford continuous following; a slow one should not pay
  for it.
- The button follows the existing viewport-bar toggles. It is a `Badge` with the `Live` icon, reads
  and flips the context state through a small `useLive` hook, and carries the same
  `data-qed-control`/`data-qed-action` and ARIA attributes as the other controls.
- The viewport's scroll handler now has one unified path. It always remembers the latest center and
  flushes the final one once the scroll settles; when the viewport is opted in, it additionally
  pushes on each tick. The existing look-at hook already keeps at most one mutation in flight and
  coalesces the rest, so the live path does not flood the connection.

## A retired workaround

This change also removes the `lazysizes` `checkElems` nudge that the original scroll-sync work added
to fix tiles that stayed blank for the scroll originator. That nudge was compensating for a server
defect rather than for genuine `lazysizes` deferral: the HTTP response-crossing bug fixed in
pyre#180, where a tile request on a reused keep-alive connection could receive an earlier request's
response. With that bug fixed, fast scrolling no longer leaves tiles persistently blank, so the nudge
is no longer needed. It therefore depends on pyre#180, which is merged.

## Verification

Driving two WebKit clients: with the button off, a follower stays put during a sustained scroll and
jumps to the final position once it settles; with the button on, the follower tracks the scroll
continuously. In both cases the two clients end at the same position, no tiles remain blank, and the
console reports no warnings.
