### PR TITLE
qed: track the pyre h5 property list api

### DIFF
--- a/pkg/cli/S3.py
+++ b/pkg/cli/S3.py
@@ -397,7 +397,9 @@ class S3(qed.shells.command, family="qed.cli.s3"):
             # convert it into K, and make it a little bigger
             cache = self.cache * 1024 * page
             # set the paging characteristics
-            fapl.setPageBufferSize(page=cache, meta=50, raw=50)
+            fapl.pageBufferSize = libh5.properties.PageBuffer(
+                bytes=cache, metadata=50, raw=50
+            )
         # make a reader
         reader = qed.h5.reader(uri=uri, fapl=fapl)
 
@@ -407,7 +409,7 @@ class S3(qed.shells.command, family="qed.cli.s3"):
         channel.line(f"opened '{uri}'")
         channel.indent()
         channel.line(
-            f"page size: {reader._file._pyre_id.fapl.getPageBufferSize()} bytes"
+            f"page buffer: {reader._file._pyre_id.fapl.pageBufferSize.bytes} bytes"
         )
         channel.outdent()
         # flush
@@ -429,11 +431,11 @@ class S3(qed.shells.command, family="qed.cli.s3"):
         # if it's non-trivial
         if page:
             # ask for the paged strategy
-            fcpl.setFilespaceStrategy(
+            fcpl.filespaceStrategy = libh5.properties.FilespaceStrategy(
                 strategy=libh5.FilespaceStrategy.page, persist=False, threshold=1
             )
             # set the page size
-            fcpl.setPageSize(size=1024 * page)
+            fcpl.pageSize = 1024 * page
         # make a tag
         tag = "default" if page == 0 else f"{page}k"
         # assemble the filename

--- a/pkg/readers/nisar/H5.py
+++ b/pkg/readers/nisar/H5.py
@@ -12,7 +12,9 @@ import qed
 
 
 # the basic reader for products in HDF5 format
-class H5(qed.flow.factory, family="qed.readers.nisar.h5", implements=qed.protocols.reader):
+class H5(
+    qed.flow.factory, family="qed.readers.nisar.h5", implements=qed.protocols.reader
+):
     """
     The base class for readers of HDF5 files
     """
@@ -93,7 +95,9 @@ class H5(qed.flow.factory, family="qed.readers.nisar.h5", implements=qed.protoco
             # form the cache size
             size = 4 * 1024 * pages
             # adjust the {fapl}
-            fapl.setPageBufferSize(page=size, meta=5, raw=50)
+            fapl.pageBufferSize = qed.h5.libh5.properties.PageBuffer(
+                bytes=size, metadata=5, raw=50
+            )
         # if i'm managed, get access credentials from the archive
         credentials = archive.credentials() if archive else {}
         # open my file

--- a/pkg/readers/nisar/products/Product.py
+++ b/pkg/readers/nisar/products/Product.py
@@ -164,7 +164,7 @@ class Product(
         # save the dataset
         self.data = data
         # ask {h5} for its on-disk layout
-        layout = data.dcpl.getLayout()
+        layout = data.dcpl.layout
         # if it is chunked
         if layout == qed.h5.libh5.Layout.chunked:
             # adjust my tile to match the dataset chunk size


### PR DESCRIPTION
## Summary

pyre's `libh5.properties.{fapl,fcpl,dcpl,...}` bindings replaced their `getX()`/`setX(...)` methods with pybind11 properties, and compound values are now named records in `libh5.properties` (`PageBuffer`, `FilespaceStrategy`, `Alignment`, `Cache`, `VersionBounds`, `Sizes`). The enums stay on `libh5` (`libh5.FilespaceStrategy.page`, `libh5.Layout.chunked`). This PR moves qed's call sites to the new api.

## Changes

- `pkg/cli/S3.py`
  - the reader: `fapl.setPageBufferSize(...)` → `fapl.pageBufferSize = libh5.properties.PageBuffer(bytes=, metadata=, raw=)`; the diagnostic reads `fapl.pageBufferSize.bytes`
  - the writer: `fcpl.setFilespaceStrategy(...)` → `fcpl.filespaceStrategy = libh5.properties.FilespaceStrategy(...)`; `fcpl.setPageSize(...)` → `fcpl.pageSize = ...`
- `pkg/readers/nisar/H5.py`: the page aggregator is configured through `fapl.pageBufferSize`
- `pkg/readers/nisar/products/Product.py`: the on-disk layout is read from `data.dcpl.layout`

These are the only touchpoints; `lib/` and `ext/` do not use pyre property lists.

## Verification

- `mm qed.pkg`; `tests/qed.pkg` `sanity` and `stacks` pass
- opened `tests/data/nisar/gcov.h5` through `qed.readers.nisar.gcov`, exercising the `fapl` and `dcpl.layout` paths
- `qed s3 empty --page=4` writes a paged file through the new `fcpl` path; `qed s3 explore` on it round-trips the page buffer size (`--cache=2` → 8192 bytes, `--cache=16` → 65536 bytes)