### PR TITLE
Adapt qed to the pyre::grid reimplementation

### DIFF
--- a/ext/qed/external.h
+++ b/ext/qed/external.h
@@ -10,8 +10,10 @@
 
 // STL
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
+#include <vector>
 
 // journal
 #include <pyre/journal.h>
@@ -88,6 +90,11 @@ namespace qed::py {
     template <typename sourceT>
     using parametric_t = pyre::viz::iterators::filters::parametric_t<sourceT>;
 }
+
+
+// the helpers that rebuild a typed grid over a python buffer and dispatch on its cell type; these
+// depend on the grid aliases above, so they come last
+#include "grid.h"
 
 
 #endif

--- a/ext/qed/grid.h
+++ b/ext/qed/grid.h
@@ -1,0 +1,48 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+
+// the grid aliases these helpers build on
+#include "external.h"
+// what the implementations need
+#include <optional>
+#include <tuple>
+#include <vector>
+
+
+// support for consuming pyre's type-erased grid: every grid the python side builds presents as a
+// buffer, and these helpers rebuild a read-only typed grid over that buffer and dispatch on its
+// cell type, so one wrapper stands in for the old per-cell-type overload pile
+namespace qed::py {
+    // interpret a python buffer as a read-only grid of rank {dim} and cell type {cellT}, its
+    // extents read from the buffer's own shape, laid over the block the buffer exports
+    template <typename cellT, int dim>
+    auto asGrid(const py::buffer_info & info) -> viewgrid_t<cellT, dim>;
+
+    // interpret a python sequence as a grid index of rank {dim}
+    template <int dim>
+    auto asIndex(const std::vector<std::ptrdiff_t> & seq) -> pyre::grid::index_t<dim>;
+
+    // interpret a python sequence as a grid shape of rank {dim}
+    template <int dim>
+    auto asShape(const std::vector<std::ptrdiff_t> & seq) -> pyre::grid::shape_t<dim>;
+
+    // dispatch on a python buffer's cell format across the candidate cell types {cellTs}: rebuild
+    // a read-only grid of rank {dim} over the buffer's block and hand it to {f}, whichever cell
+    // type matched
+    template <int dim, typename... cellTs, typename F>
+    auto onGrid(const py::buffer & source, F && f);
+} // namespace qed::py
+
+
+// the inline implementations
+#include "grid.icc"
+
+
+// end of file

--- a/ext/qed/grid.h
+++ b/ext/qed/grid.h
@@ -25,13 +25,13 @@ namespace qed::py {
     template <typename cellT, int dim>
     auto asGrid(const py::buffer_info & info) -> viewgrid_t<cellT, dim>;
 
-    // interpret a python sequence as a grid index of rank {dim}
+    // interpret any python iterable (tuple, list, generator, ...) as a grid index of rank {dim}
     template <int dim>
-    auto asIndex(const std::vector<std::ptrdiff_t> & seq) -> pyre::grid::index_t<dim>;
+    auto asIndex(const py::iterable & seq) -> pyre::grid::index_t<dim>;
 
-    // interpret a python sequence as a grid shape of rank {dim}
+    // interpret any python iterable (tuple, list, generator, ...) as a grid shape of rank {dim}
     template <int dim>
-    auto asShape(const std::vector<std::ptrdiff_t> & seq) -> pyre::grid::shape_t<dim>;
+    auto asShape(const py::iterable & seq) -> pyre::grid::shape_t<dim>;
 
     // dispatch on a python buffer's cell format across the candidate cell types {cellTs}: rebuild
     // a read-only grid of rank {dim} over the buffer's block and hand it to {f}, whichever cell

--- a/ext/qed/grid.icc
+++ b/ext/qed/grid.icc
@@ -31,29 +31,31 @@ qed::py::asGrid(const py::buffer_info & info) -> viewgrid_t<cellT, dim>
 }
 
 
-// interpret a python sequence as a grid index of rank {dim}
+// interpret any python iterable as a grid index of rank {dim}
 template <int dim>
 auto
-qed::py::asIndex(const std::vector<std::ptrdiff_t> & seq) -> pyre::grid::index_t<dim>
+qed::py::asIndex(const py::iterable & seq) -> pyre::grid::index_t<dim>
 {
-    // fill it axis by axis
+    // fill it axis by axis from the iterable, so a tuple, list, or generator all work
     pyre::grid::index_t<dim> index;
-    for (int axis = 0; axis < dim; ++axis) {
-        index[axis] = seq[axis];
+    int axis = 0;
+    for (auto coordinate : seq) {
+        index[axis++] = coordinate.cast<std::ptrdiff_t>();
     }
     return index;
 }
 
 
-// interpret a python sequence as a grid shape of rank {dim}
+// interpret any python iterable as a grid shape of rank {dim}
 template <int dim>
 auto
-qed::py::asShape(const std::vector<std::ptrdiff_t> & seq) -> pyre::grid::shape_t<dim>
+qed::py::asShape(const py::iterable & seq) -> pyre::grid::shape_t<dim>
 {
-    // fill it axis by axis
+    // fill it axis by axis from the iterable, so a tuple, list, or generator all work
     pyre::grid::shape_t<dim> shape;
-    for (int axis = 0; axis < dim; ++axis) {
-        shape[axis] = seq[axis];
+    int axis = 0;
+    for (auto extent : seq) {
+        shape[axis++] = extent.cast<std::ptrdiff_t>();
     }
     return shape;
 }

--- a/ext/qed/grid.icc
+++ b/ext/qed/grid.icc
@@ -1,0 +1,94 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+
+// my declarations
+#include "grid.h"
+
+
+// interpret a python buffer as a read-only grid of rank {dim} and cell type {cellT}
+template <typename cellT, int dim>
+auto
+qed::py::asGrid(const py::buffer_info & info) -> viewgrid_t<cellT, dim>
+{
+    // the extents, copied out of the buffer description axis by axis
+    typename viewgrid_t<cellT, dim>::shape_type shape;
+    for (int axis = 0; axis < dim; ++axis) {
+        shape[axis] = info.shape[axis];
+    }
+    // the canonical packing over that shape
+    auto packing = pyre::grid::canonical_t<dim>(shape);
+    // a read-only view over the buffer's block, sized to the packing
+    auto storage = view_t<cellT>(static_cast<const cellT *>(info.ptr), packing.cells());
+    // paired into a grid
+    return viewgrid_t<cellT, dim>(packing, storage);
+}
+
+
+// interpret a python sequence as a grid index of rank {dim}
+template <int dim>
+auto
+qed::py::asIndex(const std::vector<std::ptrdiff_t> & seq) -> pyre::grid::index_t<dim>
+{
+    // fill it axis by axis
+    pyre::grid::index_t<dim> index;
+    for (int axis = 0; axis < dim; ++axis) {
+        index[axis] = seq[axis];
+    }
+    return index;
+}
+
+
+// interpret a python sequence as a grid shape of rank {dim}
+template <int dim>
+auto
+qed::py::asShape(const std::vector<std::ptrdiff_t> & seq) -> pyre::grid::shape_t<dim>
+{
+    // fill it axis by axis
+    pyre::grid::shape_t<dim> shape;
+    for (int axis = 0; axis < dim; ++axis) {
+        shape[axis] = seq[axis];
+    }
+    return shape;
+}
+
+
+// dispatch on a python buffer's cell format across the candidate cell types {cellTs}
+template <int dim, typename... cellTs, typename F>
+auto
+qed::py::onGrid(const py::buffer & source, F && f)
+{
+    // read the buffer description, read-only
+    auto info = source.request();
+    // its rank has to be the one the caller expects
+    if (info.ndim != dim) {
+        // otherwise the caller and the data disagree
+        throw py::value_error("grid rank does not match the expected dimensionality");
+    }
+    // the result type is the same whatever cell we dispatch to; take it from the first candidate
+    using first_t = typename std::tuple_element<0, std::tuple<cellTs...>>::type;
+    using result_t = decltype(f(std::declval<viewgrid_t<first_t, dim>>()));
+    // a slot for it
+    std::optional<result_t> result;
+    // try each candidate; the first whose struct code matches the buffer wins
+    bool matched = (((info.format == py::format_descriptor<cellTs>::format())
+                         ? (result.emplace(f(asGrid<cellTs, dim>(info))), true)
+                         : false)
+                    || ...);
+    // an unmatched cell type is a caller mistake
+    if (!matched) {
+        // say which one
+        throw py::value_error("unsupported grid cell type '" + info.format + "'");
+    }
+    // hand back what {f} produced, moved out since the result may be move-only
+    return std::move(*result);
+}
+
+
+// end of file

--- a/ext/qed/isce2/interferogram/channels.cc
+++ b/ext/qed/isce2/interferogram/channels.cc
@@ -31,8 +31,8 @@ qed::py::isce2::interferogram::channels(py::module & m)
         // the name
         "amplitude",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape, const py::iterable & stride, double min,
            double max) -> bmp_t {
             // rebuild the tile geometry as rank-2 grid coordinates
             auto o = asIndex<2>(origin);
@@ -54,8 +54,8 @@ qed::py::isce2::interferogram::channels(py::module & m)
         // the name
         "complex",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape, const py::iterable & stride, double min,
            double max, double minPhase, double maxPhase) -> bmp_t {
             // rebuild the tile geometry as rank-2 grid coordinates
             auto o = asIndex<2>(origin);
@@ -78,8 +78,8 @@ qed::py::isce2::interferogram::channels(py::module & m)
         // the name
         "imaginary",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape, const py::iterable & stride, double min,
            double max) -> bmp_t {
             // rebuild the tile geometry as rank-2 grid coordinates
             auto o = asIndex<2>(origin);
@@ -101,8 +101,8 @@ qed::py::isce2::interferogram::channels(py::module & m)
         // the name
         "phase",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double low,
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape, const py::iterable & stride, double low,
            double high, double brightness) -> bmp_t {
             // rebuild the tile geometry as rank-2 grid coordinates
             auto o = asIndex<2>(origin);
@@ -125,8 +125,8 @@ qed::py::isce2::interferogram::channels(py::module & m)
         // the name
         "real",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape, const py::iterable & stride, double min,
            double max) -> bmp_t {
             // rebuild the tile geometry as rank-2 grid coordinates
             auto o = asIndex<2>(origin);

--- a/ext/qed/isce2/interferogram/channels.cc
+++ b/ext/qed/isce2/interferogram/channels.cc
@@ -1,4 +1,5 @@
-// -*- c++ -*-
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
 //
 // michael a.g. aïvázis <michael.aivazis@para-sim.com>
 // (c) 1998-2026 all rights reserved
@@ -10,7 +11,7 @@
 #include "forward.h"
 
 
-// submodule with the bindings for the native tile generators
+// submodule with the bindings for the interferogram tile generators
 void
 qed::py::isce2::interferogram::channels(py::module & m)
 {
@@ -19,114 +20,128 @@ qed::py::isce2::interferogram::channels(py::module & m)
         // the name of the module
         "channels",
         // its docstring
-        "support for native {channels}");
+        "support for interferogram {channels}");
 
+    // every source arrives as a buffer — pyre's type-erased grid, or anything else that speaks the
+    // buffer protocol — so one wrapper per channel rebuilds a read-only rank-2 grid over it and
+    // dispatches on its cell type
 
-    // add the individual channel bindings
-    // {c8} amplitude
+    // render the amplitude of a complex tile
     channels.def(
-        // the name of the function
+        // the name
         "amplitude",
         // the handler
-        &qed::isce2::interferogram::channels::amplitude<mapgrid_t<std::complex<float>>>,
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+           double max) -> bmp_t {
+            // rebuild the tile geometry as rank-2 grid coordinates
+            auto o = asIndex<2>(origin);
+            auto t = asShape<2>(shape);
+            auto s = asIndex<2>(stride);
+            // dispatch on the buffer's cell type and run the kernel over the matching grid
+            return onGrid<2, std::complex<float>, std::complex<double>>(
+                source, [&](const auto & grid) {
+                    return qed::isce2::interferogram::channels::amplitude(grid, o, t, s, min, max);
+                });
+        },
         // the signature
         "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the amplitude of a complex float tile");
-    // {c16} amplitude
-    channels.def(
-        // the name of the function
-        "amplitude",
-        // the handler
-        &qed::isce2::interferogram::channels::amplitude<mapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the amplitude of a complex double tile");
+        "render the amplitude of a complex tile");
 
-    // {c8}
+    // render the value of a complex tile
     channels.def(
-        // the name of the function
+        // the name
         "complex",
         // the handler
-        &qed::isce2::interferogram::channels::complex<mapgrid_t<std::complex<float>>>,
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+           double max, double minPhase, double maxPhase) -> bmp_t {
+            // rebuild the tile geometry as rank-2 grid coordinates
+            auto o = asIndex<2>(origin);
+            auto t = asShape<2>(shape);
+            auto s = asIndex<2>(stride);
+            // dispatch on the buffer's cell type and run the kernel over the matching grid
+            return onGrid<2, std::complex<float>, std::complex<double>>(
+                source, [&](const auto & grid) {
+                    return qed::isce2::interferogram::channels::complex(
+                        grid, o, t, s, min, max, minPhase, maxPhase);
+                });
+        },
         // the signature
         "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a, "minPhase"_a, "maxPhase"_a,
         // the docstring
-        "render the value of a complex float tile");
-    // {c16}
-    channels.def(
-        // the name of the function
-        "complex",
-        // the handler
-        &qed::isce2::interferogram::channels::complex<mapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a, "minPhase"_a, "maxPhase"_a,
-        // the docstring
-        "render the value of a complex double tile");
+        "render the value of a complex tile");
 
-    // imaginary part of {c8}
+    // render the imaginary part of a complex tile
     channels.def(
-        // the name of the function
+        // the name
         "imaginary",
         // the handler
-        &qed::isce2::interferogram::channels::imaginary<mapgrid_t<std::complex<float>>>,
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+           double max) -> bmp_t {
+            // rebuild the tile geometry as rank-2 grid coordinates
+            auto o = asIndex<2>(origin);
+            auto t = asShape<2>(shape);
+            auto s = asIndex<2>(stride);
+            // dispatch on the buffer's cell type and run the kernel over the matching grid
+            return onGrid<2, std::complex<float>, std::complex<double>>(
+                source, [&](const auto & grid) {
+                    return qed::isce2::interferogram::channels::imaginary(grid, o, t, s, min, max);
+                });
+        },
         // the signature
         "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the imaginary part a complex float tile");
-    // imaginary part of {c16}
-    channels.def(
-        // the name of the function
-        "imaginary",
-        // the handler
-        &qed::isce2::interferogram::channels::imaginary<mapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the imaginary part of a complex double tile");
+        "render the imaginary part of a complex tile");
 
-    // phase of {c8}
+    // render the phase of a complex tile
     channels.def(
-        // the name of the function
+        // the name
         "phase",
         // the handler
-        &qed::isce2::interferogram::channels::phase<mapgrid_t<std::complex<float>>>,
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double low,
+           double high, double brightness) -> bmp_t {
+            // rebuild the tile geometry as rank-2 grid coordinates
+            auto o = asIndex<2>(origin);
+            auto t = asShape<2>(shape);
+            auto s = asIndex<2>(stride);
+            // dispatch on the buffer's cell type and run the kernel over the matching grid
+            return onGrid<2, std::complex<float>, std::complex<double>>(
+                source, [&](const auto & grid) {
+                    return qed::isce2::interferogram::channels::phase(
+                        grid, o, t, s, low, high, brightness);
+                });
+        },
         // the signature
         "source"_a, "origin"_a, "shape"_a, "stride"_a, "low"_a, "high"_a, "brightness"_a,
         // the docstring
-        "render the phase of a complex float tile");
-    // phase of {c16}
-    channels.def(
-        // the name of the function
-        "phase",
-        // the handler
-        &qed::isce2::interferogram::channels::phase<mapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "low"_a, "high"_a, "brightness"_a,
-        // the docstring
-        "render the phase of a complex double tile");
+        "render the phase of a complex tile");
 
-    // real part of {c8}
+    // render the real part of a complex tile
     channels.def(
-        // the name of the function
+        // the name
         "real",
         // the handler
-        &qed::isce2::interferogram::channels::real<mapgrid_t<std::complex<float>>>,
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+           double max) -> bmp_t {
+            // rebuild the tile geometry as rank-2 grid coordinates
+            auto o = asIndex<2>(origin);
+            auto t = asShape<2>(shape);
+            auto s = asIndex<2>(stride);
+            // dispatch on the buffer's cell type and run the kernel over the matching grid
+            return onGrid<2, std::complex<float>, std::complex<double>>(
+                source, [&](const auto & grid) {
+                    return qed::isce2::interferogram::channels::real(grid, o, t, s, min, max);
+                });
+        },
         // the signature
         "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the real part a complex float tile");
-    // real part of {c16}
-    channels.def(
-        // the name of the function
-        "real",
-        // the handler
-        &qed::isce2::interferogram::channels::real<mapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the real part of a complex double tile");
+        "render the real part of a complex tile");
 
     // all done
     return;

--- a/ext/qed/isce2/interferogram/profile.cc
+++ b/ext/qed/isce2/interferogram/profile.cc
@@ -1,4 +1,5 @@
-// -*- c++ -*-
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
 //
 // michael a.g. aïvázis <michael.aivazis@para-sim.com>
 // (c) 1998-2026 all rights reserved
@@ -14,22 +15,21 @@
 void
 qed::py::isce2::interferogram::profile(py::module & m)
 {
-    // bindings for {mapgrid_t} sources
+    // the source arrives as a buffer; one wrapper rebuilds a read-only rank-2 grid over it and
+    // dispatches on its cell type
     m.def(
         // the name of the function
         "profile",
         // the handler
-        &qed::native::profile<mapgrid_t<std::complex<float>>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<mapgrid_t<std::complex<double>>>,
+        [](const py::buffer & source, const qed::native::points_t & points,
+           bool closed) -> py::object {
+            // dispatch on the buffer's cell type and collect values along the path; the result's
+            // cell type varies, so hand it back as a python object rather than one fixed type
+            return onGrid<2, std::complex<float>, std::complex<double>>(
+                source, [&](const auto & grid) -> py::object {
+                    return py::cast(qed::native::profile(grid, points, closed));
+                });
+        },
         // the signature
         "source"_a, "points"_a, "closed"_a = false,
         // the docstring

--- a/ext/qed/isce2/interferogram/stats.cc
+++ b/ext/qed/isce2/interferogram/stats.cc
@@ -21,8 +21,8 @@ qed::py::isce2::interferogram::stats(py::module & m)
         // the name of the function
         "stats",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape) -> stats_t {
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape) -> stats_t {
             // rebuild the tile geometry as rank-2 grid coordinates
             auto o = asIndex<2>(origin);
             auto t = asShape<2>(shape);

--- a/ext/qed/isce2/interferogram/stats.cc
+++ b/ext/qed/isce2/interferogram/stats.cc
@@ -1,4 +1,5 @@
-// -*- c++ -*-
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
 //
 // michael a.g. aïvázis <michael.aivazis@para-sim.com>
 // (c) 1998-2026 all rights reserved
@@ -14,27 +15,25 @@
 void
 qed::py::isce2::interferogram::stats(py::module & m)
 {
-    // bindings for {mapgrid_t} sources
+    // the source arrives as a buffer; one wrapper rebuilds a read-only rank-2 grid over it and
+    // dispatches on its cell type
     m.def(
         // the name of the function
         "stats",
         // the handler
-        &qed::native::stats<mapgrid_t<std::complex<float>>>,
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape) -> stats_t {
+            // rebuild the tile geometry as rank-2 grid coordinates
+            auto o = asIndex<2>(origin);
+            auto t = asShape<2>(shape);
+            // dispatch on the buffer's cell type and collect the statistics of the matching grid
+            return onGrid<2, std::complex<float>, std::complex<double>>(
+                source, [&](const auto & grid) { return qed::native::stats(grid, o, t); });
+        },
         // the signature
         "source"_a, "origin"_a, "shape"_a,
         // the docstring
-        "collect statistics on a subset of a dataset");
-
-    // bindings for {mapgrid_t} sources
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<mapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
+        "compute the statistics of a tile");
 
     // all done
     return;

--- a/ext/qed/isce2/unwrapped/channels.cc
+++ b/ext/qed/isce2/unwrapped/channels.cc
@@ -31,8 +31,8 @@ qed::py::isce2::unwrapped::channels(py::module & m)
         // the name
         "amplitude",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double mean,
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape, const py::iterable & stride, double mean,
            double scale, double exponent) -> bmp_t {
             // rebuild the tile geometry as rank-3 grid coordinates
             auto o = asIndex<3>(origin);
@@ -54,8 +54,8 @@ qed::py::isce2::unwrapped::channels(py::module & m)
         // the name
         "complex",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double mean,
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape, const py::iterable & stride, double mean,
            double scale, double exponent, double minPhase, double maxPhase) -> bmp_t {
             // rebuild the tile geometry as rank-3 grid coordinates
             auto o = asIndex<3>(origin);
@@ -78,8 +78,8 @@ qed::py::isce2::unwrapped::channels(py::module & m)
         // the name
         "phase",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double low,
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape, const py::iterable & stride, double low,
            double high, double brightness) -> bmp_t {
             // rebuild the tile geometry as rank-3 grid coordinates
             auto o = asIndex<3>(origin);

--- a/ext/qed/isce2/unwrapped/channels.cc
+++ b/ext/qed/isce2/unwrapped/channels.cc
@@ -1,4 +1,5 @@
-// -*- c++ -*-
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
 //
 // michael a.g. aïvázis <michael.aivazis@para-sim.com>
 // (c) 1998-2026 all rights reserved
@@ -10,7 +11,7 @@
 #include "forward.h"
 
 
-// submodule with the bindings for the native tile generators
+// submodule with the bindings for the unwrapped tile generators
 void
 qed::py::isce2::unwrapped::channels(py::module & m)
 {
@@ -19,75 +20,80 @@ qed::py::isce2::unwrapped::channels(py::module & m)
         // the name of the module
         "channels",
         // its docstring
-        "support for native {channels}");
+        "support for unwrapped {channels}");
 
+    // every source arrives as a buffer — pyre's type-erased grid, or anything else that speaks the
+    // buffer protocol — so one wrapper per channel rebuilds a read-only rank-3 grid over it and
+    // dispatches on its cell type
 
-    // add the individual channel bindings
-    // {c8} amplitude
+    // render the amplitude of a tile
     channels.def(
-        // the name of the function
+        // the name
         "amplitude",
         // the handler
-        &qed::isce2::unwrapped::channels::amplitude<mapgrid_t<float, 3>>,
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double mean,
+           double scale, double exponent) -> bmp_t {
+            // rebuild the tile geometry as rank-3 grid coordinates
+            auto o = asIndex<3>(origin);
+            auto t = asShape<3>(shape);
+            auto s = asIndex<3>(stride);
+            // dispatch on the buffer's cell type and run the kernel over the matching grid
+            return onGrid<3, float, double>(source, [&](const auto & grid) {
+                return qed::isce2::unwrapped::channels::amplitude(
+                    grid, o, t, s, mean, scale, exponent);
+            });
+        },
         // the signature
         "source"_a, "origin"_a, "shape"_a, "stride"_a, "mean"_a, "scale"_a, "exponent"_a,
         // the docstring
-        "render the amplitude of a complex float tile");
-    // {c16} amplitude
-    channels.def(
-        // the name of the function
-        "amplitude",
-        // the handler
-        &qed::isce2::unwrapped::channels::amplitude<mapgrid_t<double, 3>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "mean"_a, "scale"_a, "exponent"_a,
-        // the docstring
-        "render the amplitude of a complex double tile");
+        "render the amplitude of a tile");
 
-    // {c8}
+    // render the value of a tile
     channels.def(
-        // the name of the function
+        // the name
         "complex",
         // the handler
-        &qed::isce2::unwrapped::channels::complex<mapgrid_t<float, 3>>,
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double mean,
+           double scale, double exponent, double minPhase, double maxPhase) -> bmp_t {
+            // rebuild the tile geometry as rank-3 grid coordinates
+            auto o = asIndex<3>(origin);
+            auto t = asShape<3>(shape);
+            auto s = asIndex<3>(stride);
+            // dispatch on the buffer's cell type and run the kernel over the matching grid
+            return onGrid<3, float, double>(source, [&](const auto & grid) {
+                return qed::isce2::unwrapped::channels::complex(
+                    grid, o, t, s, mean, scale, exponent, minPhase, maxPhase);
+            });
+        },
         // the signature
         "source"_a, "origin"_a, "shape"_a, "stride"_a, "mean"_a, "scale"_a, "exponent"_a,
         "minPhase"_a, "maxPhase"_a,
         // the docstring
-        "render the value of a complex float tile");
-    // {c16}
-    channels.def(
-        // the name of the function
-        "complex",
-        // the handler
-        &qed::isce2::unwrapped::channels::complex<mapgrid_t<double, 3>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "mean"_a, "scale"_a, "exponent"_a,
-        "minPhase"_a, "maxPhase"_a,
-        // the docstring
-        "render the value of a complex double tile");
+        "render the value of a tile");
 
-    // phase of {c8}
+    // render the phase of a tile
     channels.def(
-        // the name of the function
+        // the name
         "phase",
         // the handler
-        &qed::isce2::unwrapped::channels::phase<mapgrid_t<float, 3>>,
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double low,
+           double high, double brightness) -> bmp_t {
+            // rebuild the tile geometry as rank-3 grid coordinates
+            auto o = asIndex<3>(origin);
+            auto t = asShape<3>(shape);
+            auto s = asIndex<3>(stride);
+            // dispatch on the buffer's cell type and run the kernel over the matching grid
+            return onGrid<3, float, double>(source, [&](const auto & grid) {
+                return qed::isce2::unwrapped::channels::phase(grid, o, t, s, low, high, brightness);
+            });
+        },
         // the signature
         "source"_a, "origin"_a, "shape"_a, "stride"_a, "low"_a, "high"_a, "brightness"_a,
         // the docstring
-        "render the phase of a complex float tile");
-    // phase of {c16}
-    channels.def(
-        // the name of the function
-        "phase",
-        // the handler
-        &qed::isce2::unwrapped::channels::phase<mapgrid_t<double, 3>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "low"_a, "high"_a, "brightness"_a,
-        // the docstring
-        "render the phase of a complex double tile");
-
+        "render the phase of a tile");
 
     // all done
     return;

--- a/ext/qed/isce2/unwrapped/profile.cc
+++ b/ext/qed/isce2/unwrapped/profile.cc
@@ -1,4 +1,5 @@
-// -*- c++ -*-
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
 //
 // michael a.g. aïvázis <michael.aivazis@para-sim.com>
 // (c) 1998-2026 all rights reserved
@@ -14,22 +15,20 @@
 void
 qed::py::isce2::unwrapped::profile(py::module & m)
 {
-    // bindings for {mapgrid_t} sources
+    // the source arrives as a buffer; one wrapper rebuilds a read-only rank-3 grid over it and
+    // dispatches on its cell type
     m.def(
         // the name of the function
         "profile",
         // the handler
-        &qed::isce2::unwrapped::profile<mapgrid_t<float, 3>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::isce2::unwrapped::profile<mapgrid_t<double, 3>>,
+        [](const py::buffer & source, const qed::native::points_t & points,
+           bool closed) -> py::object {
+            // dispatch on the buffer's cell type and collect values along the path; the result's
+            // cell type varies, so hand it back as a python object rather than one fixed type
+            return onGrid<3, float, double>(source, [&](const auto & grid) -> py::object {
+                return py::cast(qed::isce2::unwrapped::profile(grid, points, closed));
+            });
+        },
         // the signature
         "source"_a, "points"_a, "closed"_a = false,
         // the docstring

--- a/ext/qed/isce2/unwrapped/stats.cc
+++ b/ext/qed/isce2/unwrapped/stats.cc
@@ -1,4 +1,5 @@
-// -*- c++ -*-
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
 //
 // michael a.g. aïvázis <michael.aivazis@para-sim.com>
 // (c) 1998-2026 all rights reserved
@@ -14,27 +15,25 @@
 void
 qed::py::isce2::unwrapped::stats(py::module & m)
 {
-    // bindings for {mapgrid_t} sources
+    // the source arrives as a buffer; one wrapper rebuilds a read-only rank-3 grid over it and
+    // dispatches on its cell type
     m.def(
         // the name of the function
         "stats",
         // the handler
-        &qed::isce2::unwrapped::stats<mapgrid_t<float, 3>>,
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape) -> stats_t {
+            // rebuild the tile geometry as rank-3 grid coordinates
+            auto o = asIndex<3>(origin);
+            auto t = asShape<3>(shape);
+            // dispatch on the buffer's cell type and collect the statistics of the matching grid
+            return onGrid<3, float, double>(
+                source, [&](const auto & grid) { return qed::isce2::unwrapped::stats(grid, o, t); });
+        },
         // the signature
         "source"_a, "origin"_a, "shape"_a,
         // the docstring
-        "collect statistics on a subset of a dataset");
-
-    // bindings for {mapgrid_t} sources
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::isce2::unwrapped::stats<mapgrid_t<double, 3>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
+        "compute the statistics of a tile");
 
     // all done
     return;

--- a/ext/qed/isce2/unwrapped/stats.cc
+++ b/ext/qed/isce2/unwrapped/stats.cc
@@ -21,8 +21,8 @@ qed::py::isce2::unwrapped::stats(py::module & m)
         // the name of the function
         "stats",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape) -> stats_t {
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape) -> stats_t {
             // rebuild the tile geometry as rank-3 grid coordinates
             auto o = asIndex<3>(origin);
             auto t = asShape<3>(shape);

--- a/ext/qed/native/channels.cc
+++ b/ext/qed/native/channels.cc
@@ -1,4 +1,5 @@
-// -*- c++ -*-
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
 //
 // michael a.g. aïvázis <michael.aivazis@para-sim.com>
 // (c) 1998-2026 all rights reserved
@@ -21,276 +22,78 @@ qed::py::native::channels(py::module & m)
         // its docstring
         "support for native {channels}");
 
+    // every source arrives as a buffer — pyre's type-erased grid, or anything else that speaks the
+    // buffer protocol — so one wrapper per channel rebuilds a read-only rank-2 grid over it and
+    // dispatches on its cell type, standing in for the old per-cell-type overload pile
 
-    // add the individual channel bindings
-    // {b} value
-    channels.def(
-        // the name of the function
-        "value",
-        // the handler
-        &qed::native::channels::value<mapgrid_t<char>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the value of a byte tile");
-    // {i2} value
-    channels.def(
-        // the name of the function
-        "value",
-        // the handler
-        &qed::native::channels::value<mapgrid_t<int16_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the value of a int16_t tile");
-    // {i4} value
-    channels.def(
-        // the name of the function
-        "value",
-        // the handler
-        &qed::native::channels::value<mapgrid_t<int32_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the value of an int32_t tile");
-    // {i8} value
-    channels.def(
-        // the name of the function
-        "value",
-        // the handler
-        &qed::native::channels::value<mapgrid_t<int64_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the value of a int64_t tile");
-    // {r4} value
-    channels.def(
-        // the name of the function
-        "value",
-        // the handler
-        &qed::native::channels::value<mapgrid_t<float>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the value of a float tile");
-    // {r8} value
-    channels.def(
-        // the name of the function
-        "value",
-        // the handler
-        &qed::native::channels::value<mapgrid_t<double>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the value of a double tile");
-
-    // add the individual channel bindings for views
-    // {b} value
-    channels.def(
-        // the name of the function
-        "value",
-        // the handler
-        &qed::native::channels::value<viewgrid_t<char>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the value of a byte tile");
-    // {i2} value
-    channels.def(
-        // the name of the function
-        "value",
-        // the handler
-        &qed::native::channels::value<viewgrid_t<int16_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the value of a int16_t tile");
-    // {i4} value
-    channels.def(
-        // the name of the function
-        "value",
-        // the handler
-        &qed::native::channels::value<viewgrid_t<int32_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the value of an int32_t tile");
-    // {i8} value
-    channels.def(
-        // the name of the function
-        "value",
-        // the handler
-        &qed::native::channels::value<viewgrid_t<int64_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the value of a int64_t tile");
-    // {r4} value
-    channels.def(
-        // the name of the function
-        "value",
-        // the handler
-        &qed::native::channels::value<viewgrid_t<float>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the value of a float tile");
-    // {r8} value
-    channels.def(
-        // the name of the function
-        "value",
-        // the handler
-        &qed::native::channels::value<viewgrid_t<double>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the value of a double tile");
-
-    // {b} abs
-    channels.def(
-        // the name of the function
-        "abs",
-        // the handler
-        &qed::native::channels::magnitude<mapgrid_t<char>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the absolute value of a byte tile");
-    // {i2} abs
-    channels.def(
-        // the name of the function
-        "abs",
-        // the handler
-        &qed::native::channels::magnitude<mapgrid_t<int16_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the absolute value of a int16_t tile");
-    // {i4} abs
-    channels.def(
-        // the name of the function
-        "abs",
-        // the handler
-        &qed::native::channels::magnitude<mapgrid_t<int32_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the absolute value of an int32_t tile");
-    // {i8} abs
-    channels.def(
-        // the name of the function
-        "abs",
-        // the handler
-        &qed::native::channels::magnitude<mapgrid_t<int64_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the absolute value of a int64_t tile");
-    // {r4} abs
-    channels.def(
-        // the name of the function
-        "abs",
-        // the handler
-        &qed::native::channels::magnitude<mapgrid_t<float>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the absolute value of a float tile");
-    // {r8} abs
-    channels.def(
-        // the name of the function
-        "abs",
-        // the handler
-        &qed::native::channels::magnitude<mapgrid_t<double>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the absolute value of a double tile");
-
-    // {b} abs
-    channels.def(
-        // the name of the function
-        "abs",
-        // the handler
-        &qed::native::channels::magnitude<viewgrid_t<char>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the absolute value of a byte tile");
-    // {i2} abs
-    channels.def(
-        // the name of the function
-        "abs",
-        // the handler
-        &qed::native::channels::magnitude<viewgrid_t<int16_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the absolute value of a int16_t tile");
-    // {i4} abs
-    channels.def(
-        // the name of the function
-        "abs",
-        // the handler
-        &qed::native::channels::magnitude<viewgrid_t<int32_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the absolute value of an int32_t tile");
-    // {i8} abs
-    channels.def(
-        // the name of the function
-        "abs",
-        // the handler
-        &qed::native::channels::magnitude<viewgrid_t<int64_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the absolute value of a int64_t tile");
-    // {r4} abs
-    channels.def(
-        // the name of the function
-        "abs",
-        // the handler
-        &qed::native::channels::magnitude<viewgrid_t<float>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the absolute value of a float tile");
-    // {r8} abs
-    channels.def(
-        // the name of the function
-        "abs",
-        // the handler
-        &qed::native::channels::magnitude<viewgrid_t<double>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the absolute value of a double tile");
-
+    // render the value of a real tile
     channels.def(
         // the name
         "value",
         // the handler
-        [](py::array_t<float, py::array::c_style | py::array::forcecast> source, shape2d_t shape,
-           float low, float high) {
-            // type aliases
-            // the normalizer
-            using norm_t = parametric_t<const float *>;
-            // the color map
-            using colormap_t = gray_t<norm_t>;
-            // get the array data buffer
-            auto buffer = static_cast<const float *>(source.request().ptr);
-            // map to the unit interval
-            auto norm = norm_t(buffer, norm_t::interval_type(low, high));
-            // generate color
-            auto colormap = colormap_t(norm);
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+           double max) -> bmp_t {
+            // rebuild the tile geometry as rank-2 grid coordinates
+            auto o = asIndex<2>(origin);
+            auto t = asShape<2>(shape);
+            auto s = asIndex<2>(stride);
+            // dispatch on the buffer's cell type and run the kernel over the matching grid
+            return onGrid<2, char, int16_t, int32_t, int64_t, float, double>(
+                source, [&](const auto & grid) {
+                    return qed::native::channels::value(grid, o, t, s, min, max);
+                });
+        },
+        // the signature
+        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
+        // the docstring
+        "render the value of a real tile");
 
-            // make a bitmap
+    // render the absolute value of a real tile
+    channels.def(
+        // the name
+        "abs",
+        // the handler
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+           double max) -> bmp_t {
+            // rebuild the tile geometry as rank-2 grid coordinates
+            auto o = asIndex<2>(origin);
+            auto t = asShape<2>(shape);
+            auto s = asIndex<2>(stride);
+            // dispatch on the buffer's cell type and run the kernel over the matching grid
+            return onGrid<2, char, int16_t, int32_t, int64_t, float, double>(
+                source, [&](const auto & grid) {
+                    return qed::native::channels::magnitude(grid, o, t, s, min, max);
+                });
+        },
+        // the signature
+        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
+        // the docstring
+        "render the absolute value of a real tile");
+
+    // render the value of a numpy array directly, without going through a grid
+    channels.def(
+        // the name
+        "value",
+        // the handler
+        [](py::array_t<float, py::array::c_style | py::array::forcecast> source,
+           std::vector<std::ptrdiff_t> shape, float low, float high) -> bmp_t {
+            // the normalizer maps a range of values to the unit interval
+            using norm_t = parametric_t<const float *>;
+            // and the color map turns that into gray
+            using colormap_t = gray_t<norm_t>;
+            // get the array's data buffer
+            auto buffer = static_cast<const float *>(source.request().ptr);
+            // map it to the unit interval
+            auto norm = norm_t(buffer, norm_t::interval_type(low, high));
+            // generate the color
+            auto colormap = colormap_t(norm);
+            // make a bitmap of the requested shape
             bmp_t bmp(shape[0], shape[1]);
-            // render
+            // render into it
             bmp.encode(colormap);
-            // and return it
+            // and hand it back
             return bmp;
         },
         // the signature
@@ -298,223 +101,123 @@ qed::py::native::channels(py::module & m)
         // the docstring
         "render the values of a numpy array");
 
-    // {c8} amplitude
+    // render the value of a complex tile
     channels.def(
-        // the name of the function
-        "amplitude",
-        // the handler
-        &qed::native::channels::amplitude<mapgrid_t<std::complex<float>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the amplitude of a complex float tile");
-    // {c16} amplitude
-    channels.def(
-        // the name of the function
-        "amplitude",
-        // the handler
-        &qed::native::channels::amplitude<mapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the amplitude of a complex double tile");
-
-    // {c8}
-    channels.def(
-        // the name of the function
+        // the name
         "complex",
         // the handler
-        &qed::native::channels::complex<mapgrid_t<std::complex<float>>>,
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+           double max, double minPhase, double maxPhase, double saturation) -> bmp_t {
+            // rebuild the tile geometry as rank-2 grid coordinates
+            auto o = asIndex<2>(origin);
+            auto t = asShape<2>(shape);
+            auto s = asIndex<2>(stride);
+            // dispatch on the buffer's cell type and run the kernel over the matching grid
+            return onGrid<2, std::complex<float>, std::complex<double>>(
+                source, [&](const auto & grid) {
+                    return qed::native::channels::complex(
+                        grid, o, t, s, min, max, minPhase, maxPhase, saturation);
+                });
+        },
         // the signature
         "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a, "minPhase"_a, "maxPhase"_a,
         "saturation"_a,
         // the docstring
-        "render the value of a complex float tile");
-    // {c16}
-    channels.def(
-        // the name of the function
-        "complex",
-        // the handler
-        &qed::native::channels::complex<mapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a, "minPhase"_a, "maxPhase"_a,
-        "saturation"_a,
-        // the docstring
-        "render the value of a complex double tile");
+        "render the value of a complex tile");
 
-    // imaginary part of {c8}
+    // render the amplitude of a complex tile
     channels.def(
-        // the name of the function
-        "imaginary",
-        // the handler
-        &qed::native::channels::imaginary<mapgrid_t<std::complex<float>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the imaginary part a complex float tile");
-    // imaginary part of {c16}
-    channels.def(
-        // the name of the function
-        "imaginary",
-        // the handler
-        &qed::native::channels::imaginary<mapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the imaginary part of a complex double tile");
-
-    // phase of {c8}
-    channels.def(
-        // the name of the function
-        "phase",
-        // the handler
-        &qed::native::channels::phase<mapgrid_t<std::complex<float>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "low"_a, "high"_a, "saturation"_a,
-        "brightness"_a,
-        // the docstring
-        "render the phase of a complex float tile");
-    // phase of {c16}
-    channels.def(
-        // the name of the function
-        "phase",
-        // the handler
-        &qed::native::channels::phase<mapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "low"_a, "high"_a, "saturation"_a,
-        "brightness"_a,
-        // the docstring
-        "render the phase of a complex double tile");
-
-    // real part of {c8}
-    channels.def(
-        // the name of the function
-        "real",
-        // the handler
-        &qed::native::channels::real<mapgrid_t<std::complex<float>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the real part a complex float tile");
-    // real part of {c16}
-    channels.def(
-        // the name of the function
-        "real",
-        // the handler
-        &qed::native::channels::real<mapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the real part of a complex double tile");
-
-    // {c8} amplitude
-    channels.def(
-        // the name of the function
+        // the name
         "amplitude",
         // the handler
-        &qed::native::channels::amplitude<viewgrid_t<std::complex<float>>>,
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+           double max) -> bmp_t {
+            // rebuild the tile geometry as rank-2 grid coordinates
+            auto o = asIndex<2>(origin);
+            auto t = asShape<2>(shape);
+            auto s = asIndex<2>(stride);
+            // dispatch on the buffer's cell type and run the kernel over the matching grid
+            return onGrid<2, std::complex<float>, std::complex<double>>(
+                source, [&](const auto & grid) {
+                    return qed::native::channels::amplitude(grid, o, t, s, min, max);
+                });
+        },
         // the signature
         "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the amplitude of a complex float tile");
-    // {c16} amplitude
-    channels.def(
-        // the name of the function
-        "amplitude",
-        // the handler
-        &qed::native::channels::amplitude<viewgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the amplitude of a complex double tile");
+        "render the amplitude of a complex tile");
 
-    // {c8}
+    // render the phase of a complex tile
     channels.def(
-        // the name of the function
-        "complex",
-        // the handler
-        &qed::native::channels::complex<viewgrid_t<std::complex<float>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a, "minPhase"_a, "maxPhase"_a,
-        "saturation"_a,
-        // the docstring
-        "render the value of a complex float tile");
-    // {c16}
-    channels.def(
-        // the name of the function
-        "complex",
-        // the handler
-        &qed::native::channels::complex<viewgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a, "minPhase"_a, "maxPhase"_a,
-        "saturation"_a,
-        // the docstring
-        "render the value of a complex double tile");
-
-    // imaginary part of {c8}
-    channels.def(
-        // the name of the function
-        "imaginary",
-        // the handler
-        &qed::native::channels::imaginary<viewgrid_t<std::complex<float>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the imaginary part a complex float tile");
-    // imaginary part of {c16}
-    channels.def(
-        // the name of the function
-        "imaginary",
-        // the handler
-        &qed::native::channels::imaginary<viewgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the imaginary part of a complex double tile");
-
-    // phase of {c8}
-    channels.def(
-        // the name of the function
+        // the name
         "phase",
         // the handler
-        &qed::native::channels::phase<viewgrid_t<std::complex<float>>>,
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double low,
+           double high, double saturation, double brightness) -> bmp_t {
+            // rebuild the tile geometry as rank-2 grid coordinates
+            auto o = asIndex<2>(origin);
+            auto t = asShape<2>(shape);
+            auto s = asIndex<2>(stride);
+            // dispatch on the buffer's cell type and run the kernel over the matching grid
+            return onGrid<2, std::complex<float>, std::complex<double>>(
+                source, [&](const auto & grid) {
+                    return qed::native::channels::phase(grid, o, t, s, low, high, saturation, brightness);
+                });
+        },
         // the signature
         "source"_a, "origin"_a, "shape"_a, "stride"_a, "low"_a, "high"_a, "saturation"_a,
         "brightness"_a,
         // the docstring
-        "render the phase of a complex float tile");
-    // phase of {c16}
-    channels.def(
-        // the name of the function
-        "phase",
-        // the handler
-        &qed::native::channels::phase<viewgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a, "stride"_a, "low"_a, "high"_a, "saturation"_a,
-        "brightness"_a,
-        // the docstring
-        "render the phase of a complex double tile");
+        "render the phase of a complex tile");
 
-    // real part of {c8}
+    // render the real part of a complex tile
     channels.def(
-        // the name of the function
+        // the name
         "real",
         // the handler
-        &qed::native::channels::real<viewgrid_t<std::complex<float>>>,
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+           double max) -> bmp_t {
+            // rebuild the tile geometry as rank-2 grid coordinates
+            auto o = asIndex<2>(origin);
+            auto t = asShape<2>(shape);
+            auto s = asIndex<2>(stride);
+            // dispatch on the buffer's cell type and run the kernel over the matching grid
+            return onGrid<2, std::complex<float>, std::complex<double>>(
+                source, [&](const auto & grid) {
+                    return qed::native::channels::real(grid, o, t, s, min, max);
+                });
+        },
         // the signature
         "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the real part a complex float tile");
-    // real part of {c16}
+        "render the real part of a complex tile");
+
+    // render the imaginary part of a complex tile
     channels.def(
-        // the name of the function
-        "real",
+        // the name
+        "imaginary",
         // the handler
-        &qed::native::channels::real<viewgrid_t<std::complex<double>>>,
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+           double max) -> bmp_t {
+            // rebuild the tile geometry as rank-2 grid coordinates
+            auto o = asIndex<2>(origin);
+            auto t = asShape<2>(shape);
+            auto s = asIndex<2>(stride);
+            // dispatch on the buffer's cell type and run the kernel over the matching grid
+            return onGrid<2, std::complex<float>, std::complex<double>>(
+                source, [&](const auto & grid) {
+                    return qed::native::channels::imaginary(grid, o, t, s, min, max);
+                });
+        },
         // the signature
         "source"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the real part of a complex double tile");
+        "render the imaginary part of a complex tile");
 
     // all done
     return;

--- a/ext/qed/native/channels.cc
+++ b/ext/qed/native/channels.cc
@@ -31,8 +31,8 @@ qed::py::native::channels(py::module & m)
         // the name
         "value",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape, const py::iterable & stride, double min,
            double max) -> bmp_t {
             // rebuild the tile geometry as rank-2 grid coordinates
             auto o = asIndex<2>(origin);
@@ -54,8 +54,8 @@ qed::py::native::channels(py::module & m)
         // the name
         "abs",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape, const py::iterable & stride, double min,
            double max) -> bmp_t {
             // rebuild the tile geometry as rank-2 grid coordinates
             auto o = asIndex<2>(origin);
@@ -78,7 +78,7 @@ qed::py::native::channels(py::module & m)
         "value",
         // the handler
         [](py::array_t<float, py::array::c_style | py::array::forcecast> source,
-           std::vector<std::ptrdiff_t> shape, float low, float high) -> bmp_t {
+           const py::iterable & shape, float low, float high) -> bmp_t {
             // the normalizer maps a range of values to the unit interval
             using norm_t = parametric_t<const float *>;
             // and the color map turns that into gray
@@ -89,8 +89,10 @@ qed::py::native::channels(py::module & m)
             auto norm = norm_t(buffer, norm_t::interval_type(low, high));
             // generate the color
             auto colormap = colormap_t(norm);
-            // make a bitmap of the requested shape
-            bmp_t bmp(shape[0], shape[1]);
+            // realize the requested shape as rank-2 grid extents
+            auto s = asShape<2>(shape);
+            // make a bitmap of that shape
+            bmp_t bmp(s[0], s[1]);
             // render into it
             bmp.encode(colormap);
             // and hand it back
@@ -106,8 +108,8 @@ qed::py::native::channels(py::module & m)
         // the name
         "complex",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape, const py::iterable & stride, double min,
            double max, double minPhase, double maxPhase, double saturation) -> bmp_t {
             // rebuild the tile geometry as rank-2 grid coordinates
             auto o = asIndex<2>(origin);
@@ -131,8 +133,8 @@ qed::py::native::channels(py::module & m)
         // the name
         "amplitude",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape, const py::iterable & stride, double min,
            double max) -> bmp_t {
             // rebuild the tile geometry as rank-2 grid coordinates
             auto o = asIndex<2>(origin);
@@ -154,8 +156,8 @@ qed::py::native::channels(py::module & m)
         // the name
         "phase",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double low,
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape, const py::iterable & stride, double low,
            double high, double saturation, double brightness) -> bmp_t {
             // rebuild the tile geometry as rank-2 grid coordinates
             auto o = asIndex<2>(origin);
@@ -178,8 +180,8 @@ qed::py::native::channels(py::module & m)
         // the name
         "real",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape, const py::iterable & stride, double min,
            double max) -> bmp_t {
             // rebuild the tile geometry as rank-2 grid coordinates
             auto o = asIndex<2>(origin);
@@ -201,8 +203,8 @@ qed::py::native::channels(py::module & m)
         // the name
         "imaginary",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape, std::vector<std::ptrdiff_t> stride, double min,
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape, const py::iterable & stride, double min,
            double max) -> bmp_t {
             // rebuild the tile geometry as rank-2 grid coordinates
             auto o = asIndex<2>(origin);

--- a/ext/qed/native/profile.cc
+++ b/ext/qed/native/profile.cc
@@ -1,4 +1,5 @@
-// -*- c++ -*-
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
 //
 // michael a.g. aïvázis <michael.aivazis@para-sim.com>
 // (c) 1998-2026 all rights reserved
@@ -14,183 +15,22 @@
 void
 qed::py::native::profile(py::module & m)
 {
-    // bindings for {mapgrid_t} sources
+    // the source arrives as a buffer; one wrapper rebuilds a read-only rank-2 grid over it and
+    // dispatches on its cell type, standing in for the old per-cell-type overload pile
     m.def(
         // the name of the function
         "profile",
         // the handler
-        &qed::native::profile<mapgrid_t<char>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a = false,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<mapgrid_t<int8_t>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a = false,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<mapgrid_t<int16_t>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a = false,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<mapgrid_t<int32_t>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a = false,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<mapgrid_t<int64_t>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a = false,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<mapgrid_t<float>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a = false,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<mapgrid_t<double>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a = false,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<mapgrid_t<std::complex<float>>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a = false,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<mapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a = false,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    // bindings for {viewgrid_t} sources
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<viewgrid_t<char>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a = false,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<viewgrid_t<int8_t>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a = false,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<viewgrid_t<int16_t>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a = false,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<viewgrid_t<int32_t>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a = false,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<viewgrid_t<int64_t>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a = false,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<viewgrid_t<float>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a = false,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<viewgrid_t<double>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a = false,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<viewgrid_t<std::complex<float>>>,
-        // the signature
-        "source"_a, "points"_a, "closed"_a = false,
-        // the docstring
-        "collect values from a dataset along a path");
-
-    m.def(
-        // the name of the function
-        "profile",
-        // the handler
-        &qed::native::profile<viewgrid_t<std::complex<double>>>,
+        [](const py::buffer & source, const qed::native::points_t & points,
+           bool closed) -> py::object {
+            // dispatch on the buffer's cell type and collect values along the path; the result's
+            // cell type varies, so hand it back as a python object rather than one fixed type
+            return onGrid<2, char, int8_t, int16_t, int32_t, int64_t, float, double,
+                          std::complex<float>, std::complex<double>>(
+                source, [&](const auto & grid) -> py::object {
+                    return py::cast(qed::native::profile(grid, points, closed));
+                });
+        },
         // the signature
         "source"_a, "points"_a, "closed"_a = false,
         // the docstring

--- a/ext/qed/native/stats.cc
+++ b/ext/qed/native/stats.cc
@@ -1,4 +1,5 @@
-// -*- c++ -*-
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
 //
 // michael a.g. aïvázis <michael.aivazis@para-sim.com>
 // (c) 1998-2026 all rights reserved
@@ -14,191 +15,26 @@
 void
 qed::py::native::stats(py::module & m)
 {
-    // bindings for {mapgrid_t} sources
+    // the source arrives as a buffer; one wrapper rebuilds a read-only rank-2 grid over it and
+    // dispatches on its cell type, standing in for the old per-cell-type overload pile
     m.def(
         // the name of the function
         "stats",
         // the handler
-        &qed::native::stats<mapgrid_t<char>>,
+        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
+           std::vector<std::ptrdiff_t> shape) -> stats_t {
+            // rebuild the tile geometry as rank-2 grid coordinates
+            auto o = asIndex<2>(origin);
+            auto t = asShape<2>(shape);
+            // dispatch on the buffer's cell type and collect the statistics of the matching grid
+            return onGrid<2, char, int8_t, int16_t, int32_t, int64_t, float, double,
+                          std::complex<float>, std::complex<double>>(
+                source, [&](const auto & grid) { return qed::native::stats(grid, o, t); });
+        },
         // the signature
         "source"_a, "origin"_a, "shape"_a,
         // the docstring
-        "collect statistics on a subset of a dataset");
-
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<mapgrid_t<int8_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
-
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<mapgrid_t<int16_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
-
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<mapgrid_t<int32_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
-
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<mapgrid_t<int64_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
-
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<mapgrid_t<float>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
-
-    // bindings for {mapgrid_t} sources
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<mapgrid_t<double>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
-
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<mapgrid_t<std::complex<float>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
-
-    // bindings for {mapgrid_t} sources
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<mapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
-
-    // bindings for {viewgrid_t} sources
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<viewgrid_t<char>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
-
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<viewgrid_t<int8_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
-
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<viewgrid_t<int16_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
-
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<viewgrid_t<int32_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
-
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<viewgrid_t<int64_t>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
-
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<viewgrid_t<float>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
-
-    // bindings for {viewgrid_t} sources
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<viewgrid_t<double>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
-
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<viewgrid_t<std::complex<float>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
-
-    // bindings for {viewgrid_t} sources
-    m.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::native::stats<viewgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "collect statistics on a subset of a dataset");
+        "compute the statistics of a tile");
 
     // all done
     return;

--- a/ext/qed/native/stats.cc
+++ b/ext/qed/native/stats.cc
@@ -21,8 +21,8 @@ qed::py::native::stats(py::module & m)
         // the name of the function
         "stats",
         // the handler
-        [](const py::buffer & source, std::vector<std::ptrdiff_t> origin,
-           std::vector<std::ptrdiff_t> shape) -> stats_t {
+        [](const py::buffer & source, const py::iterable & origin,
+           const py::iterable & shape) -> stats_t {
             // rebuild the tile geometry as rank-2 grid coordinates
             auto o = asIndex<2>(origin);
             auto t = asShape<2>(shape);

--- a/ext/qed/nisar/bfpq.cc
+++ b/ext/qed/nisar/bfpq.cc
@@ -35,8 +35,8 @@ qed::py::nisar::bfpq(py::module & m)
         "amplitude",
         // the handler
         [](const dataset_t & source, const datatype_t & datatype, const py::buffer & lut,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max) -> bmp_t {
             // read and decode the tile, then render it
             return qed::nisar::bfpq::amplitude<grid_t>(
                 source, datatype, asBFPQ(lut), asIndex<2>(origin), asShape<2>(shape),
@@ -53,8 +53,8 @@ qed::py::nisar::bfpq(py::module & m)
         "complex",
         // the handler
         [](const dataset_t & source, const datatype_t & datatype, const py::buffer & lut,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max, double minPhase,
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max, double minPhase,
            double maxPhase, double saturation) -> bmp_t {
             // read and decode the tile, then render it
             return qed::nisar::bfpq::complex<grid_t>(
@@ -73,8 +73,8 @@ qed::py::nisar::bfpq(py::module & m)
         "imaginary",
         // the handler
         [](const dataset_t & source, const datatype_t & datatype, const py::buffer & lut,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max) -> bmp_t {
             // read and decode the tile, then render it
             return qed::nisar::bfpq::imaginary<grid_t>(
                 source, datatype, asBFPQ(lut), asIndex<2>(origin), asShape<2>(shape),
@@ -91,8 +91,8 @@ qed::py::nisar::bfpq(py::module & m)
         "phase",
         // the handler
         [](const dataset_t & source, const datatype_t & datatype, const py::buffer & lut,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double low, double high, double saturation,
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double low, double high, double saturation,
            double brightness) -> bmp_t {
             // read and decode the tile, then render it
             return qed::nisar::bfpq::phase<grid_t>(
@@ -111,8 +111,8 @@ qed::py::nisar::bfpq(py::module & m)
         "real",
         // the handler
         [](const dataset_t & source, const datatype_t & datatype, const py::buffer & lut,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max) -> bmp_t {
             // read and decode the tile, then render it
             return qed::nisar::bfpq::real<grid_t>(
                 source, datatype, asBFPQ(lut), asIndex<2>(origin), asShape<2>(shape),

--- a/ext/qed/nisar/bfpq.cc
+++ b/ext/qed/nisar/bfpq.cc
@@ -1,4 +1,5 @@
-// -*- c++ -*-
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
 //
 // michael a.g. aïvázis <michael.aivazis@para-sim.com>
 // (c) 1998-2026 all rights reserved
@@ -6,11 +7,13 @@
 
 // external
 #include "external.h"
+// the BFPQ lookup table helper
+#include "bfpq_lut.h"
 // namespace setup
 #include "forward.h"
 
 
-// submodule with the bindings for the nisar tile generators
+// submodule with the bindings for the nisar BFPQ tile generators
 void
 qed::py::nisar::bfpq(py::module & m)
 {
@@ -21,62 +24,104 @@ qed::py::nisar::bfpq(py::module & m)
         // its docstring
         "support for BFPQ encoded {slc} datasets");
 
-    // {c8} amplitude
+    // the BFPQ kernels read a tile out of an h5 dataset (using {datatype} for the on-disk layout),
+    // decode it through the BFPQ lookup table, and render it; the reader hands the lookup table in
+    // as a buffer, which we rebuild into the small heap grid the kernels expect
+    using grid_t = heapgrid_t<std::complex<float>>;
+
+    // render the amplitude of a BFPQ encoded slc tile
     bfpq.def(
-        // the name of the function
+        // the name
         "amplitude",
         // the handler
-        &qed::nisar::bfpq::amplitude<heapgrid_t<std::complex<float>>>,
+        [](const dataset_t & source, const datatype_t & datatype, const py::buffer & lut,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+            // read and decode the tile, then render it
+            return qed::nisar::bfpq::amplitude<grid_t>(
+                source, datatype, asBFPQ(lut), asIndex<2>(origin), asShape<2>(shape),
+                asIndex<2>(stride), min, max);
+        },
         // the signature
         "source"_a, "datatype"_a, "bfpq"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the amplitude of a BFPQ encoded complex float tile");
+        "render the amplitude of a BFPQ encoded slc tile");
 
-    // {c8}
+    // render the value of a BFPQ encoded slc tile
     bfpq.def(
-        // the name of the function
+        // the name
         "complex",
         // the handler
-        &qed::nisar::bfpq::complex<heapgrid_t<std::complex<float>>>,
+        [](const dataset_t & source, const datatype_t & datatype, const py::buffer & lut,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max, double minPhase,
+           double maxPhase, double saturation) -> bmp_t {
+            // read and decode the tile, then render it
+            return qed::nisar::bfpq::complex<grid_t>(
+                source, datatype, asBFPQ(lut), asIndex<2>(origin), asShape<2>(shape),
+                asIndex<2>(stride), min, max, minPhase, maxPhase, saturation);
+        },
         // the signature
         "source"_a, "datatype"_a, "bfpq"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         "minPhase"_a, "maxPhase"_a, "saturation"_a,
         // the docstring
-        "render the value of a BFPQ encoded complex float tile");
+        "render the value of a BFPQ encoded slc tile");
 
-    // imaginary part of {c8}
+    // render the imaginary part of a BFPQ encoded slc tile
     bfpq.def(
-        // the name of the function
+        // the name
         "imaginary",
         // the handler
-        &qed::nisar::bfpq::imaginary<heapgrid_t<std::complex<float>>>,
+        [](const dataset_t & source, const datatype_t & datatype, const py::buffer & lut,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+            // read and decode the tile, then render it
+            return qed::nisar::bfpq::imaginary<grid_t>(
+                source, datatype, asBFPQ(lut), asIndex<2>(origin), asShape<2>(shape),
+                asIndex<2>(stride), min, max);
+        },
         // the signature
         "source"_a, "datatype"_a, "bfpq"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the imaginary part of a BFPQ encoded complex float tile");
+        "render the imaginary part of a BFPQ encoded slc tile");
 
-    // phase of {c8}
+    // render the phase of a BFPQ encoded slc tile
     bfpq.def(
-        // the name of the function
+        // the name
         "phase",
         // the handler
-        &qed::nisar::bfpq::phase<heapgrid_t<std::complex<float>>>,
+        [](const dataset_t & source, const datatype_t & datatype, const py::buffer & lut,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double low, double high, double saturation,
+           double brightness) -> bmp_t {
+            // read and decode the tile, then render it
+            return qed::nisar::bfpq::phase<grid_t>(
+                source, datatype, asBFPQ(lut), asIndex<2>(origin), asShape<2>(shape),
+                asIndex<2>(stride), low, high, saturation, brightness);
+        },
         // the signature
         "source"_a, "datatype"_a, "bfpq"_a, "origin"_a, "shape"_a, "stride"_a, "low"_a, "high"_a,
         "saturation"_a, "brightness"_a,
         // the docstring
-        "render the phase of a BFPQ encoded complex float tile");
+        "render the phase of a BFPQ encoded slc tile");
 
-    // real part of {c8}
+    // render the real part of a BFPQ encoded slc tile
     bfpq.def(
-        // the name of the function
+        // the name
         "real",
         // the handler
-        &qed::nisar::bfpq::real<heapgrid_t<std::complex<float>>>,
+        [](const dataset_t & source, const datatype_t & datatype, const py::buffer & lut,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+            // read and decode the tile, then render it
+            return qed::nisar::bfpq::real<grid_t>(
+                source, datatype, asBFPQ(lut), asIndex<2>(origin), asShape<2>(shape),
+                asIndex<2>(stride), min, max);
+        },
         // the signature
         "source"_a, "datatype"_a, "bfpq"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the real part of a BFPQ encoded complex float tile");
+        "render the real part of a BFPQ encoded slc tile");
 
     // all done
     return;

--- a/ext/qed/nisar/bfpq_lut.h
+++ b/ext/qed/nisar/bfpq_lut.h
@@ -1,0 +1,40 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+
+// the nisar aliases and the grid dispatch helpers
+#include "external.h"
+// for copying the lookup table entries
+#include <algorithm>
+
+
+namespace qed::py {
+    // rebuild the BFPQ lookup table grid from a python buffer: the reader hands us the LUT as a
+    // buffer (the decoded contents of the {BFPQLUT} dataset), and the kernels want it as a small
+    // one-dimensional heap grid of floats, so copy the entries into a fresh block
+    inline auto asBFPQ(const py::buffer & lut) -> qed::nisar::bfpq_lut_t
+    {
+        // read the buffer description
+        auto info = lut.request();
+        // the number of entries
+        auto cells = static_cast<std::ptrdiff_t>(info.size);
+        // a one-dimensional layout over them
+        auto layout = pyre::grid::canonical_t<1>(pyre::grid::shape_t<1> { cells });
+        // a fresh heap block sized to hold them
+        auto storage = pyre::memory::heap_t<float> { cells };
+        // copy the lookup table entries in; they are single precision floats
+        auto source = static_cast<const float *>(info.ptr);
+        std::copy(source, source + cells, storage.data());
+        // pair the layout and storage into the lookup table grid
+        return qed::nisar::bfpq_lut_t(layout, storage);
+    }
+} // namespace qed::py
+
+
+// end of file

--- a/ext/qed/nisar/masks.cc
+++ b/ext/qed/nisar/masks.cc
@@ -32,8 +32,8 @@ qed::py::nisar::masks(py::module & m)
         "gcov",
         // the handler
         [](const dataset_t & source, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride) -> bmp_t {
             // read the tile and render it
             return qed::nisar::masks::gcov<grid_t>(
                 source, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride));
@@ -49,8 +49,8 @@ qed::py::nisar::masks(py::module & m)
         "gunw",
         // the handler
         [](const dataset_t & source, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride) -> bmp_t {
             // read the tile and render it
             return qed::nisar::masks::gunw<grid_t>(
                 source, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride));

--- a/ext/qed/nisar/masks.cc
+++ b/ext/qed/nisar/masks.cc
@@ -1,4 +1,5 @@
-// -*- c++ -*-
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
 //
 // michael a.g. aïvázis <michael.aivazis@para-sim.com>
 // (c) 1998-2026 all rights reserved
@@ -21,27 +22,43 @@ qed::py::nisar::masks(py::module & m)
         // its docstring
         "support for nisar {mask} datasets");
 
-    // {uint8_t} GUNW bitmasks
-    masks.def(
-        // the name of the function
-        "gunw",
-        // the handler
-        &qed::nisar::masks::gunw<heapgrid_t<uint8_t>>,
-        // the signature
-        "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a,
-        // the docstring
-        "render a tile of a GUNW product mask");
+    // the nisar kernels read a tile out of an h5 dataset (using {datatype} for the on-disk layout)
+    // into a grid of a fixed cell type, then render it
+    using grid_t = heapgrid_t<uint8_t>;
 
-    // {uint8_t} GCOV bitmasks
+    // render a gcov mask tile
     masks.def(
-        // the name of the function
+        // the name
         "gcov",
         // the handler
-        &qed::nisar::masks::gcov<heapgrid_t<uint8_t>>,
+        [](const dataset_t & source, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride) -> bmp_t {
+            // read the tile and render it
+            return qed::nisar::masks::gcov<grid_t>(
+                source, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride));
+        },
         // the signature
         "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a,
         // the docstring
-        "render a tile of a GCOV product mask");
+        "render a gcov mask tile");
+
+    // render a gunw mask tile
+    masks.def(
+        // the name
+        "gunw",
+        // the handler
+        [](const dataset_t & source, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride) -> bmp_t {
+            // read the tile and render it
+            return qed::nisar::masks::gunw<grid_t>(
+                source, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride));
+        },
+        // the signature
+        "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a,
+        // the docstring
+        "render a gunw mask tile");
 
     // all done
     return;

--- a/ext/qed/nisar/profile.cc
+++ b/ext/qed/nisar/profile.cc
@@ -1,4 +1,5 @@
-// -*- c++ -*-
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
 //
 // michael a.g. aïvázis <michael.aivazis@para-sim.com>
 // (c) 1998-2026 all rights reserved
@@ -6,6 +7,8 @@
 
 // external
 #include "external.h"
+// the BFPQ lookup table helper
+#include "bfpq_lut.h"
 // namespace setup
 #include "forward.h"
 
@@ -14,43 +17,69 @@
 void
 qed::py::nisar::profile(py::module & m)
 {
-    // bindings for HDF5 sources
+    // the nisar kernels read a path of samples out of an h5 dataset (using {datatype} for the
+    // on-disk layout) into a grid of a fixed cell type; the result's cell type varies with the
+    // dataset, so each wrapper hands it back as a python object
+
+    // collect values along a path from a uint8 dataset
     m.def(
-        // the name of the function
+        // the name
         "profileUInt8",
         // the handler
-        &qed::nisar::profile<heapgrid_t<std::uint8_t>>,
+        [](const dataset_t & source, const datatype_t & datatype,
+           const qed::native::points_t & points, bool closed) -> py::object {
+            // read the path and hand it back
+            return py::cast(
+                qed::nisar::profile<heapgrid_t<std::uint8_t>>(source, datatype, points, closed));
+        },
         // the signature
         "source"_a, "datatype"_a, "points"_a, "closed"_a = false,
         // the docstring
-        "collect values from a dataset along a path");
+        "collect values from a uint8 dataset along a path");
 
-    // bindings for HDF5 sources
+    // collect values along a path from a float dataset
     m.def(
-        // the name of the function
+        // the name
         "profileFloat",
         // the handler
-        &qed::nisar::profile<heapgrid_t<float>>,
+        [](const dataset_t & source, const datatype_t & datatype,
+           const qed::native::points_t & points, bool closed) -> py::object {
+            // read the path and hand it back
+            return py::cast(
+                qed::nisar::profile<heapgrid_t<float>>(source, datatype, points, closed));
+        },
         // the signature
         "source"_a, "datatype"_a, "points"_a, "closed"_a = false,
         // the docstring
-        "collect values from a dataset along a path");
+        "collect values from a float dataset along a path");
 
+    // collect values along a path from a complex float dataset
     m.def(
-        // the name of the function
+        // the name
         "profileComplexFloat",
         // the handler
-        &qed::nisar::profile<heapgrid_t<std::complex<float>>>,
+        [](const dataset_t & source, const datatype_t & datatype,
+           const qed::native::points_t & points, bool closed) -> py::object {
+            // read the path and hand it back
+            return py::cast(qed::nisar::profile<heapgrid_t<std::complex<float>>>(
+                source, datatype, points, closed));
+        },
         // the signature
         "source"_a, "datatype"_a, "points"_a, "closed"_a = false,
         // the docstring
-        "collect values from a dataset along a path");
+        "collect values from a complex float dataset along a path");
 
+    // collect values along a path from a BFPQ encoded dataset
     m.def(
-        // the name of the function
+        // the name
         "profileBFPQ",
         // the handler
-        &qed::nisar::profileBFPQ<heapgrid_t<std::complex<float>>>,
+        [](const dataset_t & source, const datatype_t & datatype, const py::buffer & lut,
+           const qed::native::points_t & points, bool closed) -> py::object {
+            // read and decode the path and hand it back
+            return py::cast(qed::nisar::profileBFPQ<heapgrid_t<std::complex<float>>>(
+                source, datatype, asBFPQ(lut), points, closed));
+        },
         // the signature
         "source"_a, "datatype"_a, "bfpq"_a, "points"_a, "closed"_a = false,
         // the docstring

--- a/ext/qed/nisar/real.cc
+++ b/ext/qed/nisar/real.cc
@@ -1,4 +1,5 @@
-// -*- c++ -*-
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
 //
 // michael a.g. aïvázis <michael.aivazis@para-sim.com>
 // (c) 1998-2026 all rights reserved
@@ -10,7 +11,7 @@
 #include "forward.h"
 
 
-// submodule with the bindings for the nisar tile generators
+// submodule with the bindings for the nisar real tile generators
 void
 qed::py::nisar::real(py::module & m)
 {
@@ -21,178 +22,156 @@ qed::py::nisar::real(py::module & m)
         // its docstring
         "support for nisar {real} datasets");
 
-    // {r4} amplitude
+    // the nisar kernels read a tile out of an h5 dataset (using {datatype} for the on-disk layout)
+    // into a grid of a fixed cell type, then render it; the masked variants pull a second dataset
+    // for the mask
+    using grid_t = heapgrid_t<float>;
+
+    // render the value of a real tile
     real.def(
-        // the name of the function
+        // the name
         "value",
         // the handler
-        &qed::nisar::real::value<heapgrid_t<float>>,
+        [](const dataset_t & source, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+            // read the tile and render it
+            return qed::nisar::real::value<grid_t>(
+                source, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride), min,
+                max);
+        },
         // the signature
         "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the value of a float tile");
-    // {r8} amplitude
-    real.def(
-        // the name of the function
-        "value",
-        // the handler
-        &qed::nisar::real::value<heapgrid_t<double>>,
-        // the signature
-        "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the amplitude of a double tile");
+        "render the value of a real tile");
 
-
-    // {r4}
+    // render the absolute value of a real tile
     real.def(
-        // the name of the function
+        // the name
         "abs",
         // the handler
-        &qed::nisar::real::abs<heapgrid_t<float>>,
+        [](const dataset_t & source, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+            // read the tile and render it
+            return qed::nisar::real::abs<grid_t>(
+                source, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride), min,
+                max);
+        },
         // the signature
         "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the absolute value of a float tile");
-    // {r8}
-    real.def(
-        // the name of the function
-        "abs",
-        // the handler
-        &qed::nisar::real::abs<heapgrid_t<double>>,
-        // the signature
-        "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the absolute value of a double tile");
+        "render the absolute value of a real tile");
 
-    // {r4}
+    // render the coherence of a real tile
     real.def(
-        // the name of the function
-        "unwrapped",
-        // the handler
-        &qed::nisar::real::unwrapped<heapgrid_t<float>>,
-        // the signature
-        "source"_a, "mask"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        "brightness"_a,
-        // the docstring
-        "render the unwrapped phase");
-    // {r8}
-    real.def(
-        // the name of the function
-        "unwrapped",
-        // the handler
-        &qed::nisar::real::unwrapped<heapgrid_t<double>>,
-        // the signature
-        "source"_a, "mask"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        "brightness"_a,
-        // the docstring
-        "render the unwrapped phase");
-
-    // {r4}
-    real.def(
-        // the name of the function
-        "unwrappedMasked",
-        // the handler
-        &qed::nisar::real::unwrappedMasked<heapgrid_t<float>>,
-        // the signature
-        "source"_a, "mask"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        "brightness"_a,
-        // the docstring
-        "render the unwrapped masked phase");
-    // {r8}
-    real.def(
-        // the name of the function
-        "unwrappedMasked",
-        // the handler
-        &qed::nisar::real::unwrappedMasked<heapgrid_t<double>>,
-        // the signature
-        "source"_a, "mask"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        "brightness"_a,
-        // the docstring
-        "render the unwrapped masked phase");
-
-    // {r4}
-    real.def(
-        // the name of the function
+        // the name
         "coherence",
         // the handler
-        &qed::nisar::real::coherence<heapgrid_t<float>>,
+        [](const dataset_t & source, const dataset_t & mask, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+            // read the tile and its mask and render them
+            return qed::nisar::real::coherence<grid_t>(
+                source, mask, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride),
+                min, max);
+        },
         // the signature
         "source"_a, "mask"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the coherence");
-    // {r8}
-    real.def(
-        // the name of the function
-        "coherence",
-        // the handler
-        &qed::nisar::real::coherence<heapgrid_t<double>>,
-        // the signature
-        "source"_a, "mask"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the coherence");
+        "render the coherence of a real tile");
 
-    // {r4}
+    // render the coherence of a real tile, masked
     real.def(
-        // the name of the function
-        "covarianceMasked",
-        // the handler
-        &qed::nisar::real::covarianceMasked<heapgrid_t<float>>,
-        // the signature
-        "source"_a, "mask"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the masked covariance");
-    // {r8}
-    real.def(
-        // the name of the function
-        "covarianceMasked",
-        // the handler
-        &qed::nisar::real::covarianceMasked<heapgrid_t<double>>,
-        // the signature
-        "source"_a, "mask"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the masked covariance");
-
-    // {r4}
-    real.def(
-        // the name of the function
-        "covariance",
-        // the handler
-        &qed::nisar::real::covariance<heapgrid_t<float>>,
-        // the signature
-        "source"_a, "mask"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the covariance");
-    // {r8}
-    real.def(
-        // the name of the function
-        "covariance",
-        // the handler
-        &qed::nisar::real::covariance<heapgrid_t<double>>,
-        // the signature
-        "source"_a, "mask"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the covariance");
-
-    // {r4}
-    real.def(
-        // the name of the function
+        // the name
         "coherenceMasked",
         // the handler
-        &qed::nisar::real::coherenceMasked<heapgrid_t<float>>,
+        [](const dataset_t & source, const dataset_t & mask, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+            // read the tile and its mask and render them
+            return qed::nisar::real::coherenceMasked<grid_t>(
+                source, mask, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride),
+                min, max);
+        },
         // the signature
         "source"_a, "mask"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the coherence");
-    // {r8}
+        "render the coherence of a real tile, masked");
+
+    // render the covariance of a real tile
     real.def(
-        // the name of the function
-        "coherenceMasked",
+        // the name
+        "covariance",
         // the handler
-        &qed::nisar::real::coherenceMasked<heapgrid_t<double>>,
+        [](const dataset_t & source, const dataset_t & mask, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+            // read the tile and its mask and render them
+            return qed::nisar::real::covariance<grid_t>(
+                source, mask, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride),
+                min, max);
+        },
         // the signature
         "source"_a, "mask"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the coherence");
+        "render the covariance of a real tile");
+
+    // render the covariance of a real tile, masked
+    real.def(
+        // the name
+        "covarianceMasked",
+        // the handler
+        [](const dataset_t & source, const dataset_t & mask, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+            // read the tile and its mask and render them
+            return qed::nisar::real::covarianceMasked<grid_t>(
+                source, mask, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride),
+                min, max);
+        },
+        // the signature
+        "source"_a, "mask"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
+        // the docstring
+        "render the covariance of a real tile, masked");
+
+    // render the unwrapped phase of a real tile
+    real.def(
+        // the name
+        "unwrapped",
+        // the handler
+        [](const dataset_t & source, const dataset_t & mask, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max, double brightness) -> bmp_t {
+            // read the tile and its mask and render them
+            return qed::nisar::real::unwrapped<grid_t>(
+                source, mask, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride),
+                min, max, brightness);
+        },
+        // the signature
+        "source"_a, "mask"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
+        "brightness"_a,
+        // the docstring
+        "render the unwrapped phase of a real tile");
+
+    // render the unwrapped phase of a real tile, masked
+    real.def(
+        // the name
+        "unwrappedMasked",
+        // the handler
+        [](const dataset_t & source, const dataset_t & mask, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max, double brightness) -> bmp_t {
+            // read the tile and its mask and render them
+            return qed::nisar::real::unwrappedMasked<grid_t>(
+                source, mask, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride),
+                min, max, brightness);
+        },
+        // the signature
+        "source"_a, "mask"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
+        "brightness"_a,
+        // the docstring
+        "render the unwrapped phase of a real tile, masked");
 
     // all done
     return;

--- a/ext/qed/nisar/real.cc
+++ b/ext/qed/nisar/real.cc
@@ -33,8 +33,8 @@ qed::py::nisar::real(py::module & m)
         "value",
         // the handler
         [](const dataset_t & source, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max) -> bmp_t {
             // read the tile and render it
             return qed::nisar::real::value<grid_t>(
                 source, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride), min,
@@ -51,8 +51,8 @@ qed::py::nisar::real(py::module & m)
         "abs",
         // the handler
         [](const dataset_t & source, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max) -> bmp_t {
             // read the tile and render it
             return qed::nisar::real::abs<grid_t>(
                 source, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride), min,
@@ -69,8 +69,8 @@ qed::py::nisar::real(py::module & m)
         "coherence",
         // the handler
         [](const dataset_t & source, const dataset_t & mask, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max) -> bmp_t {
             // read the tile and its mask and render them
             return qed::nisar::real::coherence<grid_t>(
                 source, mask, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride),
@@ -87,8 +87,8 @@ qed::py::nisar::real(py::module & m)
         "coherenceMasked",
         // the handler
         [](const dataset_t & source, const dataset_t & mask, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max) -> bmp_t {
             // read the tile and its mask and render them
             return qed::nisar::real::coherenceMasked<grid_t>(
                 source, mask, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride),
@@ -105,8 +105,8 @@ qed::py::nisar::real(py::module & m)
         "covariance",
         // the handler
         [](const dataset_t & source, const dataset_t & mask, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max) -> bmp_t {
             // read the tile and its mask and render them
             return qed::nisar::real::covariance<grid_t>(
                 source, mask, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride),
@@ -123,8 +123,8 @@ qed::py::nisar::real(py::module & m)
         "covarianceMasked",
         // the handler
         [](const dataset_t & source, const dataset_t & mask, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max) -> bmp_t {
             // read the tile and its mask and render them
             return qed::nisar::real::covarianceMasked<grid_t>(
                 source, mask, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride),
@@ -141,8 +141,8 @@ qed::py::nisar::real(py::module & m)
         "unwrapped",
         // the handler
         [](const dataset_t & source, const dataset_t & mask, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max, double brightness) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max, double brightness) -> bmp_t {
             // read the tile and its mask and render them
             return qed::nisar::real::unwrapped<grid_t>(
                 source, mask, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride),
@@ -160,8 +160,8 @@ qed::py::nisar::real(py::module & m)
         "unwrappedMasked",
         // the handler
         [](const dataset_t & source, const dataset_t & mask, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max, double brightness) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max, double brightness) -> bmp_t {
             // read the tile and its mask and render them
             return qed::nisar::real::unwrappedMasked<grid_t>(
                 source, mask, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride),

--- a/ext/qed/nisar/slc.cc
+++ b/ext/qed/nisar/slc.cc
@@ -1,4 +1,5 @@
-// -*- c++ -*-
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
 //
 // michael a.g. aïvázis <michael.aivazis@para-sim.com>
 // (c) 1998-2026 all rights reserved
@@ -10,7 +11,7 @@
 #include "forward.h"
 
 
-// submodule with the bindings for the nisar tile generators
+// submodule with the bindings for the nisar slc tile generators
 void
 qed::py::nisar::slc(py::module & m)
 {
@@ -21,114 +22,105 @@ qed::py::nisar::slc(py::module & m)
         // its docstring
         "support for nisar {slc} datasets");
 
-    // {c8} amplitude
-    slc.def(
-        // the name of the function
-        "amplitude",
-        // the handler
-        &qed::nisar::slc::amplitude<heapgrid_t<std::complex<float>>>,
-        // the signature
-        "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the amplitude of a complex float tile");
-    // {c16} amplitude
-    slc.def(
-        // the name of the function
-        "amplitude",
-        // the handler
-        &qed::nisar::slc::amplitude<heapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the amplitude of a complex double tile");
+    // the nisar kernels read a tile out of an h5 dataset (using {datatype} for the on-disk layout)
+    // into a grid of a fixed cell type, then render it; the grid type is a compile-time detail, so
+    // each wrapper just threads the dataset and layout through and turns the geometry into grid
+    // coordinates
+    using grid_t = heapgrid_t<std::complex<float>>;
 
-    // {c8}
+    // render the amplitude of a complex slc tile
     slc.def(
-        // the name of the function
+        // the name
+        "amplitude",
+        // the handler
+        [](const dataset_t & source, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+            // read the tile and render it
+            return qed::nisar::slc::amplitude<grid_t>(
+                source, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride), min,
+                max);
+        },
+        // the signature
+        "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
+        // the docstring
+        "render the amplitude of a complex slc tile");
+
+    // render the value of a complex slc tile
+    slc.def(
+        // the name
         "complex",
         // the handler
-        &qed::nisar::slc::complex<heapgrid_t<std::complex<float>>>,
+        [](const dataset_t & source, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max, double minPhase,
+           double maxPhase, double saturation) -> bmp_t {
+            // read the tile and render it
+            return qed::nisar::slc::complex<grid_t>(
+                source, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride), min,
+                max, minPhase, maxPhase, saturation);
+        },
         // the signature
         "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a, "minPhase"_a,
         "maxPhase"_a, "saturation"_a,
         // the docstring
-        "render the value of a complex float tile");
-    // {c16}
-    slc.def(
-        // the name of the function
-        "complex",
-        // the handler
-        &qed::nisar::slc::complex<heapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a, "minPhase"_a,
-        "maxPhase"_a, "saturation"_a,
-        // the docstring
-        "render the value of a complex double tile");
+        "render the value of a complex slc tile");
 
-    // imaginary part of {c8}
+    // render the imaginary part of a complex slc tile
     slc.def(
-        // the name of the function
+        // the name
         "imaginary",
         // the handler
-        &qed::nisar::slc::imaginary<heapgrid_t<std::complex<float>>>,
+        [](const dataset_t & source, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+            // read the tile and render it
+            return qed::nisar::slc::imaginary<grid_t>(
+                source, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride), min,
+                max);
+        },
         // the signature
         "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the imaginary part of a complex float tile");
-    // imaginary part of {c16}
-    slc.def(
-        // the name of the function
-        "imaginary",
-        // the handler
-        &qed::nisar::slc::imaginary<heapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the imaginary part of a complex double tile");
+        "render the imaginary part of a complex slc tile");
 
-    // phase of {c8}
+    // render the phase of a complex slc tile
     slc.def(
-        // the name of the function
+        // the name
         "phase",
         // the handler
-        &qed::nisar::slc::phase<heapgrid_t<std::complex<float>>>,
+        [](const dataset_t & source, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double low, double high, double saturation,
+           double brightness) -> bmp_t {
+            // read the tile and render it
+            return qed::nisar::slc::phase<grid_t>(
+                source, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride), low,
+                high, saturation, brightness);
+        },
         // the signature
         "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "low"_a, "high"_a,
         "saturation"_a, "brightness"_a,
         // the docstring
-        "render the phase of a complex float tile");
-    // phase of {c16}
-    slc.def(
-        // the name of the function
-        "phase",
-        // the handler
-        &qed::nisar::slc::phase<heapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "low"_a, "high"_a,
-        "saturation"_a, "brightness"_a,
-        // the docstring
-        "render the phase of a complex double tile");
+        "render the phase of a complex slc tile");
 
-    // real part of {c8}
+    // render the real part of a complex slc tile
     slc.def(
-        // the name of the function
+        // the name
         "real",
         // the handler
-        &qed::nisar::slc::real<heapgrid_t<std::complex<float>>>,
+        [](const dataset_t & source, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+            // read the tile and render it
+            return qed::nisar::slc::real<grid_t>(
+                source, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride), min,
+                max);
+        },
         // the signature
         "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the real part of a complex float tile");
-    // real part of {c16}
-    slc.def(
-        // the name of the function
-        "real",
-        // the handler
-        &qed::nisar::slc::real<heapgrid_t<std::complex<double>>>,
-        // the signature
-        "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the real part of a complex double tile");
+        "render the real part of a complex slc tile");
 
     // all done
     return;

--- a/ext/qed/nisar/slc.cc
+++ b/ext/qed/nisar/slc.cc
@@ -34,8 +34,8 @@ qed::py::nisar::slc(py::module & m)
         "amplitude",
         // the handler
         [](const dataset_t & source, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max) -> bmp_t {
             // read the tile and render it
             return qed::nisar::slc::amplitude<grid_t>(
                 source, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride), min,
@@ -52,8 +52,8 @@ qed::py::nisar::slc(py::module & m)
         "complex",
         // the handler
         [](const dataset_t & source, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max, double minPhase,
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max, double minPhase,
            double maxPhase, double saturation) -> bmp_t {
             // read the tile and render it
             return qed::nisar::slc::complex<grid_t>(
@@ -72,8 +72,8 @@ qed::py::nisar::slc(py::module & m)
         "imaginary",
         // the handler
         [](const dataset_t & source, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max) -> bmp_t {
             // read the tile and render it
             return qed::nisar::slc::imaginary<grid_t>(
                 source, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride), min,
@@ -90,8 +90,8 @@ qed::py::nisar::slc(py::module & m)
         "phase",
         // the handler
         [](const dataset_t & source, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double low, double high, double saturation,
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double low, double high, double saturation,
            double brightness) -> bmp_t {
             // read the tile and render it
             return qed::nisar::slc::phase<grid_t>(
@@ -110,8 +110,8 @@ qed::py::nisar::slc(py::module & m)
         "real",
         // the handler
         [](const dataset_t & source, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max) -> bmp_t {
             // read the tile and render it
             return qed::nisar::slc::real<grid_t>(
                 source, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride), min,

--- a/ext/qed/nisar/stack.cc
+++ b/ext/qed/nisar/stack.cc
@@ -32,8 +32,8 @@ qed::py::nisar::stack(py::module & m)
         "meanpower",
         // the handler
         [](const std::vector<dataset_t> & sources, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max) -> bmp_t {
             // read the tiles and render their mean power
             return qed::nisar::stack::meanpower<grid_t>(
                 sources, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride), min,
@@ -50,8 +50,8 @@ qed::py::nisar::stack(py::module & m)
         "coherence",
         // the handler
         [](const std::vector<dataset_t> & sources, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
-           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride, double min, double max) -> bmp_t {
             // read the tiles and render their coherence
             return qed::nisar::stack::coherence<grid_t>(
                 sources, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride), min,
@@ -68,7 +68,7 @@ qed::py::nisar::stack(py::module & m)
         "stats",
         // the handler
         [](const std::vector<dataset_t> & sources, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape) -> stats_t {
+           const py::iterable & origin, const py::iterable & shape) -> stats_t {
             // read the tiles and collect their statistics
             return qed::nisar::stack::stats<grid_t>(
                 sources, datatype, asIndex<2>(origin), asShape<2>(shape));

--- a/ext/qed/nisar/stack.cc
+++ b/ext/qed/nisar/stack.cc
@@ -1,4 +1,5 @@
-// -*- c++ -*-
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
 //
 // michael a.g. aïvázis <michael.aivazis@para-sim.com>
 // (c) 1998-2026 all rights reserved
@@ -21,68 +22,61 @@ qed::py::nisar::stack(py::module & m)
         // its docstring
         "support for aggregate views over stacks of nisar datasets");
 
-    // {c8} mean power
+    // the stack kernels read a tile out of each of a pile of h5 datasets (using {datatype} for the
+    // on-disk layout) into grids of a fixed cell type, then aggregate and render them
+    using grid_t = heapgrid_t<std::complex<float>>;
+
+    // render the mean power of a stack tile
     stack.def(
-        // the name of the function
+        // the name
         "meanpower",
         // the handler
-        &qed::nisar::stack::meanpower<heapgrid_t<std::complex<float>>>,
+        [](const std::vector<dataset_t> & sources, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+            // read the tiles and render their mean power
+            return qed::nisar::stack::meanpower<grid_t>(
+                sources, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride), min,
+                max);
+        },
         // the signature
         "sources"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the mean power of a stack of complex float tiles");
-    // {c16} mean power
-    stack.def(
-        // the name of the function
-        "meanpower",
-        // the handler
-        &qed::nisar::stack::meanpower<heapgrid_t<std::complex<double>>>,
-        // the signature
-        "sources"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the mean power of a stack of complex double tiles");
+        "render the mean power of a stack tile");
 
-    // {c8} coherence
+    // render the coherence of a stack tile
     stack.def(
-        // the name of the function
+        // the name
         "coherence",
         // the handler
-        &qed::nisar::stack::coherence<heapgrid_t<std::complex<float>>>,
+        [](const std::vector<dataset_t> & sources, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape,
+           std::vector<std::ptrdiff_t> stride, double min, double max) -> bmp_t {
+            // read the tiles and render their coherence
+            return qed::nisar::stack::coherence<grid_t>(
+                sources, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride), min,
+                max);
+        },
         // the signature
         "sources"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
         // the docstring
-        "render the coherence of a stack of complex float tiles");
-    // {c16} coherence
-    stack.def(
-        // the name of the function
-        "coherence",
-        // the handler
-        &qed::nisar::stack::coherence<heapgrid_t<std::complex<double>>>,
-        // the signature
-        "sources"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a, "min"_a, "max"_a,
-        // the docstring
-        "render the coherence of a stack of complex double tiles");
+        "render the coherence of a stack tile");
 
-    // {c8} mean-power statistics
+    // compute the statistics of a stack tile
     stack.def(
-        // the name of the function
+        // the name
         "stats",
         // the handler
-        &qed::nisar::stack::stats<heapgrid_t<std::complex<float>>>,
+        [](const std::vector<dataset_t> & sources, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape) -> stats_t {
+            // read the tiles and collect their statistics
+            return qed::nisar::stack::stats<grid_t>(
+                sources, datatype, asIndex<2>(origin), asShape<2>(shape));
+        },
         // the signature
         "sources"_a, "datatype"_a, "origin"_a, "shape"_a,
         // the docstring
-        "sample the mean power over a stack of complex float tiles");
-    // {c16} mean-power statistics
-    stack.def(
-        // the name of the function
-        "stats",
-        // the handler
-        &qed::nisar::stack::stats<heapgrid_t<std::complex<double>>>,
-        // the signature
-        "sources"_a, "datatype"_a, "origin"_a, "shape"_a,
-        // the docstring
-        "sample the mean power over a stack of complex double tiles");
+        "compute the statistics of a stack tile");
 
     // all done
     return;

--- a/ext/qed/nisar/stats.cc
+++ b/ext/qed/nisar/stats.cc
@@ -27,7 +27,7 @@ qed::py::nisar::stats(py::module & m)
         "stats",
         // the handler
         [](const dataset_t & source, const datatype_t & datatype,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape) -> stats_t {
+           const py::iterable & origin, const py::iterable & shape) -> stats_t {
             // read the tile and collect its statistics
             return qed::nisar::stats<grid_t>(source, datatype, asIndex<2>(origin), asShape<2>(shape));
         },
@@ -42,7 +42,7 @@ qed::py::nisar::stats(py::module & m)
         "statsBFPQ",
         // the handler
         [](const dataset_t & source, const datatype_t & datatype, const py::buffer & lut,
-           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape) -> stats_t {
+           const py::iterable & origin, const py::iterable & shape) -> stats_t {
             // read and decode the tile, then collect its statistics
             return qed::nisar::statsBFPQ<grid_t>(
                 source, datatype, asBFPQ(lut), asIndex<2>(origin), asShape<2>(shape));

--- a/ext/qed/nisar/stats.cc
+++ b/ext/qed/nisar/stats.cc
@@ -1,4 +1,5 @@
-// -*- c++ -*-
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
 //
 // michael a.g. aïvázis <michael.aivazis@para-sim.com>
 // (c) 1998-2026 all rights reserved
@@ -6,6 +7,8 @@
 
 // external
 #include "external.h"
+// the BFPQ lookup table helper
+#include "bfpq_lut.h"
 // namespace setup
 #include "forward.h"
 
@@ -14,26 +17,40 @@
 void
 qed::py::nisar::stats(py::module & m)
 {
-    // bindings for HDF5 sources
+    // the nisar kernels read a tile out of an h5 dataset (using {datatype} for the on-disk layout)
+    // into a grid of a fixed cell type, then collect its statistics
+    using grid_t = heapgrid_t<std::complex<float>>;
+
+    // compute the statistics of a complex slc tile
     m.def(
-        // the name of the function
+        // the name
         "stats",
         // the handler
-        &qed::nisar::stats<heapgrid_t<std::complex<float>>>,
+        [](const dataset_t & source, const datatype_t & datatype,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape) -> stats_t {
+            // read the tile and collect its statistics
+            return qed::nisar::stats<grid_t>(source, datatype, asIndex<2>(origin), asShape<2>(shape));
+        },
         // the signature
         "source"_a, "datatype"_a, "origin"_a, "shape"_a,
         // the docstring
-        "collect statistics on a subset of a dataset");
+        "compute the statistics of a complex slc tile");
 
+    // compute the statistics of a BFPQ encoded slc tile
     m.def(
-        // the name of the function
+        // the name
         "statsBFPQ",
         // the handler
-        &qed::nisar::statsBFPQ<heapgrid_t<std::complex<float>>>,
+        [](const dataset_t & source, const datatype_t & datatype, const py::buffer & lut,
+           std::vector<std::ptrdiff_t> origin, std::vector<std::ptrdiff_t> shape) -> stats_t {
+            // read and decode the tile, then collect its statistics
+            return qed::nisar::statsBFPQ<grid_t>(
+                source, datatype, asBFPQ(lut), asIndex<2>(origin), asShape<2>(shape));
+        },
         // the signature
         "source"_a, "datatype"_a, "bfpq"_a, "origin"_a, "shape"_a,
         // the docstring
-        "collect statistics on a subset of a BFPQ encoded dataset");
+        "compute the statistics of a BFPQ encoded slc tile");
 
     // all done
     return;

--- a/lib/qed/nisar/profile.icc
+++ b/lib/qed/nisar/profile.icc
@@ -225,14 +225,14 @@ qed::nisar::profileBFPQ(
             // read the BFPQ encode data
             auto encoded = pyre::h5::read<bfpq_slc_t>(dataset, datatype, origin, shape, strides);
             // report
-            channel << "encoded tile shape: " << encoded.layout().shape() << pyre::journal::endl;
+            channel << "encoded tile shape: " << encoded.packing().shape() << pyre::journal::endl;
 
             // describe the decoded tile
             auto layout = layout_t { shape };
             // allocate storage
             auto decoded = sourceT(layout, layout.cells());
             // report
-            channel << "decoded tile shape: " << decoded.layout().shape() << pyre::journal::endl;
+            channel << "decoded tile shape: " << decoded.packing().shape() << pyre::journal::endl;
             // decode the tile
             std::transform(encoded.cbegin(), encoded.cend(), decoded.begin(), decoder);
 

--- a/pkg/datatypes/Char.py
+++ b/pkg/datatypes/Char.py
@@ -14,6 +14,9 @@ class Char(Integer, family="qed.datatypes.Char"):
     The specification for one byte integers
     """
 
+    # the pyre memory cell name
+    cell = "int8"
+
     # size
     bytes = 1
 

--- a/pkg/datatypes/ComplexDouble.py
+++ b/pkg/datatypes/ComplexDouble.py
@@ -15,6 +15,9 @@ class ComplexDouble(Complex, family="qed.datatypes.complex128"):
     floating point numbers
     """
 
+    # the pyre memory cell name
+    cell = "complex128"
+
     # size
     bytes = 16
 

--- a/pkg/datatypes/ComplexFloat.py
+++ b/pkg/datatypes/ComplexFloat.py
@@ -15,6 +15,9 @@ class ComplexFloat(Complex, family="qed.datatypes.complex64"):
     floating point numbers
     """
 
+    # the pyre memory cell name
+    cell = "complex64"
+
     # size
     bytes = 8
 

--- a/pkg/datatypes/Datatype.py
+++ b/pkg/datatypes/Datatype.py
@@ -29,15 +29,19 @@ class Datatype(qed.flow.product, implements=qed.protocols.datatype):
     # constants
     summary = ("value",)
 
+    # the pyre memory cell name for this datatype; each concrete datatype sets its own, and it is
+    # what {pyre.grid} wants when it lays a grid over a block of memory
+    cell = None
+
 
     @property
     def tag(self):
         """
         Generate my type tag
         """
-        # use the class name as the tag; this is currently consistent with the {pyre.memory}
-        # bindings, so it can be interpolated into class names when requesting specific
-        # template instantiations
+        # use the class name as the tag; it is interpolated into the names of the {libqed} tile
+        # generators that are specialized by cell type, e.g. {profileFloat}. the connection to
+        # {pyre.grid}, on the other hand, goes through {cell}, the pyre memory cell name
         return self.__class__.__name__
 
 

--- a/pkg/datatypes/Double.py
+++ b/pkg/datatypes/Double.py
@@ -14,6 +14,9 @@ class Double(Real, family="qed.datatypes.real64"):
     The specification for double precision floating point numbers
     """
 
+    # the pyre memory cell name
+    cell = "float64"
+
     # size
     bytes = 8
 

--- a/pkg/datatypes/Float.py
+++ b/pkg/datatypes/Float.py
@@ -14,6 +14,9 @@ class Float(Real, family="qed.datatypes.real32"):
     The specification for single precision floating point numbers
     """
 
+    # the pyre memory cell name
+    cell = "float32"
+
     # size
     bytes = 4
 

--- a/pkg/datatypes/Int16.py
+++ b/pkg/datatypes/Int16.py
@@ -14,6 +14,9 @@ class Int16(Integer, family="qed.datatypes.int16"):
     The specification for two byte integers
     """
 
+    # the pyre memory cell name
+    cell = "int16"
+
     # size
     bytes = 2
 

--- a/pkg/datatypes/Int32.py
+++ b/pkg/datatypes/Int32.py
@@ -14,6 +14,9 @@ class Int32(Integer, family="qed.datatypes.int32"):
     The specification for four byte integers
     """
 
+    # the pyre memory cell name
+    cell = "int32"
+
     # size
     bytes = 4
 

--- a/pkg/datatypes/Int64.py
+++ b/pkg/datatypes/Int64.py
@@ -14,6 +14,9 @@ class Int64(Integer, family="qed.datatypes.int64"):
     The specification for eight byte integers
     """
 
+    # the pyre memory cell name
+    cell = "int64"
+
     # size
     bytes = 8
 

--- a/pkg/datatypes/Int8.py
+++ b/pkg/datatypes/Int8.py
@@ -14,6 +14,9 @@ class Int8(Integer, family="qed.datatypes.int8"):
     The specification for one byte integers
     """
 
+    # the pyre memory cell name
+    cell = "int8"
+
     # size
     bytes = 1
 

--- a/pkg/datatypes/UInt16.py
+++ b/pkg/datatypes/UInt16.py
@@ -14,6 +14,9 @@ class UInt16(Integer, family="qed.datatypes.uint16"):
     The specification for two byte unsigned integers
     """
 
+    # the pyre memory cell name
+    cell = "uint16"
+
     # size
     bytes = 2
 

--- a/pkg/datatypes/UInt32.py
+++ b/pkg/datatypes/UInt32.py
@@ -14,6 +14,9 @@ class UInt32(Integer, family="qed.datatypes.uint32"):
     The specification for four byte unsigned integers
     """
 
+    # the pyre memory cell name
+    cell = "uint32"
+
     # size
     bytes = 4
 

--- a/pkg/datatypes/UInt64.py
+++ b/pkg/datatypes/UInt64.py
@@ -14,6 +14,9 @@ class UInt64(Integer, family="qed.datatypes.uint64"):
     The specification for eight byte unsigned integers
     """
 
+    # the pyre memory cell name
+    cell = "uint64"
+
     # size
     bytes = 8
 

--- a/pkg/datatypes/UInt8.py
+++ b/pkg/datatypes/UInt8.py
@@ -14,6 +14,9 @@ class UInt8(Integer, family="qed.datatypes.uint8"):
     The specification for one byte unsigned integers
     """
 
+    # the pyre memory cell name
+    cell = "uint8"
+
     # size
     bytes = 1
 

--- a/pkg/readers/isce2/interferogram/Dataset.py
+++ b/pkg/readers/isce2/interferogram/Dataset.py
@@ -174,23 +174,11 @@ class Dataset(
 
         # grab the path to the dataset
         path = str(uri.address)
-        # build the name of the buffer factory
-        memoryType = f"{self.cell.tag}ConstMap"
-        # look up the factory in the {pyre::memory} bindings
-        bufferFactory = getattr(qed.libpyre.memory, memoryType)
-        # make the memory buffer
-        buffer = bufferFactory(path)
-
-        # realize the shape
-        shape = qed.libpyre.grid.Shape2D(shape=self.shape)
-        # build the packing
-        packing = qed.libpyre.grid.Canonical2D(shape=shape)
-        # grab the grid factory
-        gridFactory = getattr(qed.libpyre.grid, f"{memoryType}Grid2D")
-        # put it all together
-        data = gridFactory(packing, buffer)
-        # and return it
-        return data
+        # lay an erased grid of my cell type over the memory-mapped file and return it; it presents
+        # the buffer protocol, which is what the tile generators consume
+        return qed.libpyre.grid.map(
+            uri=path, shape=list(self.shape), cell=self.cell.cell, create=False
+        )
 
     def _collectStatistics(self):
         """
@@ -207,9 +195,9 @@ class Dataset(
         center = tuple((s - t) // 2 for s, t in zip(shape, tile))
 
         # convert to a grid index
-        center = qed.libpyre.grid.Index2D(index=center)
+        center = list(center)
         # and a shape
-        tile = qed.libpyre.grid.Shape2D(shape=tile)
+        tile = list(tile)
         # compute the stats
         stats = qed.libqed.isce2.interferogram.stats(
             source=data, origin=center, shape=tile

--- a/pkg/readers/isce2/interferogram/Dataset.py
+++ b/pkg/readers/isce2/interferogram/Dataset.py
@@ -177,7 +177,7 @@ class Dataset(
         # lay an erased grid of my cell type over the memory-mapped file and return it; it presents
         # the buffer protocol, which is what the tile generators consume
         return qed.libpyre.grid.map(
-            uri=path, shape=list(self.shape), cell=self.cell.cell, create=False
+            uri=path, shape=self.shape, cell=self.cell.cell, create=False
         )
 
     def _collectStatistics(self):
@@ -194,10 +194,6 @@ class Dataset(
         # center it in my shape
         center = tuple((s - t) // 2 for s, t in zip(shape, tile))
 
-        # convert to a grid index
-        center = list(center)
-        # and a shape
-        tile = list(tile)
         # compute the stats
         stats = qed.libqed.isce2.interferogram.stats(
             source=data, origin=center, shape=tile

--- a/pkg/readers/isce2/interferogram/channels/Channel.py
+++ b/pkg/readers/isce2/interferogram/channels/Channel.py
@@ -56,11 +56,11 @@ class Channel(qed.flow.dynamic, implements=qed.protocols.channel):
         pipeline = getattr(qed.libqed.isce2.interferogram.channels, name)
 
         # turn the shape into a {pyre::grid::shape_t}
-        shape = qed.libpyre.grid.Shape2D(shape=shape)
+        shape = list(shape)
         # the origin into a {pyre::grid::index_t}
-        origin = qed.libpyre.grid.Index2D(index=origin)
+        origin = list(origin)
         # and the zoom level into a {pyre::grid::index_t}
-        stride = qed.libpyre.grid.Index2D(index=tuple(2**level for level in zoom))
+        stride = list(tuple(2**level for level in zoom))
 
         # ask it to make a tile and return it
         return pipeline(

--- a/pkg/readers/isce2/interferogram/channels/Channel.py
+++ b/pkg/readers/isce2/interferogram/channels/Channel.py
@@ -55,12 +55,8 @@ class Channel(qed.flow.dynamic, implements=qed.protocols.channel):
         # look for the tile maker in {libqed}
         pipeline = getattr(qed.libqed.isce2.interferogram.channels, name)
 
-        # turn the shape into a {pyre::grid::shape_t}
-        shape = list(shape)
-        # the origin into a {pyre::grid::index_t}
-        origin = list(origin)
-        # and the zoom level into a {pyre::grid::index_t}
-        stride = list(tuple(2**level for level in zoom))
+        # turn the zoom levels into per-axis strides
+        stride = tuple(2**level for level in zoom)
 
         # ask it to make a tile and return it
         return pipeline(

--- a/pkg/readers/isce2/unwrapped/Dataset.py
+++ b/pkg/readers/isce2/unwrapped/Dataset.py
@@ -173,23 +173,11 @@ class Dataset(
 
         # grab the path to the dataset
         path = str(uri.address)
-        # build the name of the buffer factory
-        memoryType = f"{self.cell.tag}ConstMap"
-        # look up the factory in the {pyre::memory} bindings
-        bufferFactory = getattr(qed.libpyre.memory, memoryType)
-        # make the memory buffer
-        buffer = bufferFactory(path)
-
-        # realize the layout
-        layout = qed.libpyre.grid.Shape3D(shape=self.layout)
-        # build the packing
-        packing = qed.libpyre.grid.Canonical3D(shape=layout)
-        # grab the grid factory
-        gridFactory = getattr(qed.libpyre.grid, f"{memoryType}Grid3D")
-        # put it all together
-        data = gridFactory(packing, buffer)
-        # and return it
-        return data
+        # lay an erased grid of my cell type over the memory-mapped file and return it; it presents
+        # the buffer protocol, which is what the tile generators consume
+        return qed.libpyre.grid.map(
+            uri=path, shape=list(self.layout), cell=self.cell.cell, create=False
+        )
 
     def _collectStatistics(self):
         """
@@ -210,9 +198,9 @@ class Dataset(
         # go through my two channels
         for channel in range(2):
             # inject the index of the {channel} into the center index
-            origin = qed.libpyre.grid.Index3D(index=(center[0], channel, center[1]))
+            origin = list((center[0], channel, center[1]))
             # extend the tile shape
-            shape = qed.libpyre.grid.Shape3D(shape=(tile[0], 1, tile[1]))
+            shape = list((tile[0], 1, tile[1]))
             # compute the stats
             channelStats = qed.libqed.isce2.unwrapped.stats(
                 source=data, origin=origin, shape=shape

--- a/pkg/readers/isce2/unwrapped/Dataset.py
+++ b/pkg/readers/isce2/unwrapped/Dataset.py
@@ -176,7 +176,7 @@ class Dataset(
         # lay an erased grid of my cell type over the memory-mapped file and return it; it presents
         # the buffer protocol, which is what the tile generators consume
         return qed.libpyre.grid.map(
-            uri=path, shape=list(self.layout), cell=self.cell.cell, create=False
+            uri=path, shape=self.layout, cell=self.cell.cell, create=False
         )
 
     def _collectStatistics(self):
@@ -197,10 +197,10 @@ class Dataset(
         stats = []
         # go through my two channels
         for channel in range(2):
-            # inject the index of the {channel} into the center index
-            origin = list((center[0], channel, center[1]))
-            # extend the tile shape
-            shape = list((tile[0], 1, tile[1]))
+            # anchor the sample at this band of the line-interleaved layout
+            origin = (center[0], channel, center[1])
+            # spanning that one band
+            shape = (tile[0], 1, tile[1])
             # compute the stats
             channelStats = qed.libqed.isce2.unwrapped.stats(
                 source=data, origin=origin, shape=shape

--- a/pkg/readers/isce2/unwrapped/channels/Amplitude.py
+++ b/pkg/readers/isce2/unwrapped/channels/Amplitude.py
@@ -91,11 +91,11 @@ class Amplitude(Channel, family="qed.channels.isce2.int.amplitude"):
         lines, samples = shape
 
         # turn the shape into a {pyre::grid::shape_t}
-        shape = qed.libpyre.grid.Shape3D(shape=(lines, 1, samples))
+        shape = list((lines, 1, samples))
         # and the origin into a {pyre::grid::index_t}
-        origin = qed.libpyre.grid.Index3D(index=(line, 0, sample))
+        origin = list((line, 0, sample))
         # and the zoom level into a {pyre::grid::index_t}
-        stride = qed.libpyre.grid.Index3D(index=(2 ** zoom[0], 1, 2 ** zoom[1]))
+        stride = list((2 ** zoom[0], 1, 2 ** zoom[1]))
         # look for the tile maker in {libqed}
         tileMaker = qed.libqed.isce2.unwrapped.channels.amplitude
         # and ask it to make a tile

--- a/pkg/readers/isce2/unwrapped/channels/Amplitude.py
+++ b/pkg/readers/isce2/unwrapped/channels/Amplitude.py
@@ -90,12 +90,12 @@ class Amplitude(Channel, family="qed.channels.isce2.int.amplitude"):
         # and its shape
         lines, samples = shape
 
-        # turn the shape into a {pyre::grid::shape_t}
-        shape = list((lines, 1, samples))
-        # and the origin into a {pyre::grid::index_t}
-        origin = list((line, 0, sample))
-        # and the zoom level into a {pyre::grid::index_t}
-        stride = list((2 ** zoom[0], 1, 2 ** zoom[1]))
+        # the tile spans a single band of the line-interleaved layout
+        shape = (lines, 1, samples)
+        # anchored at the amplitude band
+        origin = (line, 0, sample)
+        # decimated by the zoom, leaving the band axis untouched
+        stride = (2 ** zoom[0], 1, 2 ** zoom[1])
         # look for the tile maker in {libqed}
         tileMaker = qed.libqed.isce2.unwrapped.channels.amplitude
         # and ask it to make a tile

--- a/pkg/readers/isce2/unwrapped/channels/Complex.py
+++ b/pkg/readers/isce2/unwrapped/channels/Complex.py
@@ -104,11 +104,11 @@ class Complex(Channel, family="qed.channels.isce2.int.complex"):
         lines, samples = shape
 
         # turn the shape into a {pyre::grid::shape_t}
-        shape = qed.libpyre.grid.Shape3D(shape=(lines, 1, samples))
+        shape = list((lines, 1, samples))
         # the origin into a {pyre::grid::index_t}
-        origin = qed.libpyre.grid.Index3D(index=(line, 0, sample))
+        origin = list((line, 0, sample))
         # and the zoom level into a {pyre::grid::index_t}
-        stride = qed.libpyre.grid.Index3D(index=(2 ** zoom[0], 1, 2 ** zoom[1]))
+        stride = list((2 ** zoom[0], 1, 2 ** zoom[1]))
         # look for the tile maker in {libqed}
         tileMaker = qed.libqed.isce2.unwrapped.channels.complex
         # and ask it to make a tile

--- a/pkg/readers/isce2/unwrapped/channels/Complex.py
+++ b/pkg/readers/isce2/unwrapped/channels/Complex.py
@@ -103,12 +103,12 @@ class Complex(Channel, family="qed.channels.isce2.int.complex"):
         # and its shape
         lines, samples = shape
 
-        # turn the shape into a {pyre::grid::shape_t}
-        shape = list((lines, 1, samples))
-        # the origin into a {pyre::grid::index_t}
-        origin = list((line, 0, sample))
-        # and the zoom level into a {pyre::grid::index_t}
-        stride = list((2 ** zoom[0], 1, 2 ** zoom[1]))
+        # the tile spans a single band of the line-interleaved layout
+        shape = (lines, 1, samples)
+        # anchored at the leading band
+        origin = (line, 0, sample)
+        # decimated by the zoom, leaving the band axis untouched
+        stride = (2 ** zoom[0], 1, 2 ** zoom[1])
         # look for the tile maker in {libqed}
         tileMaker = qed.libqed.isce2.unwrapped.channels.complex
         # and ask it to make a tile

--- a/pkg/readers/isce2/unwrapped/channels/Phase.py
+++ b/pkg/readers/isce2/unwrapped/channels/Phase.py
@@ -97,12 +97,12 @@ class Phase(Channel, family="qed.channels.isce2.int.phase"):
         # and its shape
         lines, samples = shape
 
-        # turn the shape into a {pyre::grid::shape_t}
-        shape = list((lines, 1, samples))
-        # the origin into a {pyre::grid::index_t}
-        origin = list((line, 1, sample))
-        # and the zoom level into a {pyre::grid::index_t}
-        stride = list((2 ** zoom[0], 1, 2 ** zoom[1]))
+        # the tile spans a single band of the line-interleaved layout
+        shape = (lines, 1, samples)
+        # anchored at the phase band
+        origin = (line, 1, sample)
+        # decimated by the zoom, leaving the band axis untouched
+        stride = (2 ** zoom[0], 1, 2 ** zoom[1])
         # look for the tile maker in {libqed}
         tileMaker = qed.libqed.isce2.unwrapped.channels.phase
         # and ask it to make a tile

--- a/pkg/readers/isce2/unwrapped/channels/Phase.py
+++ b/pkg/readers/isce2/unwrapped/channels/Phase.py
@@ -98,11 +98,11 @@ class Phase(Channel, family="qed.channels.isce2.int.phase"):
         lines, samples = shape
 
         # turn the shape into a {pyre::grid::shape_t}
-        shape = qed.libpyre.grid.Shape3D(shape=(lines, 1, samples))
+        shape = list((lines, 1, samples))
         # the origin into a {pyre::grid::index_t}
-        origin = qed.libpyre.grid.Index3D(index=(line, 1, sample))
+        origin = list((line, 1, sample))
         # and the zoom level into a {pyre::grid::index_t}
-        stride = qed.libpyre.grid.Index3D(index=(2 ** zoom[0], 1, 2 ** zoom[1]))
+        stride = list((2 ** zoom[0], 1, 2 ** zoom[1]))
         # look for the tile maker in {libqed}
         tileMaker = qed.libqed.isce2.unwrapped.channels.phase
         # and ask it to make a tile

--- a/pkg/readers/native/channels/Channel.py
+++ b/pkg/readers/native/channels/Channel.py
@@ -56,11 +56,11 @@ class Channel(qed.flow.dynamic, implements=qed.protocols.channel):
         pipeline = getattr(qed.libqed.native.channels, name)
 
         # turn the shape into a {pyre::grid::shape_t}
-        shape = qed.libpyre.grid.Shape2D(shape=shape)
+        shape = list(shape)
         # the origin into a {pyre::grid::index_t}
-        origin = qed.libpyre.grid.Index2D(index=origin)
+        origin = list(origin)
         # and the zoom into strides
-        stride = qed.libpyre.grid.Index2D(index=tuple(2**level for level in zoom))
+        stride = list(tuple(2**level for level in zoom))
         # build the visualization pipeline and return it
         return pipeline(
             source=source.data, origin=origin, shape=shape, stride=stride, **kwds

--- a/pkg/readers/native/channels/Channel.py
+++ b/pkg/readers/native/channels/Channel.py
@@ -55,12 +55,8 @@ class Channel(qed.flow.dynamic, implements=qed.protocols.channel):
         # look for the tile maker in {libqed}
         pipeline = getattr(qed.libqed.native.channels, name)
 
-        # turn the shape into a {pyre::grid::shape_t}
-        shape = list(shape)
-        # the origin into a {pyre::grid::index_t}
-        origin = list(origin)
-        # and the zoom into strides
-        stride = list(tuple(2**level for level in zoom))
+        # turn the zoom levels into per-axis strides
+        stride = tuple(2**level for level in zoom)
         # build the visualization pipeline and return it
         return pipeline(
             source=source.data, origin=origin, shape=shape, stride=stride, **kwds

--- a/pkg/readers/native/channels/Magnitude.py
+++ b/pkg/readers/native/channels/Magnitude.py
@@ -74,7 +74,7 @@ class Magnitude(Channel, family="qed.channels.native.abs"):
         # look for the tile maker in {libqed}
         pipeline = qed.libqed.native.channels.abs
         # turn the shape into a {pyre::grid::shape_t}
-        shape = qed.libpyre.grid.Shape2D(shape=shape)
+        shape = list(shape)
         # and invoke it
         return pipeline(source=source, shape=shape, low=low, high=high)
 

--- a/pkg/readers/native/channels/Magnitude.py
+++ b/pkg/readers/native/channels/Magnitude.py
@@ -73,8 +73,6 @@ class Magnitude(Channel, family="qed.channels.native.abs"):
         """
         # look for the tile maker in {libqed}
         pipeline = qed.libqed.native.channels.abs
-        # turn the shape into a {pyre::grid::shape_t}
-        shape = list(shape)
         # and invoke it
         return pipeline(source=source, shape=shape, low=low, high=high)
 

--- a/pkg/readers/native/channels/Value.py
+++ b/pkg/readers/native/channels/Value.py
@@ -74,7 +74,7 @@ class Value(Channel, family="qed.channels.native.value"):
         # look for the tile maker in {libqed}
         pipeline = qed.libqed.native.channels.value
         # turn the shape into a {pyre::grid::shape_t}
-        shape = qed.libpyre.grid.Shape2D(shape=shape)
+        shape = list(shape)
         # and invoke it
         return pipeline(source=source, shape=shape, low=low, high=high)
 

--- a/pkg/readers/native/channels/Value.py
+++ b/pkg/readers/native/channels/Value.py
@@ -73,8 +73,6 @@ class Value(Channel, family="qed.channels.native.value"):
         """
         # look for the tile maker in {libqed}
         pipeline = qed.libqed.native.channels.value
-        # turn the shape into a {pyre::grid::shape_t}
-        shape = list(shape)
         # and invoke it
         return pipeline(source=source, shape=shape, low=low, high=high)
 

--- a/pkg/readers/native/datasets/MemoryMap.py
+++ b/pkg/readers/native/datasets/MemoryMap.py
@@ -180,7 +180,7 @@ class MemoryMap(
         # lay an erased grid of my cell type over the memory-mapped file and return it; it presents
         # the buffer protocol, which is what the tile generators consume
         return qed.libpyre.grid.map(
-            uri=path, shape=list(self.shape), cell=self.cell.cell, create=False
+            uri=path, shape=self.shape, cell=self.cell.cell, create=False
         )
 
     def _collectStatistics(self):
@@ -197,10 +197,6 @@ class MemoryMap(
         # center it in my shape
         center = tuple((s - t) // 2 for s, t in zip(shape, tile))
 
-        # convert to a grid index
-        center = list(center)
-        # and a shape
-        tile = list(tile)
         # compute the stats
         stats = qed.libqed.native.stats(source=data, origin=center, shape=tile)
         # and return them

--- a/pkg/readers/native/datasets/MemoryMap.py
+++ b/pkg/readers/native/datasets/MemoryMap.py
@@ -177,23 +177,11 @@ class MemoryMap(
 
         # grab the path to the dataset
         path = str(uri.address)
-        # build the name of the buffer factory
-        memoryType = f"{self.cell.tag}ConstMap"
-        # look up the factory in the {pyre::memory} bindings
-        bufferFactory = getattr(qed.libpyre.memory, memoryType)
-        # make the memory buffer
-        buffer = bufferFactory(path)
-
-        # realize the dataset shape
-        shape = qed.libpyre.grid.Shape2D(shape=self.shape)
-        # build the packing
-        packing = qed.libpyre.grid.Canonical2D(shape=shape)
-        # grab the grid factory
-        gridFactory = getattr(qed.libpyre.grid, f"{memoryType}Grid2D")
-        # put it all together
-        data = gridFactory(packing, buffer)
-        # and return it
-        return data
+        # lay an erased grid of my cell type over the memory-mapped file and return it; it presents
+        # the buffer protocol, which is what the tile generators consume
+        return qed.libpyre.grid.map(
+            uri=path, shape=list(self.shape), cell=self.cell.cell, create=False
+        )
 
     def _collectStatistics(self):
         """
@@ -210,9 +198,9 @@ class MemoryMap(
         center = tuple((s - t) // 2 for s, t in zip(shape, tile))
 
         # convert to a grid index
-        center = qed.libpyre.grid.Index2D(index=center)
+        center = list(center)
         # and a shape
-        tile = qed.libpyre.grid.Shape2D(shape=tile)
+        tile = list(tile)
         # compute the stats
         stats = qed.libqed.native.stats(source=data, origin=center, shape=tile)
         # and return them

--- a/pkg/readers/nisar/products/BFPQSLC.py
+++ b/pkg/readers/nisar/products/BFPQSLC.py
@@ -114,10 +114,6 @@ class BFPQSLC(Product, family="qed.datasets.nisar.products.bfpqslc"):
         # center it in my shape
         center = tuple((s - t) // 2 for s, t in zip(shape, tile))
 
-        # convert to a grid index
-        center = list(center)
-        # and a shape
-        tile = list(tile)
         # compute the stats
         stats = qed.libqed.nisar.statsBFPQ(
             source=source,

--- a/pkg/readers/nisar/products/BFPQSLC.py
+++ b/pkg/readers/nisar/products/BFPQSLC.py
@@ -115,9 +115,9 @@ class BFPQSLC(Product, family="qed.datasets.nisar.products.bfpqslc"):
         center = tuple((s - t) // 2 for s, t in zip(shape, tile))
 
         # convert to a grid index
-        center = qed.libpyre.grid.Index2D(index=center)
+        center = list(center)
         # and a shape
-        tile = qed.libpyre.grid.Shape2D(shape=tile)
+        tile = list(tile)
         # compute the stats
         stats = qed.libqed.nisar.statsBFPQ(
             source=source,

--- a/pkg/readers/nisar/products/Product.py
+++ b/pkg/readers/nisar/products/Product.py
@@ -215,9 +215,9 @@ class Product(
         center = tuple((s - t) // 2 for s, t in zip(shape, tile))
 
         # convert to a grid index
-        center = qed.libpyre.grid.Index2D(index=center)
+        center = list(center)
         # and a shape
-        tile = qed.libpyre.grid.Shape2D(shape=tile)
+        tile = list(tile)
         # compute the stats
         stats = qed.libqed.nisar.stats(
             source=source, datatype=self.datatype.htype, origin=center, shape=tile

--- a/pkg/readers/nisar/products/Product.py
+++ b/pkg/readers/nisar/products/Product.py
@@ -214,10 +214,6 @@ class Product(
         # center it in my shape
         center = tuple((s - t) // 2 for s, t in zip(shape, tile))
 
-        # convert to a grid index
-        center = list(center)
-        # and a shape
-        tile = list(tile)
         # compute the stats
         stats = qed.libqed.nisar.stats(
             source=source, datatype=self.datatype.htype, origin=center, shape=tile

--- a/pkg/readers/nisar/products/channels/Channel.py
+++ b/pkg/readers/nisar/products/channels/Channel.py
@@ -57,12 +57,8 @@ class Channel(qed.flow.dynamic, implements=qed.protocols.channel):
         category = getattr(qed.libqed.nisar, self.category)
         # look for the tile maker in {libqed}
         pipeline = getattr(category, self.tag)
-        # turn the shape into a {pyre::grid::shape_t}
-        shape = list(shape)
-        # the origin into a {pyre::grid::index_t}
-        origin = list(origin)
-        # and the zoom into strides
-        stride = list(tuple(2**level for level in zoom))
+        # turn the zoom levels into per-axis strides
+        stride = tuple(2**level for level in zoom)
         # build the visualization pipeline and return it
         return pipeline(
             source=source.data.dataset,

--- a/pkg/readers/nisar/products/channels/Channel.py
+++ b/pkg/readers/nisar/products/channels/Channel.py
@@ -58,11 +58,11 @@ class Channel(qed.flow.dynamic, implements=qed.protocols.channel):
         # look for the tile maker in {libqed}
         pipeline = getattr(category, self.tag)
         # turn the shape into a {pyre::grid::shape_t}
-        shape = qed.libpyre.grid.Shape2D(shape=shape)
+        shape = list(shape)
         # the origin into a {pyre::grid::index_t}
-        origin = qed.libpyre.grid.Index2D(index=origin)
+        origin = list(origin)
         # and the zoom into strides
-        stride = qed.libpyre.grid.Index2D(index=tuple(2**level for level in zoom))
+        stride = list(tuple(2**level for level in zoom))
         # build the visualization pipeline and return it
         return pipeline(
             source=source.data.dataset,

--- a/pkg/readers/nisar/products/channels/MeanPower.py
+++ b/pkg/readers/nisar/products/channels/MeanPower.py
@@ -67,11 +67,11 @@ class MeanPower(Channel, family="qed.channels.nisar.meanpower"):
         # my pipeline reduces several sources at once
         pipeline = qed.libqed.nisar.stack.meanpower
         # turn the shape into a {pyre::grid::shape_t}
-        shape = qed.libpyre.grid.Shape2D(shape=shape)
+        shape = list(shape)
         # the origin into a {pyre::grid::index_t}
-        origin = qed.libpyre.grid.Index2D(index=origin)
+        origin = list(origin)
         # and the zoom into strides
-        stride = qed.libpyre.grid.Index2D(index=tuple(2**level for level in zoom))
+        stride = list(tuple(2**level for level in zoom))
         # collect the data handle of each participating member
         sources = [member.data.dataset for member in members]
         # lift my range out of log scale

--- a/pkg/readers/nisar/products/channels/MeanPower.py
+++ b/pkg/readers/nisar/products/channels/MeanPower.py
@@ -66,12 +66,8 @@ class MeanPower(Channel, family="qed.channels.nisar.meanpower"):
         """
         # my pipeline reduces several sources at once
         pipeline = qed.libqed.nisar.stack.meanpower
-        # turn the shape into a {pyre::grid::shape_t}
-        shape = list(shape)
-        # the origin into a {pyre::grid::index_t}
-        origin = list(origin)
-        # and the zoom into strides
-        stride = list(tuple(2**level for level in zoom))
+        # turn the zoom levels into per-axis strides
+        stride = tuple(2**level for level in zoom)
         # collect the data handle of each participating member
         sources = [member.data.dataset for member in members]
         # lift my range out of log scale

--- a/pkg/readers/nisar/products/channels/StackCoherence.py
+++ b/pkg/readers/nisar/products/channels/StackCoherence.py
@@ -69,12 +69,8 @@ class StackCoherence(Channel, family="qed.channels.nisar.stack.coherence"):
         """
         # my pipeline reduces several sources at once
         pipeline = qed.libqed.nisar.stack.coherence
-        # turn the shape into a {pyre::grid::shape_t}
-        shape = list(shape)
-        # the origin into a {pyre::grid::index_t}
-        origin = list(origin)
-        # and the zoom into strides
-        stride = list(tuple(2**level for level in zoom))
+        # turn the zoom levels into per-axis strides
+        stride = tuple(2**level for level in zoom)
         # collect the data handle of each participating member
         sources = [member.data.dataset for member in members]
         # build the visualization pipeline and return it; the coherence range is already linear

--- a/pkg/readers/nisar/products/channels/StackCoherence.py
+++ b/pkg/readers/nisar/products/channels/StackCoherence.py
@@ -70,11 +70,11 @@ class StackCoherence(Channel, family="qed.channels.nisar.stack.coherence"):
         # my pipeline reduces several sources at once
         pipeline = qed.libqed.nisar.stack.coherence
         # turn the shape into a {pyre::grid::shape_t}
-        shape = qed.libpyre.grid.Shape2D(shape=shape)
+        shape = list(shape)
         # the origin into a {pyre::grid::index_t}
-        origin = qed.libpyre.grid.Index2D(index=origin)
+        origin = list(origin)
         # and the zoom into strides
-        stride = qed.libpyre.grid.Index2D(index=tuple(2**level for level in zoom))
+        stride = list(tuple(2**level for level in zoom))
         # collect the data handle of each participating member
         sources = [member.data.dataset for member in members]
         # build the visualization pipeline and return it; the coherence range is already linear

--- a/pkg/stacks/Dataset.py
+++ b/pkg/stacks/Dataset.py
@@ -169,10 +169,6 @@ class Dataset(
         tile = tuple(min(256, extent) for extent in self.shape)
         # centered in my shape
         center = tuple((extent - t) // 2 for extent, t in zip(self.shape, tile))
-        # as a grid index
-        center = qed.libpyre.grid.Index2D(index=center)
-        # and a grid shape
-        tile = qed.libpyre.grid.Shape2D(shape=tile)
         # sample the per-pixel mean power over my members
         return qed.libqed.nisar.stack.stats(
             sources=sources, datatype=self.datatype.htype, origin=center, shape=tile


### PR DESCRIPTION
Adapt qed to the pyre::grid reimplementation.

This tracks the pyre grid rewrite (pyre#211), which retires the per-cell-type grid
bindings and the typed-grid Python classes in favor of a single type-erased grid that
presents the buffer protocol. qed consumed the old model in three places — its C++ tile
generators, their bindings, and the Python readers — all of which are reworked here. The
numerical kernels in `lib/qed` are unchanged.

## Grid bindings

The tile generators fall into two families:

- **native and isce2** take a grid as their source. Each binding is replaced by one
  wrapper that receives a `py::buffer` (the erased grid, or anything else that speaks the
  buffer protocol), rebuilds a read-only typed grid over it with `onGrid`, and dispatches
  on the buffer's cell format to the existing kernel. The shared helper lives in
  `ext/qed/grid.h`/`grid.icc`: `onGrid<dim, cellTs...>` for the dispatch, and `asGrid`,
  `asIndex`, `asShape` for the conversions. This collapses the old per-cell-type overload
  piles to one wrapper per generator.

- **nisar** reads a tile out of an HDF5 dataset (using an on-disk `datatype`) and only uses
  the grid type at compile time for the tile geometry. Those wrappers keep the dataset and
  datatype and convert the geometry. The stack generators take a list of datasets; the
  masked variants take a second dataset for the mask; the BFPQ generators take the lookup
  table as a buffer, which `asBFPQ` rebuilds into the small heap grid the kernels expect.

Geometry arguments accept any Python iterable — tuple, list, or generator — so callers hand
in coordinates without wrapping them.

## Readers

The readers no longer build `Shape2D`/`Index2D`/`Canonical` objects or per-type grid
factories. The three memory-mapped-file readers (native `MemoryMap`, the isce2 datasets)
lay a `pyre.grid.map` erased grid over the file; the rest pass their geometry as plain
sequences to the tile generators.

## Datatypes

Each concrete datatype carries a `cell` attribute — the pyre memory cell name (`float32`,
`complex64`, …) — which is what `pyre.grid` wants when it lays a grid over memory. The
existing `tag` remains the class-name form used to build qed's own type-specialized binding
names (`profileFloat`).

## Dependency

Requires pyre#211. Verified against the live client on NISAR GUNW products — the nisar real
and complex channels (including the masked coherence and the wrapped-interferogram phase)
render correctly.
