### PR TITLE
Accommodate the new pyre::h5 interface

### DIFF
--- a/lib/qed/nisar/profile.icc
+++ b/lib/qed/nisar/profile.icc
@@ -108,23 +108,23 @@ qed::nisar::profile(
 
     // get the last point on the path
     auto & last = closed ? path.front() : path.back();
-    // we read from
-    hsize_t readFrom[2] = {
+    // the address of the pixel we read from
+    auto readFrom = pyre::h5::index_t {
         static_cast<hsize_t>(std::get<0>(last)),
         static_cast<hsize_t>(std::get<1>(last)),
     };
     // the shape of a pixel
-    hsize_t count[2] = { 1, 1 };
+    auto count = pyre::h5::shape_t { 1, 1 };
     // get the dataspace of the dataset
-    auto readSpace = dataset.getSpace();
+    auto readSpace = dataset.dataspace();
     // select the hyperslab that corresponds to the pixel we want to extract
-    readSpace.selectHyperslab(H5S_SELECT_SET, count, readFrom);
+    readSpace.slab(readFrom, count);
     // make a dataspace for the destination
-    auto writeSpace = dataspace_t(2, count);
+    auto writeSpace = dataspace_t(count);
     // make room for the value
     value_t value;
     // transfer
-    dataset.read(&value, datatype, writeSpace, readSpace);
+    dataset.read(datatype.id(), &value, writeSpace.id(), readSpace.id());
     // and build the last entry
     values.emplace_back(std::get<0>(last), std::get<1>(last), value);
 
@@ -270,22 +270,22 @@ qed::nisar::profileBFPQ(
     // get the last point on the path
     const auto & [lastLine, lastSample] = (closed && path.size() > 2) ? path.front() : path.back();
     // build the address of the point
-    hsize_t index[2] = {
+    auto index = pyre::h5::index_t {
         static_cast<hsize_t>(lastLine),
         static_cast<hsize_t>(lastSample),
     };
     // the shape of a pixel
-    hsize_t shape[2] = { 1, 1 };
+    auto shape = pyre::h5::shape_t { 1, 1 };
     // get the dataspace of the dataset
-    auto readSpace = dataset.getSpace();
+    auto readSpace = dataset.dataspace();
     // select the hyperslab that corresponds to the pixel we want to extract
-    readSpace.selectHyperslab(H5S_SELECT_SET, shape, index);
+    readSpace.slab(index, shape);
     // make a dataspace for the destination
-    auto writeSpace = dataspace_t(2, shape);
+    auto writeSpace = dataspace_t(shape);
     // allocate room for the value
     bfpq_slc_cell_t value;
     // transfer
-    dataset.read(&value, datatype, writeSpace, readSpace);
+    dataset.read(datatype.id(), &value, writeSpace.id(), readSpace.id());
     // decode
     auto decoded = decoder(value);
     // and build the last entry

--- a/lib/qed/nisar/real/coherenceMasked.icc
+++ b/lib/qed/nisar/real/coherenceMasked.icc
@@ -52,7 +52,7 @@ qed::nisar::real::coherenceMasked(
     auto source = pyre::h5::read<source_t>(dataset, datatype, zoomedOrigin, tile, stride);
     // and the mask
     auto mask =
-        pyre::h5::read<mask_t>(maskDataset, maskDataset.getDataType(), zoomedOrigin, tile, stride);
+        pyre::h5::read<mask_t>(maskDataset, maskDataset.datatype(), zoomedOrigin, tile, stride);
 
     // build the wrokflow
     auto workflow = MaskedCoherence(source, mask, min, max);

--- a/lib/qed/nisar/real/covarianceMasked.icc
+++ b/lib/qed/nisar/real/covarianceMasked.icc
@@ -52,7 +52,7 @@ qed::nisar::real::covarianceMasked(
     auto source = pyre::h5::read<source_t>(dataset, datatype, zoomedOrigin, tile, stride);
     // and the mask
     auto mask =
-        pyre::h5::read<mask_t>(maskDataset, maskDataset.getDataType(), zoomedOrigin, tile, stride);
+        pyre::h5::read<mask_t>(maskDataset, maskDataset.datatype(), zoomedOrigin, tile, stride);
 
     // build the wrokflow
     auto workflow = MaskedCovariance(source, mask, min, max);

--- a/lib/qed/nisar/real/unwrappedMasked.icc
+++ b/lib/qed/nisar/real/unwrappedMasked.icc
@@ -55,7 +55,7 @@ qed::nisar::real::unwrappedMasked(
     auto source = pyre::h5::read<source_t>(dataset, datatype, zoomedOrigin, tile, stride);
     // and the mask
     auto mask =
-        pyre::h5::read<mask_t>(maskDataset, maskDataset.getDataType(), zoomedOrigin, tile, stride);
+        pyre::h5::read<mask_t>(maskDataset, maskDataset.datatype(), zoomedOrigin, tile, stride);
 
     // build the wrokflow
     auto workflow = MaskedPhase(source, mask, min, max, brightness);


### PR DESCRIPTION
## Summary

pyre PR#181 finished decoupling `pyre::h5` from the HDF5 C++ header, dropping
the HDF5-C++-style methods that `qed.nisar` was still calling. This broke the
`qed.ext` build. This PR tracks the new pyre native-wrapper API.

## API changes tracked

| Old (HDF5 C++ API) | New (pyre wrapper) |
|---|---|
| `dataset.getDataType()` | `dataset.datatype()` → `types::Datatype` |
| `dataset.getSpace()` | `dataset.dataspace()` → `DataSpace` |
| `space.selectHyperslab(SET, count, start)` | `space.slab(origin, shape)` |
| `dataspace_t(2, ptr)` | `dataspace_t(shape_t)` |
| `dataset.read(buf, type, mem, file)` | `dataset.read(type.id(), buf, mem.id(), file.id())` |

## Changes

- **`lib/qed/nisar/real/{coherence,covariance,unwrapped}Masked.icc`** —
  `maskDataset.getDataType()` → `maskDataset.datatype()`.
- **`lib/qed/nisar/profile.icc`** (two single-pixel read sites) — converted the
  manual hyperslab reads to the new dataspace/read API. The local `index_t`/
  `shape_t` aliases in these functions bind to the *source grid* types, so the
  dataspace calls use `pyre::h5::index_t` / `pyre::h5::shape_t`
  (`std::vector<hsize_t>`) explicitly; the old C-array `hsize_t[2]` operands
  became those vectors.

The bulk `pyre::h5::read<>(...)` call sites across the tree did not need
touching — that is qed's own template wrapper, which pyre re-implemented
internally against the new API.

## Verification

- `mm qed.ext` builds cleanly; full `mm` build is green (exit 0).
- A tree-wide scan for other dropped HDF5-C++ API names came back clean (the
  remaining `read<>` hits are the qed wrapper; `GDALBand.py`'s
  `GetDataTypeName` is GDAL's own API, unrelated).

