### PR TITLE
Resilient startup: contained configuration, passive readers, server-initiated first contact

### DIFF
--- a/.mm/qed.ext.tests
+++ b/.mm/qed.ext.tests
@@ -7,7 +7,7 @@
 # the testsuite for the qed bindings
 qed.ext.tests.stem := qed.ext
 # depends on
-qed.ext.tests.prerequisites := qed.ext
+qed.ext.tests.prerequisites := qed.pkg qed.ext
 # external dependencies
 qed.ext.tests.extern := $(qed.ext.extern)
 

--- a/.mm/qed.pkg.tests
+++ b/.mm/qed.pkg.tests
@@ -7,7 +7,7 @@
 # the test suite for the qed package
 qed.pkg.tests.stem := qed.pkg
 # depends on
-qed.pkg.tests.prerequisites := qed.pkg
+qed.pkg.tests.prerequisites := qed.pkg qed.ext
 
 
 # end of file

--- a/.mm/qed.ux.playwright
+++ b/.mm/qed.ux.playwright
@@ -18,7 +18,7 @@ qed.ux.playwright.toolchain := playwright
 # it needs the built client (the server serves it) and the test fixtures the servers read: the
 # native raster ({qed.data.native.c16}) and the two NISAR products ({qed.data.nisar.*}). each file
 # target produces its fixture only when missing -- skip-if-present, so present data is never rebuilt
-qed.ux.playwright.prerequisites := qed.ux \
+qed.ux.playwright.prerequisites := qed.pkg qed.ext qed.ux \
     $(qed.data.native.c16) $(qed.data.nisar.gslc) $(qed.data.nisar.gcov)
 
 # tell the runner where the test data lives so playwright.config can point each webServer's {qed} at

--- a/pkg/cli/Measure.py
+++ b/pkg/cli/Measure.py
@@ -389,6 +389,9 @@ class Measure(qed.shells.command, family="qed.cli.measure"):
             if only and reader.pyre_name not in only:
                 # by skipping everybody else
                 continue
+            # construction is passive; measuring needs the data, so make first contact,
+            # which also charges the discovery and stats timers this panel reports
+            reader.open()
             # go through the reader's datasets
             for dataset in reader.datasets:
                 # and each dataset's channels

--- a/pkg/gql/readers/ConnectReader.py
+++ b/pkg/gql/readers/ConnectReader.py
@@ -63,10 +63,24 @@ class ConnectReader(graphene.Mutation):
         factory = qed.protocols.reader.pyre_resolveSpecification(spec=reader)
         # get the archive
         archive = store.archive(uri=archive)
-        # instantiate
-        source = factory(archive=archive, **args)
-        # get the store
-        store = info.context["store"]
+        # carefully, since the source may be malformed or unreachable
+        try:
+            # instantiate
+            source = factory(archive=archive, **args)
+            # construction is passive; the user asked to connect, so make first contact
+            source.open()
+        # if anything goes wrong
+        except Exception as error:
+            # make a channel
+            channel = journal.warning("qed.gql.connect")
+            # complain
+            channel.line(f"could not connect '{uri}'")
+            channel.line(f"while building a '{reader}' instance")
+            channel.line(f"got: {error}")
+            # flush
+            channel.log()
+            # and report the failure to the client as a trivial reader
+            return {"reader": None}
         # add the new source to the store
         store.connectSource(source=source)
         # make a resolution context

--- a/pkg/nexus/Server.py
+++ b/pkg/nexus/Server.py
@@ -51,6 +51,10 @@ class Server(http, family="qed.nexus.servers.http"):
             # and when the accumulation moves controller bounds, the store broadcasts a
             # change notification so live clients refetch their state
             ux.store.notifier = self.notifyChange
+            # the data sources were constructed passively; the server is about to start
+            # serving, so this is the moment to establish first contact with each one;
+            # casualties are discarded with a warning, and the boot survives
+            ux.store.open()
         # attach the fleet
         self.fleet = fleet
         # all done

--- a/pkg/nexus/Tile.py
+++ b/pkg/nexus/Tile.py
@@ -315,6 +315,8 @@ class Tile(pyre.nexus.task):
         # build a fresh instance so this process owns its file handles; the derived name
         # avoids clashing with the team side instance this process may have inherited
         reader = factory(name=f"{self.reader}.crew", **config)
+        # construction is passive; a worker exists to render, so make first contact now
+        reader.open()
         # register it
         readers[self.reader] = reader
         # and hand it off

--- a/pkg/protocols/Reader.py
+++ b/pkg/protocols/Reader.py
@@ -33,5 +33,17 @@ class Reader(Producer, family="qed.readers"):
     datasets = qed.properties.list(schema=Dataset())
     datasets.doc = "the list of data sets provided by the reader"
 
+    # requirements
+    @qed.provides
+    def open(self):
+        """
+        Establish first contact with the data source: open the file, discover the datasets,
+        and derive the selector availability
+
+        Construction is passive, so a reader can be built, cataloged, and shipped without
+        touching its file; whoever needs the data initiates the contact, and repeated calls
+        are harmless
+        """
+
 
 # end of file

--- a/pkg/readers/isce2/SLC.py
+++ b/pkg/readers/isce2/SLC.py
@@ -25,10 +25,10 @@ class SLC(native.flat, family="qed.readers.isce2.slc"):
     cell.default = "complex64"
     cell.doc = "the type of the dataset payload"
 
-    # framework hooks
-    def pyre_configured(self):
+    # implementation details
+    def _resolveShape(self):
         """
-        Hook invoked after the reader configuration is complete
+        Complete my shape, consulting the auxiliary metadata file first
         """
         # get the current value of my shape
         shape = list(self.shape) if self.shape else [0, 0]
@@ -48,8 +48,8 @@ class SLC(native.flat, family="qed.readers.isce2.slc"):
             if shape[0] and shape[1]:
                 # set it
                 self.shape = tuple(shape)
-        # and chain up
-        yield from super().pyre_configured()
+        # chain up for the size-based fallback
+        super()._resolveShape()
         # all done
         return
 

--- a/pkg/readers/isce2/interferogram/Reader.py
+++ b/pkg/readers/isce2/interferogram/Reader.py
@@ -76,6 +76,11 @@ class Reader(
         if not shape or not shape[0] or not shape[1]:
             # bail; my configuration troubles have already been reported
             return self
+        # the file must be large enough to hold the declared shape; a short file would let
+        # the render machinery read past the end of the map and crash the process
+        if not self._validateSize(shape=shape, cellsPerSample=1):
+            # the complaint has been lodged
+            return self
 
         # unpack my state into a dataset configuration
         config = {
@@ -169,6 +174,30 @@ class Reader(
 
         # all done
         return
+
+    def _validateSize(self, shape, cellsPerSample):
+        """
+        Check that my file is large enough to hold {shape} samples of {cellsPerSample}
+        cells each
+        """
+        # compute the size the declared shape requires
+        required = shape[0] * shape[1] * cellsPerSample * self.cell.bytes
+        # measure the file
+        actual = qed.primitives.path(self.uri.address).stat().st_size
+        # if it holds enough
+        if actual >= required:
+            # we are good
+            return True
+        # otherwise, make a channel
+        channel = journal.warning("qed.readers.unw")
+        # complain
+        channel.line(f"'{self.uri.address}' is too small for the declared shape")
+        channel.line(f"shape {tuple(shape)} requires {required} bytes")
+        channel.line(f"but the file holds only {actual}")
+        # flush
+        channel.log()
+        # and reject
+        return False
 
     # private data
     _opened = False  # whether first contact has been made

--- a/pkg/readers/isce2/interferogram/Reader.py
+++ b/pkg/readers/isce2/interferogram/Reader.py
@@ -47,27 +47,46 @@ class Reader(
     datasets = qed.properties.list(schema=qed.protocols.dataset.output())
     datasets.doc = "the list of data sets provided by the reader"
 
-    # metamethods
-    def __init__(self, name, archive=None, **kwds):
+    # interface
+    @qed.export
+    def open(self):
+        """
+        Establish first contact with the data source: complete my shape, open the file,
+        and build my dataset
+        """
+        # if i have already made contact
+        if self._opened:
+            # there is nothing further to do
+            return self
+        # leave a mark
+        self._opened = True
+
         # make a timer that measures the layout discovery time
-        discovery = qed.timers.wall(f"qed.profiler.discovery.{name}")
-        # start the discovery timer
+        discovery = qed.timers.wall(f"qed.profiler.discovery.{self.pyre_name}")
+        # start it
         discovery.start()
-        # chain up
-        super().__init__(name=name, **kwds)
-        # stop the discovery timer
+        # complete my shape, interrogating the metadata for whatever is missing
+        self._resolveShape()
+        # stop the timer
         discovery.stop()
+
+        # get my shape
+        shape = self.shape
+        # i need it fully resolved to continue
+        if not shape or not shape[0] or not shape[1]:
+            # bail; my configuration troubles have already been reported
+            return self
 
         # unpack my state into a dataset configuration
         config = {
             "uri": self.uri,
-            "shape": self.shape,
+            "shape": shape,
             "cell": self.cell,
             "tile": self.cell.tile,
         }
 
         # make a timer that measures the amount of time it takes to collect statistics
-        stats = qed.timers.wall(f"qed.profiler.stats.{name}")
+        stats = qed.timers.wall(f"qed.profiler.stats.{self.pyre_name}")
         # and start it
         stats.start()
         # there is only one dataset in the file and it is structurally trivial; build it
@@ -77,16 +96,23 @@ class Reader(
 
         # add the dataset to the pile
         self.datasets.append(dataset)
-        # build my availability map
-        self.available = {}
 
+        # all done
+        return self
+
+    # metamethods
+    def __init__(self, name, archive=None, **kwds):
+        # chain up; construction is passive, so nothing touches the file until {open}
+        super().__init__(name=name, **kwds)
+        # initialize the availability map so the panel can render before first contact
+        self.available = {}
         # all done
         return
 
-    # framework hooks
-    def pyre_configured(self):
+    # implementation details
+    def _resolveShape(self):
         """
-        Hook invoked after the reader configuration is complete
+        Complete my shape, interrogating the auxiliary metadata for whatever is missing
         """
         # get the current value of my shape
         shape = list(self.shape) if self.shape else [0, 0]
@@ -141,10 +167,11 @@ class Reader(
                 # flush
                 channel.log()
 
-        # chain up
-        yield from super().pyre_configured()
         # all done
         return
+
+    # private data
+    _opened = False  # whether first contact has been made
 
 
 # end of file

--- a/pkg/readers/isce2/unwrapped/Reader.py
+++ b/pkg/readers/isce2/unwrapped/Reader.py
@@ -78,6 +78,12 @@ class Reader(
         if not shape or not shape[0] or not shape[1]:
             # bail; my configuration troubles have already been reported
             return self
+        # the file must be large enough to hold the declared shape; each sample is a pair
+        # of cells in the line interleaved layout, and a short file would let the render
+        # machinery read past the end of the map and crash the process
+        if not self._validateSize(shape=shape, cellsPerSample=2):
+            # the complaint has been lodged
+            return self
 
         # unpack my state into a dataset configuration
         config = {
@@ -170,6 +176,30 @@ class Reader(
 
         # all done
         return
+
+    def _validateSize(self, shape, cellsPerSample):
+        """
+        Check that my file is large enough to hold {shape} samples of {cellsPerSample}
+        cells each
+        """
+        # compute the size the declared shape requires
+        required = shape[0] * shape[1] * cellsPerSample * self.cell.bytes
+        # measure the file
+        actual = qed.primitives.path(self.uri.address).stat().st_size
+        # if it holds enough
+        if actual >= required:
+            # we are good
+            return True
+        # otherwise, make a channel
+        channel = journal.warning("qed.readers.unw")
+        # complain
+        channel.line(f"'{self.uri.address}' is too small for the declared shape")
+        channel.line(f"shape {tuple(shape)} requires {required} bytes")
+        channel.line(f"but the file holds only {actual}")
+        # flush
+        channel.log()
+        # and reject
+        return False
 
     # private data
     _opened = False  # whether first contact has been made

--- a/pkg/readers/isce2/unwrapped/Reader.py
+++ b/pkg/readers/isce2/unwrapped/Reader.py
@@ -49,26 +49,45 @@ class Reader(
     datasets = qed.properties.list(schema=qed.protocols.dataset.output())
     datasets.doc = "the list of data sets provided by the reader"
 
-    # metamethods
-    def __init__(self, name, archive=None, **kwds):
+    # interface
+    @qed.export
+    def open(self):
+        """
+        Establish first contact with the data source: complete my shape, open the file,
+        and build my dataset
+        """
+        # if i have already made contact
+        if self._opened:
+            # there is nothing further to do
+            return self
+        # leave a mark
+        self._opened = True
+
         # make a timer that measures the layout discovery time
-        discovery = qed.timers.wall(f"qed.profiler.discovery.{name}")
-        # start the discovery timer
+        discovery = qed.timers.wall(f"qed.profiler.discovery.{self.pyre_name}")
+        # start it
         discovery.start()
-        # chain up
-        super().__init__(name=name, **kwds)
-        # stop the discovery timer
+        # complete my shape, interrogating the metadata for whatever is missing
+        self._resolveShape()
+        # stop the timer
         discovery.stop()
+
+        # get my shape
+        shape = self.shape
+        # i need it fully resolved to continue
+        if not shape or not shape[0] or not shape[1]:
+            # bail; my configuration troubles have already been reported
+            return self
 
         # unpack my state into a dataset configuration
         config = {
             "uri": self.uri,
             "cell": self.cell,
-            "shape": self.shape,
+            "shape": shape,
         }
 
         # make a timer that measures the amount of time it takes to collect statistics
-        stats = qed.timers.wall(f"qed.profiler.stats.{name}")
+        stats = qed.timers.wall(f"qed.profiler.stats.{self.pyre_name}")
         # and start it
         stats.start()
         # there is only one dataset in the file and it is structurally trivial; build it
@@ -78,16 +97,23 @@ class Reader(
 
         # add the dataset to the pile
         self.datasets.append(dataset)
-        # build my availability map
-        self.available = {}
 
+        # all done
+        return self
+
+    # metamethods
+    def __init__(self, name, archive=None, **kwds):
+        # chain up; construction is passive, so nothing touches the file until {open}
+        super().__init__(name=name, **kwds)
+        # initialize the availability map so the panel can render before first contact
+        self.available = {}
         # all done
         return
 
-    # framework hooks
-    def pyre_configured(self):
+    # implementation details
+    def _resolveShape(self):
         """
-        Hook invoked after the reader configuration is complete
+        Complete my shape, interrogating the auxiliary metadata for whatever is missing
         """
         # get the current value of my shape
         shape = list(self.shape) if self.shape else [0, 0]
@@ -142,10 +168,11 @@ class Reader(
                 # flush
                 channel.log()
 
-        # chain up
-        yield from super().pyre_configured()
         # all done
         return
+
+    # private data
+    _opened = False  # whether first contact has been made
 
 
 # end of file

--- a/pkg/readers/native/Flat.py
+++ b/pkg/readers/native/Flat.py
@@ -70,6 +70,11 @@ class Flat(
         if not cell or not shape or not shape[0] or not shape[1]:
             # bail; my configuration troubles have already been reported
             return self
+        # the file must be large enough to hold the declared shape; a short file would let
+        # the render machinery read past the end of the map and crash the process
+        if not self._validateSize(cell=cell, shape=shape, cellsPerSample=1):
+            # the complaint has been lodged
+            return self
 
         # unpack my state into a dataset configuration
         config = {
@@ -176,6 +181,30 @@ class Flat(
             channel.log()
         # all done
         return
+
+    def _validateSize(self, cell, shape, cellsPerSample):
+        """
+        Check that my file is large enough to hold {shape} samples of {cellsPerSample}
+        {cell} instances each
+        """
+        # compute the size the declared shape requires
+        required = shape[0] * shape[1] * cellsPerSample * cell.bytes
+        # measure the file
+        actual = qed.primitives.path(self.uri.address).stat().st_size
+        # if it holds enough
+        if actual >= required:
+            # we are good
+            return True
+        # otherwise, make a channel
+        channel = journal.warning("qed.readers.native.flat")
+        # complain
+        channel.line(f"'{self.uri.address}' is too small for the declared shape")
+        channel.line(f"shape {tuple(shape)} requires {required} bytes")
+        channel.line(f"but the file holds only {actual}")
+        # flush
+        channel.log()
+        # and reject
+        return False
 
     # private data
     _opened = False  # whether first contact has been made

--- a/pkg/readers/native/Flat.py
+++ b/pkg/readers/native/Flat.py
@@ -39,25 +39,37 @@ class Flat(
     datasets = qed.properties.list(schema=qed.protocols.dataset.output())
     datasets.doc = "the list of data sets provided by the reader"
 
-    # metamethods
-    def __init__(self, name, archive=None, **kwds):
+    # interface
+    @qed.export
+    def open(self):
+        """
+        Establish first contact with the data source: complete my shape, open the file,
+        and build my dataset
+        """
+        # if i have already made contact
+        if self._opened:
+            # there is nothing further to do
+            return self
+        # leave a mark
+        self._opened = True
+
         # make a timer that measures the layout discovery time
-        discovery = qed.timers.wall(f"qed.profiler.discovery.{name}")
-        # start the discovery timer
+        discovery = qed.timers.wall(f"qed.profiler.discovery.{self.pyre_name}")
+        # start it
         discovery.start()
-        # chain up
-        super().__init__(name=name, **kwds)
-        # stop the discovery timer
+        # complete my shape, interrogating the file for whatever is missing
+        self._resolveShape()
+        # stop the timer
         discovery.stop()
 
         # get my cell
         cell = self.cell
         # and my shape
         shape = self.shape
-        # i need both to continue
-        if not cell or not shape:
-            # so bail, if they are not fully configured
-            return
+        # i need a cell and a fully resolved shape to continue
+        if not cell or not shape or not shape[0] or not shape[1]:
+            # bail; my configuration troubles have already been reported
+            return self
 
         # unpack my state into a dataset configuration
         config = {
@@ -68,7 +80,7 @@ class Flat(
         }
 
         # make a timer that measures the amount of time it takes to collect statistics
-        stats = qed.timers.wall(f"qed.profiler.stats.{name}")
+        stats = qed.timers.wall(f"qed.profiler.stats.{self.pyre_name}")
         # and start it
         stats.start()
         # there is only one dataset in the file and it is structurally trivial; build it
@@ -80,86 +92,93 @@ class Flat(
 
         # add the dataset to the pile
         self.datasets.append(dataset)
-        # build my availability map
-        self.available = {}
 
+        # all done
+        return self
+
+    # metamethods
+    def __init__(self, name, archive=None, **kwds):
+        # chain up; construction is passive, so nothing touches the file until {open}
+        super().__init__(name=name, **kwds)
+        # initialize the availability map so the panel can render before first contact
+        self.available = {}
         # all done
         return
 
-    # framework hooks
-    def pyre_configured(self):
+    # implementation details
+    def _resolveShape(self):
         """
-        Hook invoked after the reader configuration is complete
+        Complete my shape, interrogating the file for whatever is missing
         """
+        # get my cell
+        cell = self.cell
+        # if i don't have one
+        if not cell:
+            # make a channel
+            channel = journal.error("qed.readers.native.flat")
+            # complain
+            channel.line(f"could not load a dataset from '{self.uri.address}'")
+            channel.line(f"missing data type specification")
+            channel.line(f"please provide a value for '--cell'")
+            # flush
+            channel.log()
+            # and bail
+            return
+        # get the current value of my shape
+        shape = list(self.shape) if self.shape else [0, 0]
+        # if it is already fully resolved
+        if shape and shape[0] and shape[1]:
+            # there is nothing to infer
+            return
         # get my uri
         uri = self.uri
         # convert its address into a path
         path = qed.primitives.path(uri.address)
         # get the file size
         filesize = path.stat().st_size
-        # get my cell
-        cell = self.cell
-        # if i don't have
-        if not cell:
+        # if the width is missing but we know the height
+        if shape[1] == 0 and shape[0]:
+            # set it from the file size
+            shape[1] = filesize / shape[0] / cell.bytes
+        # if the height is missing but we know the width
+        if shape[0] == 0 and shape[1]:
+            # set it from the file size
+            shape[0] = filesize / shape[1] / cell.bytes
+        # if the shape is now fully resolved
+        if (
+            shape[0]
+            and shape[1]
+            and shape[0] == math.floor(shape[0])
+            and shape[1] == math.floor(shape[1])
+        ):
+            # set it
+            self.shape = tuple(shape)
+        # if not
+        else:
             # make a channel
-            channel = journal.error("qed.readers.native.flat")
-            # complain
-            channel.line(f"could not load a dataset from '{uri.address}'")
-            channel.line(f"missing data type specification")
-            channel.line(f"please provide a value for '--cell'")
+            channel = journal.warning("qed.readers.unw")
+            # generate a list of possible shapes
+            channel.line(f"while attempting to load '{self.uri.address}'")
+            channel.line(f"missing shape information; here are some possibilities")
+            channel.line(f"as lines x samples")
+            channel.indent()
+            # generate some options
+            for lines, samples in qed.libqed.factor(
+                product=filesize // cell.bytes, aspect=10
+            ):
+                # and show them
+                channel.line(f"{lines} x {samples}")
+            channel.outdent()
+            channel.line(
+                f"please use '--lines' or '--samples' to provide the dataset shape"
+            )
             # flush
             channel.log()
-            # just in case errors aren't fatal
-            yield f"missing cell specification for '{uri.address}'"
-            # and bail
-            return
-        # get the current value of my shape
-        shape = list(self.shape) if self.shape else [0, 0]
-        # if it's trivial
-        if not shape or shape[0] == 0 or shape[1] == 0:
-            # if the width is missing but we know the height
-            if shape[1] == 0 and shape[0]:
-                # set it from the file size
-                shape[1] = filesize / shape[0] / cell.bytes
-            # if the height is missing but we know the width
-            if shape[0] == 0 and shape[1]:
-                # set it from the file size
-                shape[0] = filesize / shape[1] / cell.bytes
-            # if the shape is now fully resolved
-            if (
-                shape[0]
-                and shape[1]
-                and shape[0] == math.floor(shape[0])
-                and shape[1] == math.floor(shape[1])
-            ):
-                # set it
-                self.shape = tuple(shape)
-            # if not
-            else:
-                # make a channel
-                channel = journal.warning("qed.readers.unw")
-                # generate a list of possible shapes
-                channel.line(f"while attempting to load '{self.uri.address}'")
-                channel.line(f"missing shape information; here are some possibilities")
-                channel.line(f"as lines x samples")
-                channel.indent()
-                # generate some options
-                for lines, samples in qed.libqed.factor(
-                    product=filesize // cell.bytes, aspect=10
-                ):
-                    # and show them
-                    channel.line(f"{lines} x {samples}")
-                channel.outdent()
-                channel.line(
-                    f"please use '--lines' or '--samples' to provide the dataset shape"
-                )
-                # flush
-                channel.log()
-
-        # chain up
-        yield from super().pyre_configured()
         # all done
         return
+
+    # private data
+    _opened = False  # whether first contact has been made
 
 
 # end of file

--- a/pkg/readers/native/GDAL.py
+++ b/pkg/readers/native/GDAL.py
@@ -40,10 +40,19 @@ class GDAL(
     datasets = qed.properties.list(schema=qed.protocols.dataset.output())
     datasets.doc = "the list of data sets provided by the reader"
 
-    # metamethods
-    def __init__(self, name, archive=None, **kwds):
-        # chain up
-        super().__init__(name=name, **kwds)
+    # interface
+    @qed.export
+    def open(self):
+        """
+        Establish first contact with the data source: open the file, discover the bands,
+        and derive the selector availability
+        """
+        # if i have already made contact
+        if self._opened:
+            # there is nothing further to do
+            return self
+        # leave a mark
+        self._opened = True
         # open the file
         dataset = self._open()
         # if something went wrong
@@ -55,7 +64,7 @@ class GDAL(
             # complain
             channel.log()
             # and bail
-            return
+            return self
         # if all is good with the data source, figure out how many rasters are available
         rasters = dataset.RasterCount
         # get my selector
@@ -74,14 +83,21 @@ class GDAL(
         self.product = dataset
         # update the selectors
         self.selectors["band"] = bands
-        # initialize the availability map
-        self.available = {}
-        # and populate it
+        # populate the availability map
         self.available["band"] = bands
         # if there is only one available band
         if len(bands) == 1:
             # force this selection
             self.selections["band"] = 0
+        # all done
+        return self
+
+    # metamethods
+    def __init__(self, name, archive=None, **kwds):
+        # chain up; construction is passive, so nothing touches the file until {open}
+        super().__init__(name=name, **kwds)
+        # initialize the availability map so the panel can render before first contact
+        self.available = {}
         # all done
         return
 
@@ -125,6 +141,9 @@ class GDAL(
         channel.log()
         # and bail, just in case errors aren't fatal
         return
+
+    # private data
+    _opened = False  # whether first contact has been made
 
 
 # end of file

--- a/pkg/readers/nisar/H5.py
+++ b/pkg/readers/nisar/H5.py
@@ -80,11 +80,21 @@ class H5(
         # all done
         return
 
-    # metamethods
-    def __init__(self, archive=None, credentials=None, fapl=None, **kwds):
-        # chain up
-        super().__init__(**kwds)
-        # if the caller didn't provide an access property list
+    @qed.export
+    def open(self):
+        """
+        Establish first contact with the data source: open the file, walk its structure,
+        discover the datasets, and derive the selector availability
+        """
+        # if i have already made contact
+        if self._opened:
+            # there is nothing further to do
+            return self
+        # leave a mark
+        self._opened = True
+        # get the access property list i was constructed with
+        fapl = self._fapl
+        # if the caller didn't provide one
         if fapl is None:
             # make a default one
             fapl = qed.h5.libh5.properties.fapl()
@@ -100,7 +110,8 @@ class H5(
             )
         # if i'm managed, get access credentials from the archive; otherwise settle for
         # whatever the caller supplied, e.g. a worker rebuilding me from a recipe
-        credentials = archive.credentials() if archive else (credentials or {})
+        archive = self._archive
+        credentials = archive.credentials() if archive else (self.credentials or {})
         # retain them, so my recipe can carry them to a worker that cannot reach the archive
         self.credentials = credentials
         # open my file
@@ -113,6 +124,21 @@ class H5(
         # and build the selector availability map
         self.available = self._checkAvailability()
 
+        # all done
+        return self
+
+    # metamethods
+    def __init__(self, archive=None, credentials=None, fapl=None, **kwds):
+        # chain up; construction is passive, so nothing touches the file until {open}
+        super().__init__(**kwds)
+        # squirrel away what first contact needs
+        self._archive = archive
+        self._fapl = fapl
+        # retain whatever credentials the caller supplied; {open} may refresh them from
+        # the archive
+        self.credentials = credentials or {}
+        # initialize the availability map so the panel can render before first contact
+        self.available = {}
         # all done
         return
 
@@ -144,6 +170,11 @@ class H5(
                 selections[axis] = option
         # all done
         return available
+
+    # private data
+    _opened = False  # whether first contact has been made
+    _archive = None  # the archive that manages my data source, when there is one
+    _fapl = None  # the file access property list i was constructed with
 
 
 # end of file

--- a/pkg/readers/nisar/L0A.py
+++ b/pkg/readers/nisar/L0A.py
@@ -26,6 +26,16 @@ class L0A(
     selectors = qed.protocols.selectors()
     selectors.doc = "a map of selector names to their allowed values"
 
+    # interface
+    @qed.export
+    def open(self):
+        """
+        Establish first contact with the data source; L0A support is a placeholder, so
+        there is nothing to discover yet
+        """
+        # nothing to do
+        return self
+
     # metamethods
     def __init__(self, **kwds):
         # chain up

--- a/pkg/shells/Plexus.py
+++ b/pkg/shells/Plexus.py
@@ -226,15 +226,17 @@ class Plexus(pyre.plexus, family="qed.shells.plexus"):
             shell = self.shell
             # web shells field requests through a configurable service
             if shell.model == "web":
-                # find out where the current service spec came from
-                priority = shell.pyre_inventory.getTraitPriority(
-                    shell.pyre_trait("service")
+                # qed prefers the flavor that renders tiles concurrently; deposit the
+                # preference at {package} priority, so it overrides the stock default but
+                # loses to any user or command line configuration of the service
+                shell.pyre_setTrait(
+                    alias="service",
+                    value="import:qed.nexus.server",
+                    priority=self.pyre_executive.priority.package(),
+                    locator=pyre.tracking.simple(
+                        "while mounting the qed application folders"
+                    ),
                 )
-                # if nobody has expressed an opinion
-                if priority.name in ("uninitialized", "defaults"):
-                    # serve tiles with the flavor that renders them concurrently; users can
-                    # override with a 'service' setting on the shell in their configuration
-                    shell.service = "import:qed.nexus.server"
 
         # all done
         return pfs
@@ -259,8 +261,10 @@ class Plexus(pyre.plexus, family="qed.shells.plexus"):
         """
         Resolve the configuration of my cell type
         """
-        # process the cell by running a competition among all the ways it could be specified
-        # first, collect my type traits in a pile
+        # the cell type has many spellings: the {cell} facility plus a boolean shorthand
+        # per supported type; each active shorthand re-deposits its value onto {cell} at
+        # the shorthand's own recorded standing, and the configuration store arbitrates
+        # the competition, so a direct {cell} assignment wins or loses on its own merits
         types = [
             "uint8",
             "uint16",
@@ -275,23 +279,18 @@ class Plexus(pyre.plexus, family="qed.shells.plexus"):
             "complex64",
             "complex128",
         ]
-        # find the ones that are active
-        active = [name for name in types if getattr(self, name)]
-        # sort the list
-        ranked = sorted(
-            # include {cell} in the pile so we know where it stands
-            active + ["cell"],
-            # the key is the trait priority
-            key=lambda name: self.pyre_inventory.getTraitPriority(
-                self.pyre_trait(name)
-            ),
-        )
-        # the winner is
-        winner = ranked[-1]
-        # if it's not an explicit cell assignment
-        if winner != "cell":
-            # override
-            self.cell = winner
+        # go through the shorthands
+        for name in types:
+            # skip the inactive ones
+            if not getattr(self, name):
+                # on to the next one
+                continue
+            # find out where this setting came from
+            priority, locator = self._traitProvenance(alias=name)
+            # and deposit onto {cell} at the shorthand's own standing
+            self.pyre_setTrait(
+                alias="cell", value=name, priority=priority, locator=locator
+            )
         # return with no configuration errors
         return []
 
@@ -299,39 +298,30 @@ class Plexus(pyre.plexus, family="qed.shells.plexus"):
         """
         Resolve the configuration of my shape
         """
-        # initialize my shape candidate
-        shape = list(self.shape) if self.shape else [0, 0]
-        # get the priority of the shape setting
-        shapePriority = self.pyre_inventory.getTraitPriority(self.pyre_trait("shape"))
-        # get the number of lines
-        lines = self.lines
-        # if it's non-trivial
-        if lines:
-            # get its priority
-            linesPriority = self.pyre_inventory.getTraitPriority(
-                self.pyre_trait("lines")
+        # the scalar shorthands compete with the rank of {shape} each one controls; every
+        # active scalar deposits a merged shape at the scalar's own recorded standing and
+        # the configuration store arbitrates, so a direct {shape} assignment wins or loses
+        # on its own merits; note that a lone scalar deposits a PARTIAL shape, with a zero
+        # in the unspecified rank: readers with size-based inference consume it to fill in
+        # the missing extent, and everybody else must reject it during validation
+        for name, rank in [("lines", 0), ("samples", 1)]:
+            # get the value of the scalar
+            value = getattr(self, name)
+            # skip the unset ones
+            if not value:
+                # on to the next one
+                continue
+            # start with the current shape, which reflects the arbitration so far
+            merged = list(self.shape) if self.shape else [0, 0]
+            # fold in the scalar
+            merged[rank] = value
+            # find out where the scalar came from
+            priority, locator = self._traitProvenance(alias=name)
+            # and deposit the merged shape at the scalar's own standing
+            self.pyre_setTrait(
+                alias="shape", value=tuple(merged), priority=priority, locator=locator
             )
-            # if it's greater than shape's
-            if linesPriority > shapePriority:
-                # override
-                shape[0] = lines
-        # get the number of samples
-        samples = self.samples
-        # if it's non-trivial
-        if samples:
-            # get its priority
-            samplesPriority = self.pyre_inventory.getTraitPriority(
-                self.pyre_trait("samples")
-            )
-            # if it's greater than shape's
-            if samplesPriority > shapePriority:
-                # override
-                shape[1] = samples
-        # if the resulting shape has a non-trivial entry
-        if shape[0] or shape[1]:
-            # store it
-            self.shape = shape
-        # all done
+        # return with no configuration errors
         return []
 
     def _loadDatasets(self):
@@ -435,6 +425,29 @@ class Plexus(pyre.plexus, family="qed.shells.plexus"):
         self._ds += 1
         # make a name and return it
         return f"qed_{self._ds:02}"
+
+    def _traitProvenance(self, alias):
+        """
+        Look up the recorded priority and locator of the trait bound to {alias}
+        """
+        # get my inventory
+        inventory = self.pyre_inventory
+        # and the trait descriptor
+        trait = self.pyre_trait(alias)
+        # ask for the recorded standing
+        priority = inventory.getTraitPriority(trait)
+        # and the recorded provenance
+        locator = inventory.getTraitLocator(trait)
+        # anonymous components record no metadata; treat their settings as construction ones
+        if priority is None:
+            # by picking the matching priority
+            priority = self.pyre_executive.priority.construction()
+        # similarly for the provenance
+        if locator is None:
+            # mark it as ours
+            locator = pyre.tracking.simple(f"while arbitrating the '{alias}' setting")
+        # hand back the pair
+        return priority, locator
 
     # private data
     _ds = 0

--- a/pkg/shells/Plexus.py
+++ b/pkg/shells/Plexus.py
@@ -411,9 +411,14 @@ class Plexus(pyre.plexus, family="qed.shells.plexus"):
                 yield f"could not instantiate '{reader}'"
                 # and move on
                 continue
-            # if all goes well, register the reader
-            self.datasets.append(reader)
-        # clear out
+            # prime the side pile on first use; this hook runs before {__init__}
+            if self._cliSources is None:
+                # so the pile is born here
+                self._cliSources = []
+            # if all goes well, set the reader aside for the store; appending to the
+            # {datasets} trait would force the wholesale conversion of the configured
+            # entries, which the store later performs one entry at a time
+            self._cliSources.append(reader)
         # all done
         return
 
@@ -452,6 +457,9 @@ class Plexus(pyre.plexus, family="qed.shells.plexus"):
     # private data
     _ds = 0
     _ux = None  # the UX manager
+    _cliSources = (
+        None  # readers built from bare command line uris, drained by the store
+    )
 
 
 # end of file

--- a/pkg/stacks/Stack.py
+++ b/pkg/stacks/Stack.py
@@ -93,9 +93,39 @@ class Stack(
         # a pinned member can realize more combos than the aggregate; hand off its own map
         return self.readers[index].available
 
+    @qed.export
+    def open(self):
+        """
+        Establish first contact with my members and build the aggregate datasets
+        """
+        # if i have already made contact
+        if self._opened:
+            # there is nothing further to do
+            return self
+        # leave a mark
+        self._opened = True
+        # get my members
+        readers = self.readers
+        # if i somehow have none
+        if not readers:
+            # there is nothing to aggregate
+            return self
+        # ask each member to make first contact with its own data source
+        for reader in readers:
+            # one at a time; repeated opens are harmless
+            reader.open()
+        # build my aggregate datasets, one per combo that every member realizes
+        self._loadDatasets()
+        # my availability is what those aggregate datasets actually realize: the intersection
+        # across all members, NOT any one member's; derive it from the datasets themselves, the
+        # way a reader derives its own availability (this also auto-selects single-valued axes)
+        self.available = self._checkAvailability()
+        # all done
+        return self
+
     # metamethods
     def __init__(self, **kwds):
-        # chain up
+        # chain up; construction is passive: my members don't touch their files until {open}
         super().__init__(**kwds)
         # get my members
         readers = self.readers
@@ -103,22 +133,16 @@ class Stack(
         self.extent = len(readers)
         # resolve the participation mask my views start from; empty membership means all
         self.defaultMask = self._resolveMask()
-        # if i somehow have none
-        if not readers:
-            # there is nothing to aggregate
-            return
-        # the selector SPEC is shared by every member by construction, so i can borrow it
-        head, *_ = readers
-        # from the first member
-        self.selectors = head.selectors
         # synthesize a uri that identifies me
         self.uri = f"stack:{self.pyre_name}"
-        # build my aggregate datasets, one per combo that every member realizes
-        self._loadDatasets()
-        # my availability is what those aggregate datasets actually realize: the intersection
-        # across all members, NOT any one member's; derive it from the datasets themselves, the
-        # way a reader derives its own availability (this also auto-selects single-valued axes)
-        self.available = self._checkAvailability()
+        # initialize the availability map so the panel can render before first contact
+        self.available = {}
+        # if i have members
+        if readers:
+            # the selector SPEC is shared by every member by construction, a class default
+            # that requires no file contact, so i can borrow it from the first one
+            head, *_ = readers
+            self.selectors = head.selectors
         # all done
         return
 
@@ -202,6 +226,9 @@ class Stack(
                 selections[axis] = option
         # all done
         return available
+
+    # private data
+    _opened = False  # whether first contact has been made
 
 
 # end of file

--- a/pkg/ux/Dispatcher.py
+++ b/pkg/ux/Dispatcher.py
@@ -118,6 +118,8 @@ class Dispatcher:
         cls = functools.reduce(getattr, reader, qed.readers)
         # instantiate it
         reader = cls(**config)
+        # construction is passive; a preview exists to produce pixels, so make first contact
+        reader.open()
         # get its first dataset
         data, *_ = reader.datasets
         # if the requested view oversteps the raster, the native pipeline would crash

--- a/pkg/ux/Sources.py
+++ b/pkg/ux/Sources.py
@@ -150,8 +150,9 @@ class Sources:
         """
         # get its name
         name = dataset.pyre_name
-        # and remove it
-        del self._datasets[name]
+        # and remove it; tolerate entries that were never indexed, e.g. datasets discovered
+        # after their source was registered but before it was re-registered
+        self._datasets.pop(name, None)
         # all done
         return dataset
 

--- a/pkg/ux/Store.py
+++ b/pkg/ux/Store.py
@@ -36,6 +36,46 @@ class Store(qed.shells.command, family="qed.cli.ux"):
         # and delegate
         return port.tile(**kwds)
 
+    # first contact
+    def open(self):
+        """
+        Initiate first contact with the connected data sources, discarding the ones that
+        fail with a warning, and refresh the viewports so their views reflect whatever the
+        survivors discovered
+        """
+        # go through a snapshot of the sources, since casualties get disconnected
+        for source in list(self.sources):
+            # carefully
+            try:
+                # establish first contact
+                source.open()
+            # if the source is unreachable or malformed
+            except Exception as error:
+                # make a channel
+                channel = journal.warning("qed.cli")
+                # complain
+                channel.line(f"could not open '{source.pyre_name}'")
+                channel.line(f"while establishing first contact with '{source.uri}'")
+                channel.line(f"got: {error}")
+                # flush
+                channel.log()
+                # disconnect the casualty
+                self.disconnectSource(name=source.pyre_name)
+                # and move on
+                continue
+            # re-register the survivor, so the dataset index reflects what it discovered
+            self.connectSource(source=source)
+        # the views built before first contact hold no pipelines; rebuild them
+        for port in self._viewports:
+            # get the view
+            view = port.view()
+            # the ones bound to a source
+            if view.reader is not None:
+                # get to refresh themselves against the discovered datasets
+                view.refresh()
+        # all done
+        return
+
     # statistics
     def accumulate(self, task, record):
         """

--- a/pkg/ux/Store.py
+++ b/pkg/ux/Store.py
@@ -43,6 +43,8 @@ class Store(qed.shells.command, family="qed.cli.ux"):
         fail with a warning, and refresh the viewports so their views reflect whatever the
         survivors discovered
         """
+        # keep track of the casualties, so viewports bound to them can be reset
+        lost = set()
         # go through a snapshot of the sources, since casualties get disconnected
         for source in list(self.sources):
             # carefully
@@ -61,18 +63,30 @@ class Store(qed.shells.command, family="qed.cli.ux"):
                 channel.log()
                 # disconnect the casualty
                 self.disconnectSource(name=source.pyre_name)
+                # remember it
+                lost.add(source.pyre_name)
                 # and move on
                 continue
             # re-register the survivor, so the dataset index reflects what it discovered
             self.connectSource(source=source)
-        # the views built before first contact hold no pipelines; rebuild them
-        for port in self._viewports:
+        # go through the viewports
+        for index, port in enumerate(self._viewports):
             # get the view
             view = port.view()
-            # the ones bound to a source
-            if view.reader is not None:
-                # get to refresh themselves against the discovered datasets
-                view.refresh()
+            # views without a source have nothing to reconcile
+            if view.reader is None:
+                # so leave them alone
+                continue
+            # a view still bound to a casualty would show the client a selection that no
+            # longer exists in the panel
+            if view.reader.pyre_name in lost:
+                # so replace its viewport with a blank one
+                self._viewports[index] = Viewport(name=str(uuid.uuid1()))
+                # and move on
+                continue
+            # everybody else was built before first contact and holds no pipelines, so
+            # they get to refresh themselves against the discovered datasets
+            view.refresh()
         # all done
         return
 
@@ -898,11 +912,29 @@ class Store(qed.shells.command, family="qed.cli.ux"):
         """
         # make a pile
         viewports = []
-        # go through the plexus views
-        for view in plexus.views:
-            # make a viewport with each one
-            viewport = Viewport(name=str(uuid.uuid1()), view=view.clone())
-            # and add it to the pile
+        # go through the plexus views, resolving each entry on its own so a bad one is
+        # discarded with a warning instead of taking the application down; note that,
+        # unlike the source piles, the {views} trait is not emptied afterwards: it is a
+        # startup seed that nothing re-reads, and live view state persists through the
+        # configuration store rather than the trait
+        for view in self._drain(plexus=plexus, alias="views"):
+            # carefully, since cloning exercises the view configuration
+            try:
+                # make a viewport with a clone of each one
+                viewport = Viewport(name=str(uuid.uuid1()), view=view.clone())
+            # if the view configuration is broken
+            except Exception as error:
+                # make a channel
+                channel = journal.warning("qed.cli")
+                # complain
+                channel.line(f"could not build a viewport for '{view}'")
+                channel.line(f"while processing the 'views' configuration")
+                channel.line(f"got: {error}")
+                # flush
+                channel.log()
+                # and discard the entry
+                continue
+            # add the survivor to the pile
             viewports.append(viewport)
         # if there weren't any
         if not viewports:

--- a/pkg/ux/Store.py
+++ b/pkg/ux/Store.py
@@ -5,6 +5,7 @@
 
 
 # support
+import pyre
 import qed
 import journal
 import uuid
@@ -725,12 +726,19 @@ class Store(qed.shells.command, family="qed.cli.ux"):
         """
         # build the map
         archives = Archives()
-        # go through the plexus sources
-        for archive in plexus.archives:
-            # and connect them
+        # go through the plexus archives, resolving each entry on its own
+        for archive in self._drain(plexus=plexus, alias="archives"):
+            # and connect the survivors
             archives.addArchive(archive=archive)
-        # clear out the plexus pile
-        plexus.archives = []
+        # the store is now the authority on the connected archives; empty the plexus pile,
+        # recording the handoff as the provenance
+        plexus.pyre_setTrait(
+            alias="archives",
+            value=[],
+            locator=pyre.tracking.simple(
+                "while handing the data archives to the store"
+            ),
+        )
         # all done
         return archives
 
@@ -740,20 +748,109 @@ class Store(qed.shells.command, family="qed.cli.ux"):
         """
         # build the map
         sources = Sources()
-        # go through the plexus sources
-        for reader in plexus.datasets:
-            # and connect them
+        # go through the plexus datasets, resolving each entry on its own so a bad one is
+        # discarded with a warning instead of taking the application down
+        for reader in self._drain(plexus=plexus, alias="datasets"):
+            # and connect the survivors
             sources.addSource(source=reader)
-        # clear out the plexus pile
-        plexus.datasets = []
+        # readers built from bare command line uris arrive as live components on a side
+        # pile, since the command line processor must not disturb the configured entries
+        for reader in plexus._cliSources or []:
+            # connect them alongside the configured ones
+            sources.addSource(source=reader)
         # go through the plexus stacks, which present as reader-like sources
-        for stack in plexus.stacks:
-            # and connect them alongside the readers
+        for stack in self._drain(plexus=plexus, alias="stacks"):
+            # and connect them as well
             sources.addSource(source=stack)
-        # clear out the plexus stack pile
-        plexus.stacks = []
+        # the store is now the authority on the connected sources; empty the plexus piles,
+        # recording the handoff as the provenance
+        locator = pyre.tracking.simple("while handing the data sources to the store")
+        plexus.pyre_setTrait(alias="datasets", value=[], locator=locator)
+        plexus.pyre_setTrait(alias="stacks", value=[], locator=locator)
         # all done
         return sources
+
+    def _drain(self, plexus, alias):
+        """
+        Resolve the entries of the plexus trait bound to {alias} one at a time, so that a
+        bad entry is discarded with a warning instead of aborting the boot
+
+        Reading the trait normally converts the whole pile as a unit, and one bad entry
+        raises while the application is still being constructed; reading the raw
+        configuration instead gives every entry its own chance to resolve
+        """
+        # find the trait descriptor
+        trait = plexus.pyre_trait(alias)
+        # its per-entry schema is the facility that resolves specs into components
+        schema = trait.schema
+        # carefully
+        try:
+            # locate the slot that holds the trait configuration
+            node = plexus.pyre_nameserver.getNode(plexus.pyre_inventory.key[trait.name])
+            # save its converter
+            saved = node.postprocessor
+            # disable it
+            node.postprocessor = pyre.schemata.identity().coerce
+            # so the read produces the raw configuration
+            raw = node.value
+            # and restore the converter
+            node.postprocessor = saved
+        # if the raw configuration is unreachable, e.g. an anonymous plexus
+        except Exception:
+            # fall back to the normal conversion, preserving the historical behavior
+            yield from getattr(plexus, alias)
+            # and done
+            return
+
+        # normalize the raw value into a pile of entries: a missing setting
+        if raw is None:
+            # contributes nothing
+            entries = []
+        # a string carries comma separated specs, possibly wrapped in grouping delimiters
+        elif isinstance(raw, str):
+            # split it the way the framework does
+            entries = [
+                entry.strip()
+                for entry in raw.strip("[]{}()").split(",")
+                if entry.strip()
+            ]
+        # a sequence is already a pile
+        elif isinstance(raw, (list, tuple)):
+            # take it as is
+            entries = list(raw)
+        # anything else
+        else:
+            # is a single entry
+            entries = [raw]
+
+        # go through the entries
+        for entry in entries:
+            # live components, e.g. the default archives, pass through unharmed
+            if hasattr(entry, "pyre_family"):
+                # hand it off
+                yield entry
+                # and move on
+                continue
+            # everything else is a spec that must be resolved; carefully
+            try:
+                # exactly the way the framework resolves a single pile entry
+                component = schema.process(value=entry, incognito=True)
+            # any failure at all
+            except Exception as error:
+                # make a channel
+                channel = journal.warning("qed.cli")
+                # complain
+                channel.line(f"could not load '{entry}'")
+                channel.line(f"while processing the '{alias}' configuration")
+                channel.line(f"got: {error}")
+                # flush
+                channel.log()
+                # and discard the entry
+                continue
+            # a survivor joins the pile
+            yield component
+        # all done
+        return
 
     def _loadPersistentViewports(self, plexus, sources):
         """

--- a/pkg/ux/View.py
+++ b/pkg/ux/View.py
@@ -69,6 +69,18 @@ class View(qed.component, family="qed.ux.views.view", implements=qed.protocols.u
         # form the pipeline name and look it up
         return self._pipelines[f"{self.pyre_name}.{channel}"]
 
+    def refresh(self):
+        """
+        Rebuild my pipeline registry and re-resolve my selections, e.g. after my reader has
+        established first contact with its data source and discovered its datasets
+        """
+        # go through the pipelines my reader's datasets support
+        for pipeline in self.pipelines():
+            # register the new ones, keeping any existing clone with its live state
+            self._pipelines.setdefault(pipeline.pyre_name, pipeline)
+        # and re-resolve my selections against the discovered datasets
+        return self.resolve()
+
     def widen(self, dataset: str, stats: tuple) -> bool:
         """
         Expand the controller bounds of my pipeline clones for {dataset} to accommodate

--- a/tests/qed.pkg/aggregate.py
+++ b/tests/qed.pkg/aggregate.py
@@ -32,6 +32,8 @@ if not os.path.exists(product):
 one = qed.readers.nisar.gslc(name="agg_one", uri=product)
 two = qed.readers.nisar.gslc(name="agg_two", uri=product)
 stack = qed.stacks.stack(name="agg", readers=[one, two])
+# make first contact, which also opens the members
+stack.open()
 # find the aggregate dataset
 dataset = stack.find(selector={"band": "L", "frequency": "A", "polarization": "HH"})
 # grab its mean power pipeline

--- a/tests/qed.pkg/bounds.py
+++ b/tests/qed.pkg/bounds.py
@@ -17,6 +17,8 @@ import qed
 app = qed.shells.qed(name="qed.app")
 # build its dispatcher, which assembles the store with the local {d16} reader
 ux = qed.ux.dispatcher(plexus=app, docroot=qed.filesystem.local(root="."), pfs=app.pfs)
+# initiate first contact with the sources, the way the server does when it is ready
+ux.store.open()
 # get the reader
 reader, *_ = ux.store.sources
 # and its dataset; the local fixture is 65x65

--- a/tests/qed.pkg/credentials.py
+++ b/tests/qed.pkg/credentials.py
@@ -35,13 +35,18 @@ grant = {"region": "us-west-2", "access_key": "AKIATEST", "secret_key": "sekrit"
 # a stand-in for an archive
 archive = types.SimpleNamespace(credentials=lambda: dict(grant))
 
-# a managed reader pulls its credentials from its archive
+# a managed reader pulls its credentials from its archive at first contact
 managed = qed.readers.nisar.gslc(name="cred_managed", uri=product, archive=archive)
-# and retains them
+# construction is passive, so nothing has been granted yet
+assert managed.credentials == {}
+# make first contact
+managed.open()
+# and check that the grant was retained
 assert managed.credentials == grant
 
 # an unmanaged reader has none
 plain = qed.readers.nisar.gslc(name="cred_plain", uri=product)
+plain.open()
 assert plain.credentials == {}
 
 # describe a tile of the managed reader

--- a/tests/qed.pkg/deposits.py
+++ b/tests/qed.pkg/deposits.py
@@ -1,0 +1,109 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Check that the plexus resolves its cell, shape, and service settings by depositing
+candidates into the configuration store and letting normal arbitration decide
+
+An application registers globally with the journal, so each case runs in its own process
+"""
+
+# externals
+import subprocess
+import sys
+
+
+# run one scenario in a fresh interpreter and hand back what it prints
+def scenario(body: str) -> str:
+    """
+    Execute {body} in a subprocess and return its output
+    """
+    # run it
+    result = subprocess.run(
+        [sys.executable, "-c", body], capture_output=True, text=True, check=True
+    )
+    # and hand back the trimmed output
+    return result.stdout.strip()
+
+
+# a cell shorthand with a later standing beats an earlier direct assignment
+assert (
+    scenario(
+        "import qed\n"
+        "app = qed.shells.qed(name='t', cell='float32', complex64=True)\n"
+        "print(app.cell.pyre_family())\n"
+    )
+    == "qed.datatypes.complex64"
+)
+
+# and a direct assignment with a later standing beats an earlier shorthand
+assert (
+    scenario(
+        "import qed\n"
+        "app = qed.shells.qed(name='t', complex64=True, cell='float32')\n"
+        "print(app.cell.pyre_family())\n"
+    )
+    == "qed.datatypes.real32"
+)
+
+# a lone scalar deposits a partial shape, with a zero in the unspecified rank, for the
+# size-based inference of the flat readers to complete
+assert (
+    scenario(
+        "import qed\n"
+        "app = qed.shells.qed(name='t', lines=100)\n"
+        "print(app.shape)\n"
+    )
+    == "(100, 0)"
+)
+
+# a scalar with a later standing merges into an earlier shape
+assert (
+    scenario(
+        "import qed\n"
+        "app = qed.shells.qed(name='t', shape=(50, 60), samples=70)\n"
+        "print(app.shape)\n"
+    )
+    == "(50, 70)"
+)
+
+# and a shape with a later standing beats an earlier scalar
+assert (
+    scenario(
+        "import qed\n"
+        "app = qed.shells.qed(name='t', samples=70, shape=(50, 60))\n"
+        "print(app.shape)\n"
+    )
+    == "(50, 60)"
+)
+
+# a web shell serves tiles with the concurrent flavor by default
+assert (
+    scenario(
+        "import qed\n"
+        "app = qed.shells.qed(name='t', shell='web')\n"
+        "print(app.shell.service)\n"
+    )
+    == "import:qed.nexus.server"
+)
+
+# but any real opinion about the service wins over the deposited preference
+assert (
+    scenario(
+        "import pyre, qed\n"
+        "pyre.executive.nameserver.insert(\n"
+        "    name='t.shell.service', value='http',\n"
+        "    priority=pyre.executive.priority.user(),\n"
+        "    locator=pyre.tracking.simple('test'))\n"
+        "app = qed.shells.qed(name='t', shell='web')\n"
+        "print(app.shell.service)\n"
+    )
+    == "http"
+)
+
+
+# end of file

--- a/tests/qed.pkg/fleet.py
+++ b/tests/qed.pkg/fleet.py
@@ -20,10 +20,14 @@ import qed
 app = qed.shells.qed(name="qed.app")
 # build its dispatcher, which assembles the store with the local {d16} reader
 ux = qed.ux.dispatcher(plexus=app, docroot=qed.filesystem.local(root="."), pfs=app.pfs)
+# initiate first contact with the sources, the way the server does when it is ready
+ux.store.open()
 # get the configured reader
 one, *_ = ux.store.sources
 # and open the same raster a second time as an independent data product
 two = qed.readers.native.flat(name="d16b", uri="./c16.dat", shape=(65, 65), cell="c16")
+# construction is passive, so make first contact explicitly
+two.open()
 
 
 # build a task for a {reader}, along with the reference tile it should produce

--- a/tests/qed.pkg/hit.py
+++ b/tests/qed.pkg/hit.py
@@ -21,6 +21,8 @@ import qed
 app = qed.shells.qed(name="qed.app")
 # build its dispatcher, which assembles the store with the local {d16} reader
 ux = qed.ux.dispatcher(plexus=app, docroot=qed.filesystem.local(root="."), pfs=app.pfs)
+# initiate first contact with the sources, the way the server does when it is ready
+ux.store.open()
 # get the reader
 reader, *_ = ux.store.sources
 # and its dataset

--- a/tests/qed.pkg/identity.py
+++ b/tests/qed.pkg/identity.py
@@ -20,6 +20,8 @@ import qed
 app = qed.shells.qed(name="qed.app")
 # build its dispatcher, which assembles the store with the local {d16} reader
 ux = qed.ux.dispatcher(plexus=app, docroot=qed.filesystem.local(root="."), pfs=app.pfs)
+# initiate first contact with the sources, the way the server does when it is ready
+ux.store.open()
 # get the reader
 reader, *_ = ux.store.sources
 # and its dataset

--- a/tests/qed.pkg/resilience.py
+++ b/tests/qed.pkg/resilience.py
@@ -26,10 +26,10 @@ pri = pyre.executive.priority
 # and a locator
 loc = pyre.tracking.simple("while staging the resilience test")
 
-# configure a pile with one good entry, one unresolvable family, and one reader whose
-# construction fails with a raw {FileNotFoundError}; the latter two must not kill the boot;
-# the deposit carries {command} priority so it beats the fixture configuration this test
-# directory holds for the nexus suite
+# configure a pile with one good entry, one unresolvable family, one reader whose
+# construction fails with a raw {FileNotFoundError}, and one whose declared shape does not
+# fit in its file; none of them may kill the boot; the deposit carries {command} priority
+# so it beats the fixture configuration this test directory holds for the nexus suite
 ns.insert(
     name="t.datasets",
     priority=pri.command(),
@@ -38,17 +38,30 @@ ns.insert(
         "import:qed.readers.native.flat#good",
         "import:qed.readers.nosuch#bogus",
         "import:qed.readers.isce2.slc#broken",
+        "import:qed.readers.native.flat#short",
     ),
 )
 # point the good reader at the fixture, a 65x65 c16 raster
 ns.insert(name="good.uri", value=str(fixture), priority=pri.user(), locator=loc)
 ns.insert(name="good.cell", value="c16", priority=pri.user(), locator=loc)
 ns.insert(name="good.shape", value="65,65", priority=pri.user(), locator=loc)
-# and the broken one at a file that does not exist
-ns.insert(name="broken.uri", value="/nope/missing.slc", priority=pri.user(), locator=loc)
+# point the broken one at a file that does not exist
+ns.insert(
+    name="broken.uri", value="/nope/missing.slc", priority=pri.user(), locator=loc
+)
+# and declare a shape one sample too large for the short one, which would otherwise let
+# the render machinery read past the end of the map
+ns.insert(name="short.uri", value=str(fixture), priority=pri.user(), locator=loc)
+ns.insert(name="short.cell", value="c16", priority=pri.user(), locator=loc)
+ns.insert(name="short.shape", value="65,66", priority=pri.user(), locator=loc)
+# n.b.: a broken view entry rides the same per-entry containment as the datasets, but it
+# cannot be exercised from this directory: resolving an unresolvable spec sends the pyre
+# linker shelf-hunting, and it imports {views.py} -- a test driver with module level side
+# effects -- so the scenario is left to the datasets entries above
 
-# the discards are reported on this channel; quiet it so the test passes silently
+# the discards are reported on these channels; quiet them so the test passes silently
 journal.warning("qed.cli").deactivate()
+journal.warning("qed.readers.native.flat").deactivate()
 
 # boot the application
 app = qed.shells.qed(name="t")
@@ -59,19 +72,32 @@ ux = qed.ux.dispatcher(plexus=app, docroot=qed.filesystem.local(root="."), pfs=a
 # the store survived
 store = ux.store
 # construction is passive, so only the unresolvable family was discarded at the handoff;
-# the reader with the missing file constructs fine and survives until first contact
-assert [source.pyre_name for source in store.sources] == ["good", "broken"]
+# the readers with the missing file and the oversized shape construct fine and survive
+# until first contact
+assert [source.pyre_name for source in store.sources] == ["good", "broken", "short"]
 # and no dataset exists yet, since nothing has touched a file
 assert store.dataset(name="good.data") is None
 # the plexus pile was emptied by the handoff
 assert app.datasets == []
+# with no view configuration, there is a single blank viewport
+assert len(list(store.viewports)) == 1
+
+# bind the doomed source to the viewport, the way persisted state might
+store.selectSource(viewport=0, name="broken")
+# and check that it took
+assert store.view(viewport=0).reader is not None
 
 # initiate first contact, the way the server does when it is ready to serve
 store.open()
-# the reader with the missing file was discarded
-assert [source.pyre_name for source in store.sources] == ["good"]
-# and the survivor discovered its dataset
+# the reader with the missing file was discarded; the one with the oversized shape was
+# contained and stays connected, exposing no datasets
+assert [source.pyre_name for source in store.sources] == ["good", "short"]
+# the good survivor discovered its dataset
 assert store.dataset(name="good.data") is not None
+# the short one did not
+assert store.dataset(name="short.data") is None
+# and the viewport bound to the casualty was reset
+assert store.view(viewport=0).reader is None
 
 
 # end of file

--- a/tests/qed.pkg/resilience.py
+++ b/tests/qed.pkg/resilience.py
@@ -58,12 +58,20 @@ ux = qed.ux.dispatcher(plexus=app, docroot=qed.filesystem.local(root="."), pfs=a
 
 # the store survived
 store = ux.store
-# holding exactly the good source
-assert [source.pyre_name for source in store.sources] == ["good"]
-# whose dataset resolved against the fixture
-assert store.dataset(name="good.data") is not None
-# and the plexus pile was emptied by the handoff
+# construction is passive, so only the unresolvable family was discarded at the handoff;
+# the reader with the missing file constructs fine and survives until first contact
+assert [source.pyre_name for source in store.sources] == ["good", "broken"]
+# and no dataset exists yet, since nothing has touched a file
+assert store.dataset(name="good.data") is None
+# the plexus pile was emptied by the handoff
 assert app.datasets == []
+
+# initiate first contact, the way the server does when it is ready to serve
+store.open()
+# the reader with the missing file was discarded
+assert [source.pyre_name for source in store.sources] == ["good"]
+# and the survivor discovered its dataset
+assert store.dataset(name="good.data") is not None
 
 
 # end of file

--- a/tests/qed.pkg/resilience.py
+++ b/tests/qed.pkg/resilience.py
@@ -1,0 +1,69 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Check that the application boots despite misconfigured datasets: the store resolves the
+configured entries one at a time, discarding the bad ones with a warning, and takes
+ownership of the survivors
+"""
+
+# support
+import journal
+import pyre
+import qed
+
+# the c16 fixture that ships with the test suite
+fixture = pyre.primitives.path(__file__).parent / "c16.dat"
+
+# get the configuration store
+ns = pyre.executive.nameserver
+# the priority of a user configuration file
+pri = pyre.executive.priority
+# and a locator
+loc = pyre.tracking.simple("while staging the resilience test")
+
+# configure a pile with one good entry, one unresolvable family, and one reader whose
+# construction fails with a raw {FileNotFoundError}; the latter two must not kill the boot;
+# the deposit carries {command} priority so it beats the fixture configuration this test
+# directory holds for the nexus suite
+ns.insert(
+    name="t.datasets",
+    priority=pri.command(),
+    locator=loc,
+    value=(
+        "import:qed.readers.native.flat#good",
+        "import:qed.readers.nosuch#bogus",
+        "import:qed.readers.isce2.slc#broken",
+    ),
+)
+# point the good reader at the fixture, a 65x65 c16 raster
+ns.insert(name="good.uri", value=str(fixture), priority=pri.user(), locator=loc)
+ns.insert(name="good.cell", value="c16", priority=pri.user(), locator=loc)
+ns.insert(name="good.shape", value="65,65", priority=pri.user(), locator=loc)
+# and the broken one at a file that does not exist
+ns.insert(name="broken.uri", value="/nope/missing.slc", priority=pri.user(), locator=loc)
+
+# the discards are reported on this channel; quiet it so the test passes silently
+journal.warning("qed.cli").deactivate()
+
+# boot the application
+app = qed.shells.qed(name="t")
+# and build its dispatcher explicitly, the way the test environment must since it has no
+# document root; constructing the store here used to die with an unhandled {FileNotFoundError}
+ux = qed.ux.dispatcher(plexus=app, docroot=qed.filesystem.local(root="."), pfs=app.pfs)
+
+# the store survived
+store = ux.store
+# holding exactly the good source
+assert [source.pyre_name for source in store.sources] == ["good"]
+# whose dataset resolved against the fixture
+assert store.dataset(name="good.data") is not None
+# and the plexus pile was emptied by the handoff
+assert app.datasets == []
+
+
+# end of file

--- a/tests/qed.pkg/selector.py
+++ b/tests/qed.pkg/selector.py
@@ -38,18 +38,26 @@ class Select(qed.application, family="qed.apps.selector"):
         """
         The main entry point
         """
+        # locate the product
+        path = qed.primitives.path(str(self.uri.address))
+        # if the fixture has not been generated
+        if not path.exists():
+            # there is nothing to check
+            return 0
         # unpack my state into a selector
         selector = {"frequency": self.frequency, "polarization": self.polarization}
         # make a reader
         reader = qed.readers.nisar.rslc(name=f"{self.pyre_name}.reader", uri=self.uri)
+        # make first contact
+        reader.open()
         # ask it for matching datasets
         for dataset in reader.select(selector=selector):
             # show me
             print(f"select: {dataset.pyre_name}: {dataset.selector}")
-        # pick the first one
-        dataset = reader.pick(selector=selector)
+        # find the first one
+        dataset = reader.find(selector=selector)
         # show me
-        print(f"pick: {dataset.pyre_name}: {dataset.selector}")
+        print(f"find: {dataset.pyre_name}: {dataset.selector}")
         # all done
         return
 

--- a/tests/qed.pkg/shared.py
+++ b/tests/qed.pkg/shared.py
@@ -20,6 +20,8 @@ import qed
 app = qed.shells.qed(name="qed.app")
 # build its dispatcher, which assembles the store with the local {d16} reader
 ux = qed.ux.dispatcher(plexus=app, docroot=qed.filesystem.local(root="."), pfs=app.pfs)
+# initiate first contact with the sources, the way the server does when it is ready
+ux.store.open()
 # get the reader
 reader, *_ = ux.store.sources
 # and its dataset

--- a/tests/qed.pkg/team.py
+++ b/tests/qed.pkg/team.py
@@ -19,6 +19,8 @@ import qed
 app = qed.shells.qed(name="qed.app")
 # build its dispatcher, which assembles the store with the local {d16} reader
 ux = qed.ux.dispatcher(plexus=app, docroot=qed.filesystem.local(root="."), pfs=app.pfs)
+# initiate first contact with the sources, the way the server does when it is ready
+ux.store.open()
 # get the reader
 reader, *_ = ux.store.sources
 # and its dataset

--- a/tests/qed.pkg/tile.py
+++ b/tests/qed.pkg/tile.py
@@ -20,6 +20,8 @@ import qed
 app = qed.shells.qed(name="qed.app")
 # build its dispatcher, which assembles the store with the local {d16} reader
 ux = qed.ux.dispatcher(plexus=app, docroot=qed.filesystem.local(root="."), pfs=app.pfs)
+# initiate first contact with the sources, the way the server does when it is ready
+ux.store.open()
 # get the reader
 reader, *_ = ux.store.sources
 # and its dataset


### PR DESCRIPTION
## Summary

qed used to die at boot when any configured dataset was bad: building the store forced the wholesale conversion of the `datasets` trait, which instantiated every reader, and reader construction did real I/O — so a single missing file surfaced as an unhandled traceback in the middle of application construction. This PR makes startup resilient in three layers: configuration settings resolve by deposits into the configuration store instead of hand-rolled priority comparisons; the store resolves configured sources one entry at a time, discarding bad ones with a warning; and reader construction becomes passive, with first data access moved to a new `open` obligation on the reader protocol that the server initiates when it is ready to serve.

## Configuration deposits

The three arbitration sites in `pkg/shells/Plexus.py` no longer inspect and compare trait priorities. Each active cell shorthand (`--c8`, `--r4`, ...) re-deposits its value onto `cell` at the shorthand's own recorded priority and locator; the `--lines`/`--samples` scalars deposit merged shapes at the donor's standing; the web shell's `service` preference is deposited unconditionally at `package` priority, above the stock default and below any user or command line opinion. The nameserver's normal arbitration decides every competition, and provenance survives.

The former `if shape[0] or shape[1]` guard is gone: a lone scalar now deposits a partial shape — with a zero in the unspecified rank — at the scalar's own priority, which is exactly what the flat readers' size-based inference consumes; readers without inference reject an incomplete shape during `open`, where the failure is contained.

## Per-entry containment at the handoff

`Store._loadPersistentSources` and `_loadPersistentArchives` no longer iterate the converted traits. They read the raw configuration off the slot — temporarily swapping the node's postprocessor for the identity coercion — and resolve each entry individually, exactly the way the framework resolves a single pile entry. A bad entry, whether an unresolvable family or an exception during construction, is discarded with a `qed.cli` warning. Readers built from bare command line uris ride a side pile so the trait conversion is never forced. The ownership handoff still empties the plexus piles, now with a locator naming the handoff.

## Passive construction and `open`

The reader protocol gains an `open()` obligation: establish first contact with the data source — open the file, discover the datasets, derive the selector availability. Construction is passive everywhere: the flat readers move their `pyre_configured` file probes into a subclass-chained `_resolveShape` invoked from `open`; the NISAR `H5` reader defers the file open, the hierarchy walk, product discovery, and availability; the GDAL reader defers the open and band discovery; stacks open their members before aggregating; `L0A` opens trivially. The discovery and stats profiler timers move with the work they measure. Repeated opens are harmless.

First contact happens where the data is actually needed:

- `Server.activate` calls `Store.open()`, which opens every source with per-source containment — a failure warns and disconnects — re-registers survivors so the dataset index reflects what they discovered, and refreshes each viewport's view against the discovered datasets (`View.refresh`).
- nexus workers open the reader they rebuild in `Tile._locateReader`.
- the `/preview` handler opens its throwaway reader; `ConnectReader` opens inside the mutation and reports a failure as a clean null result; the measure panel opens the sources it sweeps.

CLI actions that never render touch no data file: `qed about --shell=script` in a directory configured with a 7.6 GB NISAR GSLC runs in 0.4 s.

## Tests

- `tests/qed.pkg/deposits.py` — the cell/shape/service arbitration, each case in its own interpreter.
- `tests/qed.pkg/resilience.py` — a boot with one good entry, one unresolvable family, and one reader with a missing file: the family is discarded at the handoff, the missing file at first contact, and the application survives both.
- The existing suite makes first contact explicitly where it needs datasets; two stale drivers (`selector.py`'s retired `pick`, `credentials.py`'s construction-time grant) are brought up to date, with the credentials check now asserting the passive state before `open` and the grant after.
- The `.mm` test suites now list `qed.pkg`/`qed.ext` as prerequisites, so package changes invalidate test stamps.

All 25 `tests/qed.pkg` drivers pass, along with the 55-spec playwright suite; the web flow was verified live against the GSLC fixture.