### PR TITLE
Views built before first contact adopt the reader's auto-picked selections

### DIFF
--- a/.mm/qed.ux.playwright
+++ b/.mm/qed.ux.playwright
@@ -30,5 +30,9 @@ qed.ux.playwright.env := \
     QED_DATA_NISAR=$(dir $(qed.data.nisar.gslc)) \
     QED_DATA_NISAR_SOLO=$(dir $(qed.data.nisar.gslc))solo
 
+# a hand-run of playwright from the suite directory drops its report tree in the source tree;
+# mm-driven runs are staged, so theirs is removed with the staging area
+qed.ux.playwright.clean := test-results
+
 
 # end of file

--- a/.mm/qed.ux.playwright
+++ b/.mm/qed.ux.playwright
@@ -22,10 +22,13 @@ qed.ux.playwright.prerequisites := qed.pkg qed.ext qed.ux \
     $(qed.data.native.c16) $(qed.data.nisar.gslc) $(qed.data.nisar.gcov)
 
 # tell the runner where the test data lives so playwright.config can point each webServer's {qed} at
-# it; the suite runs staged, away from the source tree, so it needs the absolute paths
+# it; the suite runs staged, away from the source tree, so it needs the absolute paths. the solo
+# server reads the shared gslc fixture through its own single-source configuration directory, so it
+# rides the same prerequisite
 qed.ux.playwright.env := \
     QED_DATA_NATIVE=$(dir $(qed.data.native.c16)) \
-    QED_DATA_NISAR=$(dir $(qed.data.nisar.gslc))
+    QED_DATA_NISAR=$(dir $(qed.data.nisar.gslc)) \
+    QED_DATA_NISAR_SOLO=$(dir $(qed.data.nisar.gslc))solo
 
 
 # end of file

--- a/pkg/ux/View.py
+++ b/pkg/ux/View.py
@@ -74,6 +74,13 @@ class View(qed.component, family="qed.ux.views.view", implements=qed.protocols.u
         Rebuild my pipeline registry and re-resolve my selections, e.g. after my reader has
         established first contact with its data source and discovered its datasets
         """
+        # first contact may have auto-picked the single-valued selector axes; a view built
+        # before its reader opened copied an empty pile, and the client deliberately makes
+        # single-valued axes inert, so unless the picks are adopted here the selection can
+        # never be completed interactively
+        if not self.selections:
+            # adopt the reader's picks; a copy, so later edits stay local to me
+            self.selections = dict(self.reader.selections)
         # go through the pipelines my reader's datasets support
         for pipeline in self.pipelines():
             # register the new ones, keeping any existing clone with its live state

--- a/tests/data/nisar/solo/qed.yaml
+++ b/tests/data/nisar/solo/qed.yaml
@@ -1,0 +1,33 @@
+# -*- pyre -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the archive root: the directory that holds the generated rasters
+qed.nisar: ..
+
+# the one and only source; a single source is auto-selected into the blank viewport at
+# boot, BEFORE the reader makes first contact -- the staging path the adoption spec guards
+gslc:
+    uri: "{qed.nisar}/gslc.h5"
+
+
+# attach the dataset to the application
+datasets:
+    - nisar.gslc#gslc
+
+
+# run as a web app on a default test port; a runner launches {qed} from this directory and
+# may override the port on the command line so parallel suites do not collide
+qed.app:
+    shell: web
+    nexus.services.web:
+        address: ip4:0.0.0.0:8125
+
+# never spawn a browser; the test driver owns the browser
+pyre.shells.web#qed.app.shell:
+    auto: no
+
+
+# end of file

--- a/tests/qed.pkg/selection.py
+++ b/tests/qed.pkg/selection.py
@@ -1,0 +1,79 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Check that a view built before its reader established first contact adopts the reader's
+auto-picked selections when the store opens its sources
+
+The boot path constructs views passively: a single source is auto-selected into the blank
+viewport while its reader has empty selections, and first contact later auto-picks the
+single-valued selector axes on the reader. The view must adopt those picks during the
+refresh, because the client deliberately makes single-valued axes inert, so a view that
+misses them can never complete its selection interactively
+"""
+
+# support
+import journal
+import pyre
+import qed
+
+# the NISAR fixture this driver reads; part of the shared test data tree
+product = pyre.primitives.path(__file__).parent / ".." / "data" / "nisar" / "gslc.h5"
+# if it has not been generated
+if not product.exists():
+    # there is nothing to check
+    raise SystemExit(0)
+
+# get the configuration store
+ns = pyre.executive.nameserver
+# the priority factories
+pri = pyre.executive.priority
+# and a locator
+loc = pyre.tracking.simple("while staging the selection test")
+
+# configure a single source, so the boot path auto-selects it into the blank viewport;
+# the deposit carries {command} priority so it beats the fixture configuration this test
+# directory holds for the nexus suite
+ns.insert(
+    name="t.datasets",
+    priority=pri.command(),
+    locator=loc,
+    value=("import:qed.readers.nisar.gslc#solo",),
+)
+# point it at the product
+ns.insert(name="solo.uri", value=str(product), priority=pri.user(), locator=loc)
+
+# quiet the configuration chatter
+journal.warning("qed.cli").deactivate()
+
+# boot the application
+app = qed.shells.qed(name="t")
+# and build its dispatcher explicitly, the way the test environment must
+ux = qed.ux.dispatcher(plexus=app, docroot=qed.filesystem.local(root="."), pfs=app.pfs)
+# get the store
+store = ux.store
+
+# the single source was auto-selected into the viewport while still passive
+view = store.view(viewport=0)
+# so it is bound to the reader
+assert view.reader is not None
+# with no selections, since the reader has not made first contact
+assert dict(view.selections) == {}
+
+# initiate first contact, the way the server does when it is ready to serve
+store.open()
+
+# the reader auto-picked its single-valued axes during first contact
+reader = store.source(name="solo")
+# the fixture must realize at least one single-valued axis for this check to have teeth
+assert len(reader.selections) > 0
+# and the view adopted the picks during its refresh
+view = store.view(viewport=0)
+assert dict(view.selections) == dict(reader.selections)
+
+
+# end of file

--- a/tests/qed.ux.playwright/playwright.config.ts
+++ b/tests/qed.ux.playwright/playwright.config.ts
@@ -26,6 +26,13 @@ const nisarPort = Number(process.env.QED_PORT_NISAR ?? 8138)
 const nisarBaseURL = process.env.QED_URL_NISAR ?? `http://localhost:${nisarPort}`
 const nisarDataDir = process.env.QED_DATA_NISAR ?? "../data/nisar"
 
+// a third server with a SINGLE source: the boot path auto-selects a lone source into the blank
+// viewport before the reader makes first contact, which is the staging condition the {solo} specs
+// guard -- it cannot be reproduced on the multi-source servers above
+const soloPort = Number(process.env.QED_PORT_SOLO ?? 8139)
+const soloBaseURL = process.env.QED_URL_SOLO ?? `http://localhost:${soloPort}`
+const soloDataDir = process.env.QED_DATA_NISAR_SOLO ?? "../data/nisar/solo"
+
 
 // the qed.ux suite drives the built client in a headless browser to enforce the semantic-markup
 // convention (doc/semantic-markup.md). playwright owns discovery, parallelism, and -- via the
@@ -54,7 +61,7 @@ export default defineConfig({
         // {qed.automation} localStorage flag the app's gate checks, for both servers under test
         storageState: {
             cookies: [],
-            origins: [baseURL, nisarBaseURL].map(origin => ({
+            origins: [baseURL, nisarBaseURL, soloBaseURL].map(origin => ({
                 origin,
                 localStorage: [{ name: "qed.automation", value: "1" }],
             })),
@@ -91,6 +98,15 @@ export default defineConfig({
             testMatch: /nisar\/.*\.spec\.ts/,
             fullyParallel: false,
             use: { ...devices["Desktop Chrome"], baseURL: nisarBaseURL },
+        },
+        // the solo suite runs against the single-source server; it guards the boot-time selection
+        // adoption -- views built before first contact must inherit the reader's auto-picked axes.
+        // it operates the polarization control, so it is serial and restores what it touches
+        {
+            name: "solo",
+            testMatch: /solo\/.*\.spec\.ts/,
+            fullyParallel: false,
+            use: { ...devices["Desktop Chrome"], baseURL: soloBaseURL },
         },
         // the api-contract project: it drives {window.qed} but asserts the MODEL (state/viewports/
         // controllers) instead of the DOM, so a failure localizes to the server/store layer rather
@@ -130,6 +146,15 @@ export default defineConfig({
             command: `qed --qed.app.nexus.services.web.address=ip4:0.0.0.0:${nisarPort}`,
             cwd: nisarDataDir,
             url: nisarBaseURL,
+            reuseExistingServer: !process.env.CI,
+            timeout: 60_000,
+            stdout: "ignore",
+            stderr: "pipe",
+        },
+        {
+            command: `qed --qed.app.nexus.services.web.address=ip4:0.0.0.0:${soloPort}`,
+            cwd: soloDataDir,
+            url: soloBaseURL,
             reuseExistingServer: !process.env.CI,
             timeout: 60_000,
             stdout: "ignore",

--- a/tests/qed.ux.playwright/solo/adoption.spec.ts
+++ b/tests/qed.ux.playwright/solo/adoption.spec.ts
@@ -1,0 +1,70 @@
+// -*- web -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// support
+import { test, expect } from "@playwright/test"
+
+
+// this suite runs against the SOLO server: a single NISAR source, which the boot path
+// auto-selects into the blank viewport BEFORE the reader makes first contact. that is the
+// regression surface this spec guards: first contact auto-picks the single-valued selector
+// axes on the reader, and the view built at boot must ADOPT those picks -- the client
+// deliberately makes single-valued axes inert, so a view that misses them can never
+// complete its selection interactively. it operates the polarization control, so it is
+// serial and restores what it touches
+
+test.describe.serial("boot-time selection adoption", () => {
+    test("the single-valued axis arrives pre-selected, with no interaction", async ({ page }) => {
+        await page.goto("/", { waitUntil: "load" })
+        // wait for the reader panel to mount
+        await page.locator('[data-qed-reader="gslc"]').waitFor({ timeout: 10_000 })
+
+        // the fixture realizes exactly one band; first contact auto-picked it, and the
+        // view adopted the pick -- this radio is checked without a single click
+        const band = page.locator('[data-qed-reader="gslc"] [data-qed-axis="band"] [data-qed-value="L"]')
+        await expect(band).toHaveAttribute("aria-checked", "true")
+
+        // the frequency and polarization axes are multi-valued, so they wait for the user
+        for (const axis of ["frequency", "polarization"]) {
+            const group = page.locator(`[data-qed-reader="gslc"] [data-qed-axis="${axis}"]`)
+            await expect(group.locator('[aria-checked="true"]')).toHaveCount(0)
+        }
+    })
+
+    test("clicking the remaining axes completes the selection and surfaces the channels", async ({ page }) => {
+        await page.goto("/", { waitUntil: "load" })
+        await page.locator('[data-qed-reader="gslc"]').waitFor({ timeout: 10_000 })
+
+        // the channels row is not on display while the selection is incomplete
+        const channels = page.locator('[data-qed-reader="gslc"] [data-qed-control="channel"]')
+        await expect(channels).toHaveCount(0)
+
+        // pick the frequency and the polarization through the real radios, the way a user does
+        const picks = [["frequency", "A"], ["polarization", "HH"]]
+        for (const [axis, value] of picks) {
+            const radio = page.locator(
+                `[data-qed-reader="gslc"] [data-qed-axis="${axis}"] [data-qed-value="${value}"]`)
+            await radio.click()
+            await expect(radio).toHaveAttribute("aria-checked", "true")
+        }
+
+        // the selection is now fully formed, so the channels radiogroup appears
+        await expect(channels).toHaveCount(1)
+
+        // restore the blank selection so a rerun starts clean: toggling each pick clears it
+        for (const [axis, value] of picks) {
+            const radio = page.locator(
+                `[data-qed-reader="gslc"] [data-qed-axis="${axis}"] [data-qed-value="${value}"]`)
+            await radio.click()
+            await expect(radio).toHaveAttribute("aria-checked", "false")
+        }
+        await expect(channels).toHaveCount(0)
+    })
+})
+
+
+/* end of file */


### PR DESCRIPTION
## Summary

A regression from #93: with passive construction, the boot path builds views before their readers make first contact. `View.pyre_configured` copies `reader.selections` only at construction — at that moment an empty pile — and first contact later auto-picks the single-valued selector axes on the reader, with nothing carrying the picks to the already-built view. The client deliberately makes single-valued axes inert (a coordinate click only fires when more than one value is available), so on any product with a single-valued axis the selection could never be completed interactively: the axis stayed starred, the dataset never bound, and the channels never appeared.

## The fix

`View.refresh()` — the step the store runs for every viewport after opening its sources — now adopts the reader's selections when the view has none, mirroring the construction-time copy. Seven lines in `pkg/ux/View.py`.

## The tests

The regression only manifests on a server whose boot auto-selects a source into the blank viewport — a single-source configuration — and only through the interactive click path, which is why the existing suites missed it: the NISAR test server hosts two sources, and its specs drive selection through the `window.qed` mutations, which work for any axis.

- `tests/qed.pkg/selection.py` covers the mechanism: a single NISAR source, booted passively, auto-selected into the viewport; after `store.open()` the view's selections must match the reader's auto-picks. Fails without the fix.
- A third playwright server, `solo`, runs against a new single-source fixture configuration (`tests/data/nisar/solo/qed.yaml`, reading the shared gslc fixture). Its spec asserts that the single-valued band arrives pre-checked with no interaction, then completes the selection by clicking the frequency and polarization radios — the real user path — checks that the channels radiogroup appears, and restores the blank selection. The pre-selection assertion fails without the fix.

The full suite (57 specs across the three servers) and the `tests/qed.pkg` drivers pass.

Note: under the staging redesign being drafted in `doc/staging.md`, views can no longer be built before first contact and this code path disappears; the fix is needed on main today.