### PR TITLE
The zoom minimap renders a dataset thumbnail that seeds whole-dataset statistics

### DIFF
--- a/ext/qed/external.h
+++ b/ext/qed/external.h
@@ -49,6 +49,8 @@ namespace qed::py {
 
     // a collection of tile statstics
     using stats_t = std::tuple<double, double, double>;
+    // a mergeable statistical sample: count, min, mean, m2, max
+    using sample_t = std::tuple<double, double, double, double, double>;
 
     // aliases for hdf5 entities
     using dataset_t = pyre::h5::dataset_t;

--- a/ext/qed/native/stats.cc
+++ b/ext/qed/native/stats.cc
@@ -36,6 +36,27 @@ qed::py::native::stats(py::module & m)
         // the docstring
         "compute the statistics of a tile");
 
+    // collect a mergeable sample of a strided tile, the render footprint of a decimated view
+    m.def(
+        // the name of the function
+        "sample",
+        // the handler
+        [](const py::buffer & source, const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride) -> sample_t {
+            // rebuild the tile geometry as rank-2 grid coordinates
+            auto o = asIndex<2>(origin);
+            auto t = asShape<2>(shape);
+            auto s = asIndex<2>(stride);
+            // dispatch on the buffer's cell type and sample the matching grid
+            return onGrid<2, char, int8_t, int16_t, int32_t, int64_t, float, double,
+                          std::complex<float>, std::complex<double>>(
+                source, [&](const auto & grid) { return qed::native::sample(grid, o, t, s); });
+        },
+        // the signature
+        "source"_a, "origin"_a, "shape"_a, "stride"_a,
+        // the docstring
+        "collect a mergeable statistical sample of the strided tile at {origin}+{shape}");
+
     // all done
     return;
 }

--- a/ext/qed/nisar/stats.cc
+++ b/ext/qed/nisar/stats.cc
@@ -52,6 +52,40 @@ qed::py::nisar::stats(py::module & m)
         // the docstring
         "compute the statistics of a BFPQ encoded slc tile");
 
+    // collect a mergeable sample of a strided complex slc tile
+    m.def(
+        // the name
+        "sample",
+        // the handler
+        [](const dataset_t & source, const datatype_t & datatype, const py::iterable & origin,
+           const py::iterable & shape, const py::iterable & stride) -> sample_t {
+            // read the decimated tile and sample it
+            return qed::nisar::sample<grid_t>(
+                source, datatype, asIndex<2>(origin), asShape<2>(shape), asIndex<2>(stride));
+        },
+        // the signature
+        "source"_a, "datatype"_a, "origin"_a, "shape"_a, "stride"_a,
+        // the docstring
+        "collect a mergeable statistical sample of the strided slc tile at {origin}+{shape}");
+
+    // collect a mergeable sample of a strided BFPQ encoded slc tile
+    m.def(
+        // the name
+        "sampleBFPQ",
+        // the handler
+        [](const dataset_t & source, const datatype_t & datatype, const py::buffer & lut,
+           const py::iterable & origin, const py::iterable & shape,
+           const py::iterable & stride) -> sample_t {
+            // read and decode the decimated tile, then sample it
+            return qed::nisar::sampleBFPQ<grid_t>(
+                source, datatype, asBFPQ(lut), asIndex<2>(origin), asShape<2>(shape),
+                asIndex<2>(stride));
+        },
+        // the signature
+        "source"_a, "datatype"_a, "bfpq"_a, "origin"_a, "shape"_a, "stride"_a,
+        // the docstring
+        "collect a mergeable statistical sample of the strided BFPQ tile at {origin}+{shape}");
+
     // all done
     return;
 }

--- a/lib/qed/native/stats.h
+++ b/lib/qed/native/stats.h
@@ -11,6 +11,10 @@
 namespace qed::native {
     // the layout of the collected statistics
     using stats_t = std::tuple<double, double, double>;
+    // the layout of a mergeable statistical sample: count, min, mean, m2, max; samples from
+    // different tiles combine with the parallel form of Welford's update, so workers can
+    // contribute partial results that accumulate into whole-dataset statistics
+    using sample_t = std::tuple<double, double, double, double, double>;
 
     // stats for a complex grid source
     template <typename sourceT>
@@ -25,6 +29,19 @@ namespace qed::native {
     // the helper that collects the statistics
     template <typename sourceT>
     auto collectStatistics(const sourceT & source) -> stats_t;
+
+    // a mergeable sample of the magnitudes of a strided tile; {origin} and {tile} are in
+    // decimated coordinates, exactly as the render kernels see them
+    template <typename sourceT>
+    auto sample(
+        // the source
+        const sourceT & source,
+        // the origin of the tile
+        typename sourceT::index_type origin,
+        // the tile shape
+        typename sourceT::shape_type tile,
+        // the strides
+        typename sourceT::index_type stride) -> sample_t;
 }
 
 

--- a/lib/qed/native/stats.icc
+++ b/lib/qed/native/stats.icc
@@ -81,4 +81,61 @@ qed::native::collectStatistics(
 }
 
 
+// collect a mergeable sample of the magnitudes of a strided tile
+template <typename sourceT>
+auto
+qed::native::sample(
+    // the source
+    const sourceT & source,
+    // the origin of the tile
+    typename sourceT::index_type origin,
+    // the tile shape
+    typename sourceT::shape_type tile,
+    // the strides
+    typename sourceT::index_type stride) -> sample_t
+{
+    // my counters: the number of samples and the running mean and second moment
+    double count = 0.0, mean = 0.0, m2 = 0.0;
+    // the running extrema
+    double min = std::numeric_limits<double>::max();
+    double max = std::numeric_limits<double>::lowest();
+
+    // go through the rows of the tile
+    for (auto i = 0l; i < static_cast<long>(tile[0]); ++i) {
+        // and its columns
+        for (auto j = 0l; j < static_cast<long>(tile[1]); ++j) {
+            // project the tile cell onto the source, the way the render kernels do: the
+            // origin is in decimated coordinates, and the stride spaces the samples
+            auto idx = typename sourceT::index_type { (origin[0] + i) * stride[0],
+                                                      (origin[1] + j) * stride[1] };
+            // compute the magnitude
+            double r = std::abs(source[idx]);
+            // if this is a nan
+            if (std::isnan(r)) {
+                // don't let it pollute the sample
+                continue;
+            }
+            // count the contribution
+            count += 1.0;
+            // fold it into the running mean and second moment, a la Welford
+            double delta = r - mean;
+            mean += delta / count;
+            m2 += delta * (r - mean);
+            // and update the extrema
+            min = std::min(min, r);
+            max = std::max(max, r);
+        }
+    }
+
+    // an empty sample, e.g. a tile of nothing but nans
+    if (count == 0.0) {
+        // contributes nothing; the accumulator skips it
+        return { 0.0, 0.0, 0.0, 0.0, 0.0 };
+    }
+
+    // all done
+    return { count, min, mean, m2, max };
+}
+
+
 // end of file

--- a/lib/qed/nisar/stats.h
+++ b/lib/qed/nisar/stats.h
@@ -34,6 +34,37 @@ namespace qed::nisar {
         typename sourceT::index_type origin,
         // the tile shape
         typename sourceT::shape_type tile) -> native::stats_t;
+
+    // a mergeable sample of a strided tile of a complex HDF5 source; {origin} and {tile} are
+    // in decimated coordinates, exactly as the render kernels see them
+    template <typename sourceT>
+    auto sample(
+        // the source
+        const dataset_t & source,
+        // the data layout
+        const datatype_t & datatype,
+        // the origin of the tile
+        typename sourceT::index_type origin,
+        // the tile shape
+        typename sourceT::shape_type tile,
+        // the strides
+        typename sourceT::index_type stride) -> native::sample_t;
+
+    // a mergeable sample of a strided tile of a BFPQ encoded complex HDF5 source
+    template <typename sourceT>
+    auto sampleBFPQ(
+        // the source
+        const dataset_t & source,
+        // the data layout
+        const datatype_t & datatype,
+        // the BFPQ lookup table
+        bfpq_lut_t bfpq,
+        // the origin of the tile
+        typename sourceT::index_type origin,
+        // the tile shape
+        typename sourceT::shape_type tile,
+        // the strides
+        typename sourceT::index_type stride) -> native::sample_t;
 }
 
 

--- a/lib/qed/nisar/stats.icc
+++ b/lib/qed/nisar/stats.icc
@@ -73,4 +73,83 @@ qed::nisar::statsBFPQ(
 }
 
 
+// collect a mergeable sample of a strided tile
+template <typename sourceT>
+auto
+qed::nisar::sample(
+    // the source
+    const dataset_t & dataset,
+    // the layout
+    const datatype_t & datatype,
+    // the origin of the tile
+    typename sourceT::index_type origin,
+    // the tile shape
+    typename sourceT::shape_type tile,
+    // the strides
+    typename sourceT::index_type stride) -> native::sample_t
+{
+    // the origin of the data region is scaled by the stride
+    auto from = origin;
+    // by going through its entries
+    for (int axis = 0; axis < decltype(from)::rank(); ++axis) {
+        // and multiplying them by the stride
+        from[axis] *= stride[axis];
+    }
+    // read the decimated tile; the hyperslab machinery applies the stride
+    auto source = pyre::h5::read<sourceT>(dataset, datatype, from, tile, stride);
+    // the data is now dense in memory, so sample it at unit stride
+    return native::sample(source, { 0, 0 }, tile, { 1, 1 });
+}
+
+
+// collect a mergeable sample of a strided BFPQ encoded tile
+template <typename sourceT>
+auto
+qed::nisar::sampleBFPQ(
+    // the source
+    const dataset_t & dataset,
+    // the layout
+    const datatype_t & datatype,
+    // the BFPQ lookup table
+    bfpq_lut_t bfpq,
+    // the origin of the tile
+    typename sourceT::index_type origin,
+    // the tile shape
+    typename sourceT::shape_type tile,
+    // the strides
+    typename sourceT::index_type stride) -> native::sample_t
+{
+    // type aliases
+    using value_t = typename sourceT::value_type;
+    using layout_t = typename sourceT::packing_type;
+
+    // the origin of the data region is scaled by the stride
+    auto from = origin;
+    // by going through its entries
+    for (int axis = 0; axis < decltype(from)::rank(); ++axis) {
+        // and multiplying them by the stride
+        from[axis] *= stride[axis];
+    }
+    // read the decimated BFPQ encoded data into a grid
+    auto source = pyre::h5::read<bfpq_slc_t>(dataset, datatype, from, tile, stride);
+    // describe the decoded tile
+    auto packing = layout_t { tile };
+    // build storage for the decoded tile
+    auto decoded = sourceT(packing, packing.cells());
+    // the decoder
+    auto decoder = [&](bfpq_slc_cell_t encoded) -> value_t {
+        // unpack and decode
+        auto r = bfpq.at(encoded.real());
+        auto i = bfpq.at(encoded.imag());
+        // pack and ship
+        return value_t { r, i };
+    };
+    // decode the tile
+    std::transform(source.cbegin(), source.cend(), decoded.begin(), decoder);
+
+    // the data is now dense in memory, so sample it at unit stride
+    return native::sample(decoded, { 0, 0 }, tile, { 1, 1 });
+}
+
+
 // end of file

--- a/lib/qed/nisar/stats.icc
+++ b/lib/qed/nisar/stats.icc
@@ -68,8 +68,8 @@ qed::nisar::statsBFPQ(
     // decode the tile
     std::transform(source.cbegin(), source.cend(), decoded.begin(), decoder);
 
-    // compute the statistics and pass them on
-    return native::collectStatistics(source);
+    // compute the statistics of the decoded tile and pass them on
+    return native::collectStatistics(decoded);
 }
 
 

--- a/pkg/controllers/Controller.py
+++ b/pkg/controllers/Controller.py
@@ -30,6 +30,18 @@ class Controller(qed.component, implements=qed.protocols.controller):
         # all done
         return
 
+    def widen(self, stats: tuple) -> bool:
+        """
+        Expand my display bounds to accommodate {stats}, the accumulated whole-dataset
+        statistics, without ever touching the user's picks
+        """
+        # controllers pinned by the user stay exactly where they were put
+        if not self.auto:
+            # untouched
+            return False
+        # otherwise, let my flavor decide; it reports whether anything actually moved
+        return self._widen(stats=stats)
+
     # metamethods
     def __init__(self, **kwds):
         # chain up
@@ -68,8 +80,18 @@ class Controller(qed.component, implements=qed.protocols.controller):
         # i don't know much about how to do that
         return
 
+    def _widen(self, stats: tuple) -> bool:
+        """
+        Expand my display bounds to accommodate {stats}
+        """
+        # by default, there is nothing to expand
+        return False
+
     # constants
     tag = "controller"
+    # traits that shape the presentation but not the rendered pixels; they are excluded from
+    # tile identities, so adjusting them does not invalidate cached work
+    cosmetic = ("min", "max")
 
 
 # end of file

--- a/pkg/controllers/LinearRange.py
+++ b/pkg/controllers/LinearRange.py
@@ -65,6 +65,39 @@ class LinearRange(Controller, family="qed.controllers.linearrange"):
         # all done
         return
 
+    def _widen(self, stats: tuple) -> bool:
+        """
+        Expand my bounds to accommodate {stats}, the accumulated whole-dataset statistics
+        """
+        # unpack the stats
+        low, mean, high = stats
+        # measure the current span
+        span = self.max - self.min
+        # small escapes are tolerated; the slack provides hysteresis
+        slack = 0.05 * span if span > 0 else 0.0
+        # if the current bounds accommodate the data to within the slack
+        if low >= self.min - slack and high <= self.max + slack:
+            # nothing to do
+            return False
+        # form the widened extent
+        lowest = min(self.min, low)
+        highest = max(self.max, high)
+        # with some breathing room, so the next small escape doesn't move them again
+        margin = 0.05 * (highest - lowest)
+        # bounds adjustments are presentation only, so my dirty flag must survive them
+        marked = self.dirty
+        # widen whichever end the data escaped
+        if low < self.min - slack:
+            # the bottom
+            self.min = lowest - margin
+        if high > self.max + slack:
+            # the top
+            self.max = highest + margin
+        # restore the flag
+        self.dirty = marked
+        # report the move
+        return True
+
     # constants
     tag = "range"
 

--- a/pkg/controllers/LogRange.py
+++ b/pkg/controllers/LogRange.py
@@ -76,6 +76,38 @@ class LogRange(Controller, family="qed.controllers.logrange"):
         # all done
         return
 
+    def _widen(self, stats: tuple) -> bool:
+        """
+        Expand my bounds to accommodate {stats}, the accumulated whole-dataset statistics
+        """
+        # unpack the stats, which arrive in linear scale
+        low, mean, high = stats
+        # a degenerate sample has nothing to teach a log scale
+        if high <= 0:
+            # so leave things alone
+            return False
+        # protect the low end from zeros and excessive dynamic range, like {_autotune} does
+        if low <= 0 or low / high < 1e-3:
+            # by clipping it
+            low = high / 1e3
+        # form the candidate bounds on whole decades, which provides natural hysteresis:
+        # the bounds only move when the data escapes the current decade
+        lowest = math.floor(math.log10(low))
+        highest = math.ceil(math.log10(high))
+        # if the current bounds already accommodate the data
+        if lowest >= self.min and highest <= self.max:
+            # nothing to do
+            return False
+        # bounds adjustments are presentation only, so my dirty flag must survive them
+        marked = self.dirty
+        # widen, and only ever widen, each end
+        self.min = min(self.min, lowest)
+        self.max = max(self.max, highest)
+        # restore the flag
+        self.dirty = marked
+        # report the move
+        return True
+
     # constants
     tag = "range"
 

--- a/pkg/nexus/Fleet.py
+++ b/pkg/nexus/Fleet.py
@@ -62,8 +62,10 @@ class Fleet(qed.component, family="qed.nexus.fleets.tile"):
         team = Team(name=f"{self.pyre_name}.{reader}")
         # the team's crew traffic rides the shared event loop
         team.dispatcher = self.dispatcher
-        # and its successful renders land in the shared cache
+        # its successful renders land in the shared cache
         team.cache = self.cache
+        # and their statistical samples drain into the shared sink
+        team.stats = self.stats
         # register it
         self.teams[reader] = team
         # show me
@@ -128,6 +130,9 @@ class Fleet(qed.component, family="qed.nexus.fleets.tile"):
         # the shared event loop; whoever builds me is responsible for setting it before any
         # tiles are rendered
         self.dispatcher = None
+        # the statistics sink; whoever builds me wires it, and teams formed afterwards
+        # drain their samples into it
+        self.stats = None
         # all done
         return
 

--- a/pkg/nexus/Server.py
+++ b/pkg/nexus/Server.py
@@ -4,6 +4,9 @@
 # (c) 1998-2026 all rights reserved
 
 
+# externals
+import json
+
 # support
 import pyre
 
@@ -45,8 +48,30 @@ class Server(http, family="qed.nexus.servers.http"):
             # the statistical samples the crews take drain into the store, where they
             # accumulate into whole-dataset statistics
             fleet.stats = ux.store.accumulate
+            # and when the accumulation moves controller bounds, the store broadcasts a
+            # change notification so live clients refetch their state
+            ux.store.notifier = self.notifyChange
         # attach the fleet
         self.fleet = fleet
+        # all done
+        return
+
+    # interface
+    def notifyChange(self):
+        """
+        Push a change notification to every live client subscribed to my hub
+        """
+        # the notification frame is constant, so build it once; the framing matches the one
+        # the graphql handler broadcasts after successful mutations, so clients treat both
+        # identically: any message means "refetch your state"
+        if self._changeFrame is None:
+            # use the {EventStream} framing so the wire format lives in one place
+            stream = self.eventStream(server=self)
+            # a minimal payload
+            self._changeFrame = stream.event(json.dumps({"type": "change"}))
+        # broadcast it on the global topic; coalesce, so a burst collapses into a single
+        # pending refetch per client rather than a storm
+        self.hub.publish(self._changeFrame, coalesce=True)
         # all done
         return
 
@@ -67,6 +92,7 @@ class Server(http, family="qed.nexus.servers.http"):
     # implementation details
     # private data
     fleet = None  # the manager of the tile rendering teams, built at activation
+    _changeFrame = None  # the constant change notification frame, built on first use
 
 
 # end of file

--- a/pkg/nexus/Server.py
+++ b/pkg/nexus/Server.py
@@ -38,7 +38,14 @@ class Server(http, family="qed.nexus.servers.http"):
         # its teams must never spin their own event loops: crew traffic is serviced by the
         # node's selector, so hand the fleet the shared dispatcher
         fleet.dispatcher = dispatcher
-        # and attach it
+        # find the ux manager, mounted while the application folders were being assembled
+        ux = getattr(app, "_ux", None)
+        # if it is there
+        if ux is not None:
+            # the statistical samples the crews take drain into the store, where they
+            # accumulate into whole-dataset statistics
+            fleet.stats = ux.store.accumulate
+        # attach the fleet
         self.fleet = fleet
         # all done
         return

--- a/pkg/nexus/Spool.py
+++ b/pkg/nexus/Spool.py
@@ -71,13 +71,15 @@ class Spool:
         return
 
     # metamethods
-    def __init__(self, size, file=None, **kwds):
+    def __init__(self, size, file=None, stats=None, **kwds):
         # chain up
         super().__init__(**kwds)
         # the payload size
         self.size = size
         # the file that holds the payload
         self.file = file
+        # the statistical sample of the rendered source region, when the worker took one
+        self.stats = stats
         # all done
         return
 
@@ -85,8 +87,9 @@ class Spool:
         """
         Prepare for the trip over the wire
         """
-        # descriptors cannot travel in the byte stream; only the size gets pickled
-        return {"size": self.size}
+        # descriptors cannot travel in the byte stream; the size and the statistics record,
+        # a small tuple of floats, are the only pickled cargo
+        return {"size": self.size, "stats": self.stats}
 
     def __setstate__(self, state):
         """
@@ -94,6 +97,8 @@ class Spool:
         """
         # restore the size
         self.size = state["size"]
+        # and the statistics record, tolerating reports from workers that took no sample
+        self.stats = state.get("stats")
         # the descriptor arrives separately, as ancillary data
         self.file = None
         # all done

--- a/pkg/nexus/Team.py
+++ b/pkg/nexus/Team.py
@@ -52,6 +52,10 @@ class Team(Staff, family="qed.nexus.teams.tile"):
         super().collect(task=task, result=result)
         # if the result is spooled
         if isinstance(result, Spool):
+            # if the worker took a statistical sample and a sink is attached
+            if result.stats is not None and self.stats is not None:
+                # hand over the record so it accumulates into whole-dataset statistics
+                self.stats(task=task, record=result.stats)
             # everybody has been served, including the case where every subscriber withdrew;
             # if a cache is attached
             if self.cache is not None:
@@ -66,6 +70,7 @@ class Team(Staff, family="qed.nexus.teams.tile"):
 
     # private data
     cache = None  # the shared tile cache, attached by the fleet that builds me
+    stats = None  # the statistics sink, attached by the fleet that builds me
 
 
 # end of file

--- a/pkg/nexus/Tile.py
+++ b/pkg/nexus/Tile.py
@@ -53,7 +53,24 @@ class Tile(pyre.nexus.task):
             raise self.RecoverableError(description=str(error)) from None
         # on success, park the encoded tile in a spool; its descriptor travels as ancillary
         # data on the crew channel, so the payload itself never crosses the wire
-        return Spool.stash(data=memoryview(tile))
+        spool = Spool.stash(data=memoryview(tile))
+        # datasets that know how to measure themselves contribute source statistics
+        sample = getattr(dataset, "sample", None)
+        # if this one does
+        if sample is not None:
+            # carefully, since the render is the deliverable and the sample is a bonus
+            try:
+                # revisit the footprint this render saw and attach the mergeable record to
+                # the report, so the team side can accumulate whole-dataset statistics
+                spool.stats = sample(
+                    zoom=self.zoom, origin=self.origin, shape=self.shape
+                )
+            # let the sample die quietly on any failure
+            except Exception:
+                # the tile is still good; it just doesn't contribute statistics
+                pass
+        # hand off the report
+        return spool
 
     # metamethods
     def __init__(self, view, channel, zoom, origin, shape, **kwds):
@@ -75,6 +92,9 @@ class Tile(pyre.nexus.task):
         self.config = self._harvestReader(reader=reader)
         # the dataset is identified by its selector, which is stable across reader rebuilds
         self.selector = dict(view.dataset.selector)
+        # record the dataset name as well; it keys the statistics accumulator on the team
+        # side, and is deliberately not part of the identity, being derived state
+        self.dataset = view.dataset.pyre_name
         # locate the visualization pipeline that carries the live controller state
         pipeline = view.pipeline(channel=channel)
         # and harvest its configuration

--- a/pkg/nexus/Tile.py
+++ b/pkg/nexus/Tile.py
@@ -204,8 +204,16 @@ class Tile(pyre.nexus.task):
         """
         # initialize the pile
         config = {}
+        # components may declare traits that shape the presentation but not the rendered
+        # pixels, e.g. the display bounds of controllers; they are left out, so adjusting
+        # them neither perturbs the tile identity nor invalidates cached work
+        cosmetic = getattr(component, "cosmetic", ())
         # go through the properties
         for trait in component.pyre_properties():
+            # skip the presentation-only ones
+            if trait.name in cosmetic:
+                # they do not travel
+                continue
             # reduce each value to wire-friendly form, insisting on primitives so that
             # infrastructure state, e.g. the flow bookkeeping sets, gets left behind
             value = self._scrub(value=getattr(component, trait.name), strict=True)

--- a/pkg/readers/native/datasets/MemoryMap.py
+++ b/pkg/readers/native/datasets/MemoryMap.py
@@ -102,6 +102,18 @@ class MemoryMap(
         # render a tile and return it
         return channel.tile(source=self, zoom=zoom, origin=origin, shape=shape)
 
+    def sample(self, zoom: tuple, origin: tuple, shape: tuple) -> tuple:
+        """
+        Collect a mergeable statistical sample of the tile at {origin}+{shape}, visiting
+        exactly the decimated footprint the render at this {zoom} sees
+        """
+        # the render pipeline decimates by striding
+        stride = tuple(2**level for level in zoom)
+        # sample the strided footprint and return the mergeable record
+        return qed.libqed.native.sample(
+            source=self.data, origin=origin, shape=shape, stride=stride
+        )
+
     def summary(self):
         """
         Build a sequence of the important channels that form my summary view

--- a/pkg/readers/nisar/products/BFPQSLC.py
+++ b/pkg/readers/nisar/products/BFPQSLC.py
@@ -87,6 +87,23 @@ class BFPQSLC(Product, family="qed.datasets.nisar.products.bfpqslc"):
         # all done
         return
 
+    def sample(self, zoom: tuple, origin: tuple, shape: tuple) -> tuple:
+        """
+        Collect a mergeable statistical sample of the tile at {origin}+{shape}, decoding the
+        BFPQ encoded values before measuring them
+        """
+        # the render pipeline decimates by striding
+        stride = tuple(2**level for level in zoom)
+        # sample the decoded strided footprint and return the mergeable record
+        return qed.libqed.nisar.sampleBFPQ(
+            source=self.data.dataset,
+            datatype=self.datatype.htype,
+            bfpq=self.bfpq,
+            origin=origin,
+            shape=shape,
+            stride=stride,
+        )
+
     # metamethods
     def __init__(self, bfpq, **kwds):
         # save the lookup table; do this before chaining up so my overrides have access

--- a/pkg/readers/nisar/products/Product.py
+++ b/pkg/readers/nisar/products/Product.py
@@ -125,6 +125,22 @@ class Product(
             **kwds,
         )
 
+    def sample(self, zoom: tuple, origin: tuple, shape: tuple) -> tuple:
+        """
+        Collect a mergeable statistical sample of the tile at {origin}+{shape}, visiting
+        exactly the decimated footprint the render at this {zoom} sees
+        """
+        # the render pipeline decimates by striding
+        stride = tuple(2**level for level in zoom)
+        # sample the strided footprint and return the mergeable record
+        return qed.libqed.nisar.sample(
+            source=self.data.dataset,
+            datatype=self.datatype.htype,
+            origin=origin,
+            shape=shape,
+            stride=stride,
+        )
+
     def summary(self):
         """
         Build a sequence of the important channels that form my summary view

--- a/pkg/ux/Dispatcher.py
+++ b/pkg/ux/Dispatcher.py
@@ -330,6 +330,12 @@ class Dispatcher:
             if extent <= 0:
                 # reject
                 return False
+            # the recognizer admits signed zoom levels, but the render pipeline only knows how
+            # to decimate; a negative level would produce a fractional stride and die deep in
+            # the extension, so refuse it here
+            if level < 0:
+                # reject
+                return False
             # the stride the render pipeline derives from the zoom level
             stride = 2**level
             # the source footprint must start within the raster

--- a/pkg/ux/Sample.py
+++ b/pkg/ux/Sample.py
@@ -1,0 +1,91 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the accumulator of whole-dataset statistics
+class Sample:
+    """
+    A mergeable accumulator of dataset statistics
+
+    Workers ship per-tile records of the form (count, min, mean, m2, max) over the magnitude
+    of the source values; this accumulator folds them together using the parallel form of
+    Welford's update, so the running statistics are exact regardless of arrival order
+    """
+
+    # interface
+    def merge(self, record: tuple) -> "Sample":
+        """
+        Fold the per-tile {record} into my running statistics
+        """
+        # unpack the record
+        count, low, mean, m2, high = record
+        # an empty record, e.g. from a tile of nothing but nans
+        if count == 0:
+            # contributes nothing
+            return self
+        # count the contribution
+        self.tiles += 1
+        # if this is the first real record
+        if self.count == 0:
+            # it becomes the running state
+            self.count = count
+            self.min = low
+            self.mean = mean
+            self.m2 = m2
+            self.max = high
+            # all done
+            return self
+        # otherwise, form the combined population size
+        total = self.count + count
+        # the distance between the two means
+        delta = mean - self.mean
+        # fold in the second moment, a la Chan et al.
+        self.m2 += m2 + delta**2 * self.count * count / total
+        # shift the mean by the record's weighted contribution
+        self.mean += delta * count / total
+        # update the population size
+        self.count = total
+        # and the extrema
+        self.min = min(self.min, low)
+        self.max = max(self.max, high)
+        # all done
+        return self
+
+    @property
+    def variance(self) -> float:
+        """
+        The variance of the accumulated sample
+        """
+        # the second moment over the population size, guarding against an empty sample
+        return self.m2 / self.count if self.count > 0 else 0.0
+
+    # metamethods
+    def __init__(self, **kwds):
+        # chain up
+        super().__init__(**kwds)
+        # the number of records folded in
+        self.tiles = 0
+        # the population size
+        self.count = 0
+        # the extrema
+        self.min = 0.0
+        self.max = 0.0
+        # the running mean and second moment
+        self.mean = 0.0
+        self.m2 = 0.0
+        # all done
+        return
+
+    def __str__(self) -> str:
+        # a compact rendering for the diagnostic channels
+        return (
+            f"tiles: {self.tiles}, count: {self.count:g}, "
+            f"min: {self.min:g}, mean: {self.mean:g}, max: {self.max:g}, "
+            f"variance: {self.variance:g}"
+        )
+
+
+# end of file

--- a/pkg/ux/Store.py
+++ b/pkg/ux/Store.py
@@ -55,6 +55,13 @@ class Store(qed.shells.command, family="qed.cli.ux"):
         channel = journal.debug("qed.ux.stats")
         # and show me the running state
         channel.log(f"{name}: {sample}")
+        # reconcile the controllers of the dataset with the accumulated range
+        touched = self._reconcile(name=name, sample=sample)
+        # if any bounds moved and someone is listening
+        if touched and self.notifier is not None:
+            # let every live client know so it refetches its state; the notification is
+            # coalesced, so a burst of adjustments collapses into a single refetch
+            self.notifier()
         # all done
         return
 
@@ -64,6 +71,35 @@ class Store(qed.shells.command, family="qed.cli.ux"):
         """
         # look it up
         return self._statistics.get(name)
+
+    def _reconcile(self, name, sample):
+        """
+        Widen the controller bounds of the dataset called {name} to accommodate the
+        accumulated {sample}: the slider ranges stretch, but the user's picks are never
+        touched, and the session token never rolls, since the rendered pixels are unchanged
+        """
+        # find the dataset
+        dataset = self.dataset(name=name)
+        # it may have been disconnected while its tiles were in flight
+        if dataset is None:
+            # in which case there is nothing to adjust
+            return False
+        # reduce the sample to the triple the controllers understand
+        stats = (sample.min, sample.mean, sample.max)
+        # nothing has moved yet
+        touched = False
+        # go through the reference pipelines of the dataset
+        for channel in dataset.channels.values():
+            # and their controllers
+            for controller, _ in channel.controllers():
+                # giving each one a chance to stretch
+                touched = controller.widen(stats=stats) or touched
+        # the per-view clones mirror the reference configuration, so they stretch too
+        for port in self._viewports:
+            # one viewport at a time
+            touched = port.view().widen(dataset=name, stats=stats) or touched
+        # report whether anything moved
+        return touched
 
     # archives
     @property
@@ -650,6 +686,11 @@ class Store(qed.shells.command, family="qed.cli.ux"):
         view = port.zoomReset()
         # all done
         return view.zoom
+
+    # private data
+    # the change broadcaster, wired by whoever owns the client connections; when set, it is
+    # invoked after controller bounds move so live clients refetch their state
+    notifier = None
 
     # metamethods
     def __init__(self, plexus, docroot, **kwds):

--- a/pkg/ux/Store.py
+++ b/pkg/ux/Store.py
@@ -14,6 +14,7 @@ from .Harvester import Harvester
 
 # my parts
 from .Archives import Archives
+from .Sample import Sample
 from .Sources import Sources
 from .Viewport import Viewport
 
@@ -33,6 +34,36 @@ class Store(qed.shells.command, family="qed.cli.ux"):
         port = self._viewports[viewport]
         # and delegate
         return port.tile(**kwds)
+
+    # statistics
+    def accumulate(self, task, record):
+        """
+        Fold the statistical {record} of a tile rendered for {task} into the running
+        whole-dataset statistics of the task's dataset
+        """
+        # get the name of the dataset the tile belongs to
+        name = getattr(task, "dataset", None)
+        # tasks from before the statistics era don't carry one
+        if name is None or record is None:
+            # and contribute nothing
+            return
+        # look up the accumulator of the dataset, creating it on first contact
+        sample = self._statistics.setdefault(name, Sample())
+        # fold in the record
+        sample.merge(record=record)
+        # make a channel
+        channel = journal.debug("qed.ux.stats")
+        # and show me the running state
+        channel.log(f"{name}: {sample}")
+        # all done
+        return
+
+    def statistics(self, name):
+        """
+        Retrieve the accumulated statistics of the dataset called {name}, if any
+        """
+        # look it up
+        return self._statistics.get(name)
 
     # archives
     @property
@@ -639,6 +670,9 @@ class Store(qed.shells.command, family="qed.cli.ux"):
         self._dataArchives = archives
         self._dataSources = sources
         self._viewports = viewports
+        # the whole-dataset statistics accumulators, keyed by dataset name, populated as
+        # rendered tiles report their samples
+        self._statistics = {}
 
         # all done
         return

--- a/pkg/ux/View.py
+++ b/pkg/ux/View.py
@@ -69,6 +69,28 @@ class View(qed.component, family="qed.ux.views.view", implements=qed.protocols.u
         # form the pipeline name and look it up
         return self._pipelines[f"{self.pyre_name}.{channel}"]
 
+    def widen(self, dataset: str, stats: tuple) -> bool:
+        """
+        Expand the controller bounds of my pipeline clones for {dataset} to accommodate
+        {stats}, the accumulated whole-dataset statistics
+        """
+        # nothing has moved yet
+        touched = False
+        # my clones for this dataset live under its namespace
+        prefix = f"{self.pyre_name}.{dataset}."
+        # go through my pipelines
+        for name, pipeline in self._pipelines.items():
+            # skipping the ones that belong to other datasets
+            if not name.startswith(prefix):
+                # on to the next one
+                continue
+            # go through the controllers of this pipeline
+            for controller, _ in pipeline.controllers():
+                # and give each one a chance to stretch
+                touched = controller.widen(stats=stats) or touched
+        # report whether anything moved
+        return touched
+
     def tile(self, channel, zoom, origin, shape):
         """
         Render a tile of data using the {channel} visualization pipeline

--- a/pkg/ux/__init__.py
+++ b/pkg/ux/__init__.py
@@ -11,6 +11,7 @@ from .Dispatcher import Dispatcher as dispatcher
 from .Store import Store as store
 from .Viewport import Viewport as viewport
 from .View import View as view
+from .Sample import Sample as sample
 
 # configurable state
 from .Source import Source as source

--- a/tests/data/native/qed.yaml
+++ b/tests/data/native/qed.yaml
@@ -62,13 +62,18 @@ qed.app:
     shell: web
     nexus.services.web:
         address: ip4:0.0.0.0:8123
-    # place the tile diagnostic under user control
+    # place the tile and stats diagnostics under user control
     journal:
         channels:
           - debug, qed.ux.tiles
+          - debug, qed.ux.stats
 
-# and turn it on: one line per tile request, with outcome and timings
+# and turn them on: one line per tile request, with outcome and timings
 qed.journal.debug.qed.ux.tiles:
+    active: yes
+
+# and one line per statistics merge, with the running whole-dataset accumulation
+qed.journal.debug.qed.ux.stats:
     active: yes
 
 # never spawn a browser; the test driver owns the browser

--- a/tests/qed.ext/sample.py
+++ b/tests/qed.ext/sample.py
@@ -1,0 +1,52 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Exercise the strided mergeable sample kernel: the Welford moments, the stride arithmetic,
+the nan hygiene, and the magnitude reduction of complex sources
+"""
+
+# externals
+import numpy as np
+
+# support
+import qed
+
+# a 4x4 ramp
+ramp = np.arange(16, dtype=np.float32).reshape(4, 4)
+# sample every other cell in each direction: the values 0, 2, 8, 10
+record = qed.libqed.native.sample(source=ramp, origin=(0, 0), shape=(2, 2), stride=(2, 2))
+# four samples, from 0 to 10, with mean 5 and second moment 68
+assert record == (4.0, 0.0, 5.0, 68.0, 10.0)
+
+# an all-nan tile
+fog = np.full((4, 4), np.nan, dtype=np.float32)
+# contributes an empty record
+record = qed.libqed.native.sample(source=fog, origin=(0, 0), shape=(2, 2), stride=(2, 2))
+# with nothing in it
+assert record == (0.0, 0.0, 0.0, 0.0, 0.0)
+
+# a complex tile with magnitudes 5, 0, 0, 10
+z = np.array([[3 + 4j, 0], [0, 6 + 8j]], dtype=np.complex64)
+# is sampled by magnitude
+record = qed.libqed.native.sample(source=z, origin=(0, 0), shape=(2, 2), stride=(1, 1))
+# unpack
+count, low, mean, m2, high = record
+# four samples spanning 0 to 10
+assert count == 4.0 and low == 0.0 and high == 10.0
+# with mean 15/4
+assert abs(mean - 3.75) < 1e-6
+# and the matching second moment
+assert abs(m2 - 68.75) < 1e-6
+
+# a decimated origin is scaled by the stride: origin (1,1) at stride (2,2) starts at cell (2,2)
+record = qed.libqed.native.sample(source=ramp, origin=(1, 1), shape=(1, 1), stride=(2, 2))
+# so the single sample is the value at (2,2)
+assert record == (1.0, 10.0, 10.0, 0.0, 10.0)
+
+
+# end of file

--- a/tests/qed.pkg/accumulate.py
+++ b/tests/qed.pkg/accumulate.py
@@ -1,0 +1,75 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Check that the whole-dataset statistics accumulator merges per-tile records exactly: folding
+partial records in any order must agree with a single pass over all the values
+"""
+
+# externals
+import statistics
+
+# support
+import qed
+
+
+# reduce a batch of values to the record a worker would ship
+def record(values):
+    """
+    Build the mergeable (count, min, mean, m2, max) record of {values}
+    """
+    # the population size
+    count = len(values)
+    # the mean
+    mean = statistics.fmean(values)
+    # the second moment about the mean
+    m2 = sum((v - mean) ** 2 for v in values)
+    # assemble the record
+    return (count, min(values), mean, m2, max(values))
+
+
+# two batches of values, deliberately lopsided
+first = [1.0, 2.0, 3.0, 4.0]
+second = [10.0, 20.0, 30.0]
+
+# an accumulator
+sample = qed.ux.sample()
+# fold in the two partial records
+sample.merge(record=record(first))
+sample.merge(record=record(second))
+
+# the reference: a single pass over the union
+count, low, mean, m2, high = record(first + second)
+# the population size matches
+assert sample.count == count
+# so do the extrema
+assert sample.min == low and sample.max == high
+# the mean agrees
+assert abs(sample.mean - mean) < 1e-12
+# and so does the second moment, hence the variance
+assert abs(sample.m2 - m2) < 1e-9
+assert abs(sample.variance - m2 / count) < 1e-9
+# two records were folded in
+assert sample.tiles == 2
+
+# an empty record, e.g. from an all-nan tile
+sample.merge(record=(0.0, 0.0, 0.0, 0.0, 0.0))
+# contributes nothing
+assert sample.count == count and sample.tiles == 2
+
+# merge order must not matter: fold the batches the other way around
+mirror = qed.ux.sample()
+mirror.merge(record=record(second))
+mirror.merge(record=record(first))
+# and compare the running state
+assert mirror.count == sample.count
+assert mirror.min == sample.min and mirror.max == sample.max
+assert abs(mirror.mean - sample.mean) < 1e-12
+assert abs(mirror.m2 - sample.m2) < 1e-9
+
+
+# end of file

--- a/tests/qed.pkg/widen.py
+++ b/tests/qed.pkg/widen.py
@@ -1,0 +1,73 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Check that controllers widen their display bounds to accommodate accumulated statistics
+without ever touching the user's picks, the dirty flag, or pinned configurations
+"""
+
+# support
+import qed
+
+
+# a log range controller, tuned to a modest sample: values around 1
+log = qed.controllers.logRange(name="widen_log")
+# tune it
+log.autotune(stats=(0.9, 1.0, 1.1))
+# remember its state
+low, high = log.low, log.high
+# and mark it clean, the way view registration does
+log.dirty = False
+
+# a sample whose bounds the controller already accommodates
+assert log.widen(stats=(0.5, 1.0, 2.0)) is False
+# moves nothing
+assert log.low == low and log.high == high and log.dirty is False
+
+# a sample with a large peak, e.g. a pole caught by a whole-dataset pass
+assert log.widen(stats=(0.5, 1.3, 2654.0)) is True
+# stretches the top to the next decade above the peak
+assert log.max == 4
+# leaves the picks alone
+assert log.low == low and log.high == high
+# and survives without marking the controller dirty
+assert log.dirty is False
+
+# a pinned controller
+pinned = qed.controllers.logRange(name="widen_pinned")
+# opts out of automatic adjustments
+pinned.auto = False
+# remember its bounds
+bounds = (pinned.min, pinned.max)
+# even an escaping sample
+assert pinned.widen(stats=(1e-8, 1.0, 1e8)) is False
+# moves nothing
+assert (pinned.min, pinned.max) == bounds
+
+# a linear range controller
+linear = qed.controllers.linearRange(name="widen_linear")
+# tuned to a narrow sample
+linear.autotune(stats=(-1.0, 0.0, 1.0))
+# and marked clean
+linear.dirty = False
+# remember its bounds
+lo, hi = linear.min, linear.max
+# a small escape within the slack
+assert linear.widen(stats=(lo - 0.01, 0.0, hi + 0.01)) is False
+# is tolerated
+assert linear.min == lo and linear.max == hi
+# a real escape
+assert linear.widen(stats=(lo, 0.0, 10 * hi)) is True
+# stretches the top past the data
+assert linear.max > 10 * hi
+# leaves the bottom alone
+assert linear.min == lo
+# and does not mark the controller dirty
+assert linear.dirty is False
+
+
+# end of file

--- a/ux/client/views/viz/controls/zoom/minimap.js
+++ b/ux/client/views/viz/controls/zoom/minimap.js
@@ -13,9 +13,13 @@ import { useViewports } from '~/views/viz'
 // style
 import { theme } from '~/palette'
 
+// locals
+// components
+import { Thumbnail } from './thumbnail'
+
 
 // export the minimap
-export const Minimap = ({ ils, shape, zoom }) => {
+export const Minimap = ({ viewport, ils, shape, zoom, reader, dataset, channel, session }) => {
     // we have
     // - the shape of the dataset in the active view
     // - the current zoom level
@@ -282,6 +286,9 @@ export const Minimap = ({ ils, shape, zoom }) => {
             data-qed-shape={`${dHeight},${dWidth}`}>
             <Placemat x={0} y={0} width={1} height={1} />
             <Data ref={data} x={0} y={0} width={dWidth * scale} height={dHeight * scale} />
+            {/* the dataset thumbnail covers the gray placeholder once its slices arrive */}
+            <Thumbnail viewport={viewport} reader={reader} dataset={dataset} channel={channel}
+                session={session} shape={shape} scale={scale} ils={ils} />
             <Viewport ref={rep} x={zoomX * x * scale} y={zoomY * y * scale}
                 width={zoomX * width * scale} height={zoomY * height * scale}
                 data-qed-view-origin={viewOrigin} data-qed-view-shape={viewShape} />

--- a/ux/client/views/viz/controls/zoom/thumbnail.js
+++ b/ux/client/views/viz/controls/zoom/thumbnail.js
@@ -1,0 +1,246 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// externals
+import React from 'react'
+import styled from 'styled-components'
+
+// project
+// hooks
+import { tileURI } from '~/views/viz'
+
+
+// the dataset thumbnail: a small mosaic of heavily decimated tiles from the {data} api that
+// covers the gray placeholder once every slice has arrived; the same render pass seeds the
+// server side dataset statistics, so the reveal marks the end of the collection
+export const Thumbnail = ({ viewport, reader, dataset, channel, session, shape, scale, ils }) => {
+    // the generation currently on display; starts out empty, which leaves the gray placeholder
+    // visible while the first generation is being fetched
+    const [current, setCurrent] = React.useState(null)
+    // the load ledger of the generation being fetched
+    const progress = React.useRef({ key: null, loaded: null })
+    // the retry round: bumping it remounts the slices that haven't arrived, so a dropped
+    // connection or a lost load event delays the reveal instead of canceling it
+    const [round, setRound] = React.useState(0)
+
+    // the thumbnail can only be formed when the view is fully resolved
+    const live = (reader && dataset && channel && session) ? true : false
+
+    // assemble the specification of the desired generation
+    const spec = React.useMemo(() => {
+        // if the view is not fully resolved
+        if (!live) {
+            // there is nothing to fetch
+            return null
+        }
+        // unpack the dataset shape
+        const [dHeight, dWidth] = shape
+        // pick the decimation level that brings the long axis down to a few thousand pixels;
+        // the browser resizes the result into the minimap box, so the extra resolution costs
+        // nothing on screen, while the render decomposes into many standard slices that keep
+        // the whole crew busy and sample the raster densely enough to seed useful statistics
+        const exp = Math.max(0, Math.trunc(Math.log2(Math.max(dHeight, dWidth) / resolution)))
+        // deduce the corresponding stride
+        const stride = 2 ** exp
+        // form the decimated raster shape; floor division, so the footprint stays within bounds
+        const decimated = [Math.trunc(dHeight / stride), Math.trunc(dWidth / stride)]
+        // form the base uri of tile requests at this decimation level
+        const base = tileURI({
+            viewport, reader, dataset, channel,
+            zoom: { horizontal: -exp, vertical: -exp },
+        })
+        // the slice unit is the dataset's preferred tile: the HDF5 chunk shape for products
+        // that have one, so slice footprints stay chunk-aligned and no chunk is decompressed
+        // by two different workers
+        const unit = dataset.tile ?? [512, 512]
+        // make a pile for the tile specs
+        const tiles = []
+        // chop the decimated raster into slices, matching the crew's unit of work,
+        // by going through the vertical partition
+        for (const [row, height] of partition(decimated[0], unit[0])) {
+            // and the horizontal partition
+            for (const [col, width] of partition(decimated[1], unit[1])) {
+                // form the request for this slice; the session token busts the browser cache
+                // whenever the server rolls it, e.g. on a change to the visualization stretch
+                const uri = `${base}/${row}x${col}+${height}x${width}?session=${session}`
+                // record the slice; its placement is in decimated coordinates so the geometry
+                // can be projected onto the minimap at render time with the live {scale}
+                tiles.push({ uri, row, col, height, width })
+            }
+        }
+        // a generation is identified by its base uri and the session token
+        return { key: `${base}?session=${session}`, stride, decimated, tiles }
+        // the {scale} is deliberately not an input: it affects placement, not identity
+    }, [live, viewport, reader, dataset, channel, session, shape])
+
+    // when the desired generation is new, reset the ledger; this happens during render, but it
+    // is idempotent because it is gated by the generation key
+    if (spec && progress.current.key !== spec.key && (!current || current.key !== spec.key)) {
+        // start a fresh ledger
+        progress.current = { key: spec.key, loaded: new Set() }
+        // and grant the new generation a full allowance of retries; a render-phase state
+        // update, the sanctioned way to reset state derived from changing inputs
+        setRound(0)
+    }
+
+    // deduce whether a new generation is in flight
+    const pending = spec && (!current || current.key !== spec.key)
+
+    // fetch the pending generation: slices are preloaded with detached {Image} objects, whose
+    // load events are reliable, unlike those of svg {image} elements; once every slice is in
+    // the browser cache the generation goes on display and the svg mosaic paints instantly
+    React.useEffect(() => {
+        // if nothing is in flight
+        if (!pending) {
+            // nothing to fetch
+            return undefined
+        }
+        // capture the generation this effect serves
+        const generation = spec
+        // and its ledger
+        const ledger = progress.current
+        // the teardown guard
+        let alive = true
+        // go through the slices
+        for (const tile of generation.tiles) {
+            // skip the ones that have already arrived
+            if (ledger.loaded.has(tile.uri)) {
+                // on to the next one
+                continue
+            }
+            // make a loader
+            const img = new window.Image()
+            // record the arrival of its slice
+            img.onload = () => {
+                // unless the generation is stale
+                if (!alive || ledger !== progress.current) {
+                    // in which case, ignore it
+                    return
+                }
+                // add the slice to the ledger
+                ledger.loaded.add(tile.uri)
+                // if the generation is now complete
+                if (ledger.loaded.size === generation.tiles.length) {
+                    // put it on display
+                    setCurrent(generation)
+                }
+                // all done
+                return
+            }
+            // failures are left to the retry rounds
+            img.onerror = () => null
+            // start the fetch
+            img.src = tile.uri
+        }
+        // register the teardown
+        return () => { alive = false }
+        // refetch the stragglers whenever the generation changes or a retry round starts
+    }, [pending, spec?.key, round])
+
+    // while a generation is in flight, nudge it periodically: refetching the slices that
+    // haven't arrived retries dropped connections; completed slices sit in the server cache,
+    // so a retry is cheap. the round cap turns a persistently broken generation into a quiet
+    // fallback to whatever is on display
+    React.useEffect(() => {
+        // if nothing is in flight
+        if (!pending) {
+            // nothing to watch
+            return undefined
+        }
+        // otherwise, arm the timer
+        const timer = window.setInterval(() => {
+            // advance the round, up to the cap
+            setRound(old => old < retries ? old + 1 : old)
+        }, patience)
+        // and register its teardown
+        return () => window.clearInterval(timer)
+        // rearm whenever the pending generation changes identity or resolves
+    }, [pending, spec?.key])
+
+    // project a slice onto the minimap: decimated coordinates back to source pixels, then
+    // through the minimap scale; interior slices bleed one screen pixel into their trailing
+    // neighbors, which paint over the overlap, so fractional placement leaves no seams
+    const place = (tile, generation) => {
+        // unpack the generation geometry
+        const { stride, decimated } = generation
+        // one screen pixel, in minimap units
+        const bleed = 1 / ils
+        // and project
+        return {
+            x: tile.col * stride * scale,
+            y: tile.row * stride * scale,
+            width: tile.width * stride * scale
+                + (tile.col + tile.width < decimated[1] ? bleed : 0),
+            height: tile.height * stride * scale
+                + (tile.row + tile.height < decimated[0] ? bleed : 0),
+        }
+    }
+
+    // if the view is not fully resolved
+    if (!live) {
+        // leave the placeholder alone
+        return null
+    }
+    // render; only the completed generation appears, painted from the browser cache, so the
+    // gray placeholder shows through until the crew is done; the thumbnail is decorative and
+    // must not intercept the minimap interactions
+    return (
+        <Mat aria-hidden="true" data-qed-thumbnail={current ? "ready" : "pending"}>
+            {current && current.tiles.map(tile => (
+                <Sliver key={tile.uri} href={tile.uri} {...place(tile, current)}
+                    preserveAspectRatio="none" />
+            ))}
+        </Mat>
+    )
+}
+
+
+// the target long-axis extent of the decimated thumbnail; a few thousand pixels, so the crew
+// has a real workload of slices while the browser shrinks the mosaic into the minimap box
+const resolution = 2048
+// the pause between retry rounds, generous enough that a slice legitimately in flight on a
+// cold source is left alone
+const patience = 30000
+// the retry allowance per generation
+const retries = 5
+
+
+// helpers
+// given an {extent}, generate (start, chunk) pairs that cover it with {tile} sized chunks,
+// plus whatever remainder is left over
+function* partition(extent, tile) {
+    // figure out how many whole chunks fit
+    const div = Math.trunc(extent / tile)
+    // and what's left behind
+    const mod = extent % tile
+    // the first {div} entries are
+    for (let i = 0; i < div; ++i) {
+        // whole chunks at multiples of {tile}
+        yield [i * tile, tile]
+    }
+    // if there is anything left over
+    if (mod > 0) {
+        // it forms the trailing chunk
+        yield [div * tile, mod]
+    }
+    // all done
+    return
+}
+
+
+// styling
+// the group; transparent to pointer events so clicks fall through to the gray hit target
+const Mat = styled.g`
+    pointer-events: none;
+`
+
+// the individual slices
+const Sliver = styled.image`
+    pointer-events: none;
+`
+
+
+// end of file

--- a/ux/client/views/viz/controls/zoom/zoom.js
+++ b/ux/client/views/viz/controls/zoom/zoom.js
@@ -28,7 +28,9 @@ import { Save } from './save'
 //  display the zoom control
 export const Zoom = ({ viewport, view, min = -6, max = 4, ils = 200 }) => {
     // unpack the view
-    const { reader, dataset, channel, zoom } = useFragment(zoomControlsGetZoomStateFragment, view)
+    const { session, reader, dataset, channel, zoom } = useFragment(
+        zoomControlsGetZoomStateFragment, view
+    )
 
     // inspect the view components to initialize my state
     const enabled = (reader && dataset && channel) ? true : false
@@ -120,7 +122,8 @@ export const Zoom = ({ viewport, view, min = -6, max = 4, ils = 200 }) => {
                 </g>
                 {/* the minimap */}
                 <g transform={`translate(100 0) scale(${ils})`}>
-                    <Minimap ils={ils} zoom={zoom} shape={dataset.shape} />
+                    <Minimap viewport={viewport} ils={ils} zoom={zoom} shape={dataset.shape}
+                        reader={reader} dataset={dataset} channel={channel} session={session} />
                 </g>
                 {/* the lock */}
                 <g transform="translate(60 240)">
@@ -154,15 +157,20 @@ const Controller = styled(Slider)`
 // the fragment
 const zoomControlsGetZoomStateFragment = graphql`
     fragment zoomControlsGetZoomStateFragment on View {
+        session
         reader {
             id
+            api
         }
         dataset {
             id
+            name
             shape
+            tile
         }
         channel {
             id
+            tag
         }
         zoom {
             dirty


### PR DESCRIPTION
## Summary

The zoom controller's minimap replaces its gray dataset-extent box with an actual thumbnail of the dataset, rendered tile-by-tile by the nexus crews through the ordinary `/data` api. The same render pass seeds per-dataset statistics: workers ship a mergeable statistical record with every tile they render, the store accumulates the records into whole-dataset statistics, and the visualization controllers widen their slider bounds live as the accumulation refines — without disturbing the user's picks, the session token, or cached tiles.

## The thumbnail

`ux/client/views/viz/controls/zoom/thumbnail.js` assembles a mosaic of heavily decimated tiles covering the full raster. The decimation exponent brings the long axis down to about 2048 pixels; the browser shrinks the result into the minimap box, so the extra resolution costs nothing on screen while the render decomposes into many slices that keep the whole crew busy. The slice unit is the dataset's advertised tile — the HDF5 chunk shape for products that have one — so slice footprints are chunk-aligned and no chunk is decompressed by two different workers.

The gray box remains as the placeholder and the click target: slices are preloaded with detached `Image()` objects, and the SVG mosaic is revealed only when every slice has arrived. Detached preloads are deliberate — Chromium does not reliably deliver `load` events to svg `image` elements on initial mount. A slice that fails or stalls is retried on a generous cadence; a persistently broken generation quietly leaves the placeholder, or the previous thumbnail, on display. Interior slices bleed one screen pixel into their trailing neighbors, which paint over the overlap, so fractional placement leaves no seams. The `?session=` token on the slice urls re-fetches the thumbnail whenever the server rolls it, e.g. on a change to the visualization stretch.

On a 7.6 GB NISAR GSLC (76752×76752 complex64, deflate+shuffle), the cold thumbnail completes in about 6 seconds — 12 with the statistics pass — with the work spread across the team; unallocated fill chunks cost nothing.

## The statistics

`lib/qed/native/stats` and `lib/qed/nisar/stats` gain strided sample kernels that visit exactly the decimated footprint a render sees and return a mergeable record — count, min, mean, second moment, max — over the magnitude of the source values, skipping nans. A BFPQ flavor decodes before measuring. Workers attach the record to the spool; it travels in the pickled report alongside the payload size. `Team.collect` drains records into `Store.accumulate`, which folds them into a per-dataset `qed.ux.Sample` using the parallel form of Welford's update, so partial results combine exactly regardless of arrival order. The `qed.ux.stats` debug channel logs each merge.

## The controllers

Range controllers gain a `widen` operation: when the accumulated range escapes the current display bounds, the bounds stretch — log ranges to the next whole decade, linear ranges with a 5% hysteresis slack — and the store broadcasts the same coalesced change frame the graphql layer uses after mutations, so live clients refetch and the sliders stretch in place. The user's low/high picks never move, controllers pinned with `auto: no` never participate, the session token never rolls, and the bounds are declared `cosmetic` so the tile task identity harvest excludes them: a widened controller does not invalidate cached work.

## Fixes along the way

- The `/data` recognizer admitted negative decimation exponents, which produce a fractional stride and die deep in the extension; `_dataInBounds` now refuses them.
- `statsBFPQ` computed its statistics on the encoded source tile and discarded the decoded one; it now measures the decoded values.

## Tests

- `tests/qed.ext/sample.py` exercises the strided kernel: Welford moments, stride arithmetic, nan hygiene, complex magnitudes.
- `tests/qed.pkg/accumulate.py` checks that merging partial records agrees exactly with a single pass over the union, in either order.
- `tests/qed.pkg/widen.py` checks the widening rules: hysteresis, pinned controllers, preserved picks and dirty flags.
- The native fixture activates the `qed.ux.stats` diagnostic alongside the tile diagnostic.