### PR TITLE
Use pyre::chroma and the updated pyre::viz infrastructure

### DIFF
--- a/lib/qed/nisar/mask/RawMask.h
+++ b/lib/qed/nisar/mask/RawMask.h
@@ -11,6 +11,7 @@
 #include <array>
 // support
 #include <pyre/viz.h>
+#include <pyre/chroma.h>
 
 
 // map a single value to a shade of gray

--- a/lib/qed/nisar/mask/RawMask.icc
+++ b/lib/qed/nisar/mask/RawMask.icc
@@ -43,12 +43,12 @@ qed::nisar::mask::RawMask<sourceT>::RawMask(source_const_reference source) :
             // moderate chroma
             float C = 0.16f;
             // encode and store
-            _palette[code] = pyre::viz::colorspaces::oklch(L, C, h);
+            _palette[code] = pyre::chroma::rgb::oklch(L, C, h);
         }
     }
 
     // generic water
-    _palette[100] = pyre::viz::colorspaces::oklch(0.78f, 0.08f, 240.f);
+    _palette[100] = pyre::chroma::rgb::oklch(0.78f, 0.08f, 240.f);
 
     // water values: 100 + 10*{ref} + {sec}
     // go through the possible reference subswath values
@@ -64,7 +64,7 @@ qed::nisar::mask::RawMask<sourceT>::RawMask(source_const_reference source) :
             float L = 0.88f - 0.08f * float(sec - 1);
             float C = 0.10f;
             // enode and store
-            _palette[code] = pyre::viz::colorspaces::oklch(L, C, h);
+            _palette[code] = pyre::chroma::rgb::oklch(L, C, h);
         }
     }
 


### PR DESCRIPTION
## Track pyre's chroma migration

pyre's `survey` branch (**pyre/pyre#187**) consolidated all color math into a new
`pyre::chroma` library: it **deleted `lib/pyre/viz/colorspaces/`** and moved those
converters under `pyre::chroma::rgb::`. `oklch` now lives at
`pyre::chroma::rgb::oklch(lightness, chromaLevel, hue) → rgb_t` — same three-float
signature as before.

`lib/qed/nisar/mask/RawMask.icc` called `pyre::viz::colorspaces::oklch` in three
places, so qed will not compile against the updated pyre until they're re-pointed.

### Change
- `RawMask.icc`: `pyre::viz::colorspaces::oklch` → `pyre::chroma::rgb::oklch` (×3).
- `RawMask.h`: add `#include <pyre/chroma.h>`.

Type-safe: `_palette` is `std::array<pyre::viz::rgb_t, …>`, and `pyre::viz::rgb_t` now
aliases `pyre::chroma::rgb_t` — exactly what `chroma::rgb::oklch` returns.

The viz colormaps qed uses (`pyre::viz::iterators::colormaps::*`) are unaffected.

### Verified
`mm` builds qed clean against the survey-branch pyre — `ext/qed/nisar/mask.cc`
(which instantiates `RawMask`, running the `oklch` palette code) recompiles without error.

### ⚠️ Merge order
**Depends on pyre/pyre#187.** Merge this only *after* that PR lands (it's what makes
`pyre::chroma::rgb::oklch` exist); until then, qed on `main` still builds against the old pyre.
