### PR TITLE
qed.ux: editable display bounds for the viz controllers

### DIFF
--- a/doc/automation-surface.md
+++ b/doc/automation-surface.md
@@ -48,7 +48,7 @@ window.qed = {
   },
   viewports() → [state, …],                      // every viewport, for split layouts
   readers()   → [{ name, selectors:{axis:[…]} }],// the reader catalog
-  controllers(viewport?) → [{ kind, slot, min, max }], // colour-stretch controllers; kind = range|value
+  controllers(viewport?) → [{ kind, slot, auto, min, max }], // colour-stretch controllers; kind = range|value; auto = follows the data
 
   // --- commands: act without synthesizing clicks ---
   selectReader(reader, viewport?),
@@ -64,8 +64,16 @@ window.qed = {
     toggleClosedPath(viewport?),
     toggleSelection(handle, viewport?), toggleSelectionMulti(handle, viewport?), extendSelection(handle, viewport?),
   },
-  range: { update(controller, {min,low,high,max}, channel?, viewport?), reset(controller, channel?, viewport?) },
-  value: { update(controller, {min,value,max}, channel?, viewport?), reset(controller, channel?, viewport?) },
+  range: {
+    update(controller, {min,low,high,max}, channel?, viewport?), reset(controller, channel?, viewport?),
+    resize(controller, {min,max}, channel?, viewport?),  // hand-set bounds; must enclose low/high; pins the controller
+    setAuto(controller, auto, channel?, viewport?),  // pin (false) or release (true); releasing widens to the accumulated statistics
+  },
+  value: {
+    update(controller, {min,value,max}, channel?, viewport?), reset(controller, channel?, viewport?),
+    resize(controller, {min,max}, channel?, viewport?),  // hand-set bounds; must enclose value; pins the controller
+    setAuto(controller, auto, channel?, viewport?),  // pin (false) or release (true); releasing widens to the accumulated statistics
+  },
   sync: {
     toggle(aspect, viewport?), toggleAll(aspect, viewport?), reset(viewport?),  // sync flags
     updateOffset(row, col, viewport?),            // the relative sync offset, in source pixels

--- a/doc/statistics.md
+++ b/doc/statistics.md
@@ -163,9 +163,12 @@ These are the rules the current code enforces, and that any change must preserve
    controllers and excluded from the identity harvest, so widening them never invalidates
    cached work and never rolls a session. `widen` only ever expands, never touches picks,
    and preserves the `dirty` flag — `dirty` is harvested, so flipping it would also perturb
-   identity.
+   identity. The `auto` flag is `cosmetic` too: pinning a controller or releasing it changes
+   what statistics may do later, not the pixels, so it leaves identities alone as well.
 3. **Pinned controllers never move.** `auto: no` gates both `autotune` and `widen`; the test
-   fixtures pin their pipelines for determinism and rely on this absolutely.
+   fixtures pin their pipelines for determinism and rely on this absolutely. A hand edit of
+   the bounds pins the controller, and the lock on its header pins or releases it; releasing
+   widens to the statistics accumulated so far, since no further report may ever arrive.
 4. **The autotuners are shape-sensitive, and now guarded.** `LinearRange._autotune` and
    `LogRange._autotune` unpack a bare `(low, mean, high)`; the channel wrappers index into
    the sample, and the isce2 unwrapped flavor expects a *list of two* triples for its

--- a/pkg/controllers/Controller.py
+++ b/pkg/controllers/Controller.py
@@ -163,8 +163,9 @@ class Controller(qed.component, implements=qed.protocols.controller):
     # constants
     tag = "controller"
     # traits that shape the presentation but not the rendered pixels; they are excluded from
-    # tile identities, so adjusting them does not invalidate cached work
-    cosmetic = ("min", "max")
+    # tile identities, so adjusting them does not invalidate cached work: the display bounds,
+    # and the flag that says whether statistics may move them
+    cosmetic = ("auto", "min", "max")
 
 
 # end of file

--- a/pkg/controllers/Controller.py
+++ b/pkg/controllers/Controller.py
@@ -48,6 +48,66 @@ class Controller(qed.component, implements=qed.protocols.controller):
         # otherwise, let my flavor decide; it reports whether anything actually moved
         return self._widen(stats=stats)
 
+    def resize(self, *, min: float, max: float) -> bool:
+        """
+        Set my display bounds to [{min}, {max}] by hand; the new extent must leave my picks in
+        place, so the rendered pixels never change, and the edit pins me so that statistics
+        can no longer move my bounds
+        """
+        # an extent that would encroach on my picks is refused
+        if not self.accommodates(min=min, max=max):
+            # untouched
+            return False
+        # adopt the bounds
+        self.min = min
+        self.max = max
+        # a hand-set extent is pinned: neither autotune nor widen may move it from now on
+        self.auto = False
+        # report the move
+        return True
+
+    def pin(self) -> None:
+        """
+        Opt out of automatic adjustments: neither autotune nor widen may move my bounds
+        """
+        # easy enough
+        self.auto = False
+        # all done
+        return
+
+    def unpin(self, stats: tuple | None = None) -> bool:
+        """
+        Opt back into automatic adjustments and, if {stats} are on offer, stretch my bounds to
+        accommodate them right away, since no further statistics may ever arrive
+        """
+        # release the pin
+        self.auto = True
+        # without statistics, there is nothing to catch up on
+        if stats is None:
+            # so report that the bounds stayed put
+            return False
+        # otherwise, stretch, and report whether anything moved
+        return self.widen(stats=stats)
+
+    def accommodates(self, *, min: float, max: float) -> bool:
+        """
+        Check whether the extent [{min}, {max}] is well formed and leaves my picks inside it
+        """
+        # a degenerate or inverted extent is meaningless
+        if min >= max:
+            # so refuse it
+            return False
+        # get the span of my picks
+        envelope = self._envelope()
+        # a controller without picks accommodates any well formed extent
+        if envelope is None:
+            # so accept it
+            return True
+        # unpack
+        lowest, highest = envelope
+        # the extent must enclose the picks
+        return min <= lowest and highest <= max
+
     # metamethods
     def __init__(self, **kwds):
         # chain up
@@ -92,6 +152,13 @@ class Controller(qed.component, implements=qed.protocols.controller):
         """
         # by default, there is nothing to expand
         return False
+
+    def _envelope(self) -> tuple | None:
+        """
+        Report the span of my picks as a (lowest, highest) pair, or None if i have no picks
+        """
+        # by default, i have no picks for an extent to accommodate
+        return None
 
     # constants
     tag = "controller"

--- a/pkg/controllers/LinearRange.py
+++ b/pkg/controllers/LinearRange.py
@@ -98,6 +98,13 @@ class LinearRange(Controller, family="qed.controllers.linearrange"):
         # report the move
         return True
 
+    def _envelope(self) -> tuple:
+        """
+        Report the span of my picks
+        """
+        # my range is my span
+        return (self.low, self.high)
+
     # constants
     tag = "range"
 

--- a/pkg/controllers/LogRange.py
+++ b/pkg/controllers/LogRange.py
@@ -108,6 +108,13 @@ class LogRange(Controller, family="qed.controllers.logrange"):
         # report the move
         return True
 
+    def _envelope(self) -> tuple:
+        """
+        Report the span of my picks
+        """
+        # my range is my span
+        return (self.low, self.high)
+
     # constants
     tag = "range"
 

--- a/pkg/controllers/Value.py
+++ b/pkg/controllers/Value.py
@@ -40,6 +40,14 @@ class Value(Controller, family="qed.controllers.value"):
         # and let the caller know
         return True
 
+    # helpers
+    def _envelope(self) -> tuple:
+        """
+        Report the span of my picks
+        """
+        # my single pick is both ends of my span
+        return (self.value, self.value)
+
     # constants
     tag = "value"
 

--- a/pkg/gql/Mutation.py
+++ b/pkg/gql/Mutation.py
@@ -24,6 +24,10 @@ from .controllers.ViewRangeReset import ViewRangeReset
 from .controllers.ViewValueReset import ViewValueReset
 from .controllers.ViewRangeUpdate import ViewRangeUpdate
 from .controllers.ViewValueUpdate import ViewValueUpdate
+from .controllers.ViewRangeResize import ViewRangeResize
+from .controllers.ViewValueResize import ViewValueResize
+from .controllers.ViewRangeAutoSet import ViewRangeAutoSet
+from .controllers.ViewValueAutoSet import ViewValueAutoSet
 
 
 # the mutation anchor
@@ -87,6 +91,14 @@ class Mutation(graphene.ObjectType):
     # updates to viz controllers
     viewRangeUpdate = ViewRangeUpdate.Field()
     viewValueUpdate = ViewValueUpdate.Field()
+
+    # hand edits of the display bounds of viz controllers
+    viewRangeResize = ViewRangeResize.Field()
+    viewValueResize = ViewValueResize.Field()
+
+    # pinning and releasing viz controllers
+    viewRangeAutoSet = ViewRangeAutoSet.Field()
+    viewValueAutoSet = ViewValueAutoSet.Field()
 
     # resetting of viz controller state
     viewRangeReset = ViewRangeReset.Field()

--- a/pkg/gql/controllers/Controller.py
+++ b/pkg/gql/controllers/Controller.py
@@ -18,6 +18,7 @@ class Controller(graphene.Interface):
     id = graphene.ID()
     dirty = graphene.Boolean()
     slot = graphene.String()
+    auto = graphene.Boolean()
     min = graphene.Float()
     max = graphene.Float()
 

--- a/pkg/gql/controllers/RangeController.py
+++ b/pkg/gql/controllers/RangeController.py
@@ -30,6 +30,7 @@ class RangeController(graphene.ObjectType):
     dirty = graphene.Boolean()
     # payload
     slot = graphene.String()
+    auto = graphene.Boolean()
     min = graphene.Float()
     max = graphene.Float()
     low = graphene.Float()
@@ -62,6 +63,16 @@ class RangeController(graphene.ObjectType):
         controller = context["controller"]
         # easy enough
         return controller.dirty
+
+    @staticmethod
+    def resolve_auto(context, *_):
+        """
+        Check whether the controller follows the data statistics or is pinned
+        """
+        # extract the controller
+        controller = context["controller"]
+        # easy enough
+        return controller.auto
 
     @staticmethod
     def resolve_min(context, *_):

--- a/pkg/gql/controllers/ValueController.py
+++ b/pkg/gql/controllers/ValueController.py
@@ -30,6 +30,7 @@ class ValueController(graphene.ObjectType):
     dirty = graphene.Boolean()
     # payload
     slot = graphene.String()
+    auto = graphene.Boolean()
     min = graphene.Float()
     max = graphene.Float()
     value = graphene.Float()
@@ -61,6 +62,16 @@ class ValueController(graphene.ObjectType):
         controller = context["controller"]
         # easy enough
         return controller.dirty
+
+    @staticmethod
+    def resolve_auto(context, *_):
+        """
+        Check whether the controller follows the data statistics or is pinned
+        """
+        # extract the controller
+        controller = context["controller"]
+        # easy enough
+        return controller.auto
 
     @staticmethod
     def resolve_min(context, *_):

--- a/pkg/gql/controllers/ViewRangeAutoSet.py
+++ b/pkg/gql/controllers/ViewRangeAutoSet.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import graphene
+
+# the request payload
+from .ViewRangeAutoSetInput import ViewRangeAutoSetInput
+
+# the result types
+from ..views.View import View
+from .RangeController import RangeController
+
+
+# set the auto flag of a range controller
+class ViewRangeAutoSet(graphene.Mutation):
+    """
+    Pin a range controller, or release it to follow the data statistics; a released controller
+    stretches its display bounds to accommodate the statistics accumulated so far, but its picks
+    never move, so the rendered pixels are unchanged
+    """
+
+    # inputs
+    class Arguments:
+        # the request payload
+        input = ViewRangeAutoSetInput(required=True)
+
+    # the result is the view, whose session token is unchanged since no pixels moved
+    view = graphene.Field(View)
+    # and the adjusted range controller
+    controller = graphene.Field(RangeController)
+
+    # the mutator
+    @staticmethod
+    def mutate(root, info, input):
+        """
+        Set the auto flag of the controller named in {input}
+        """
+        # unpack the payload
+        viewport = input["viewport"]
+        channelName = input["channel"]
+        controllerName = input["controller"]
+        # grab the store
+        store = info.context["store"]
+        # ask it to adjust the controller
+        view, controller = store.vizSetControllerAuto(
+            viewport=viewport,
+            channel=channelName,
+            name=controllerName,
+            auto=input["auto"],
+        )
+        # build the resolution context
+        context = {
+            "view": view,
+            "controller": {
+                "controller": controller,
+            },
+        }
+        # and use the result to resolve the mutation
+        return context
+
+
+# end of file

--- a/pkg/gql/controllers/ViewRangeAutoSetInput.py
+++ b/pkg/gql/controllers/ViewRangeAutoSetInput.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import graphene
+
+
+# the request payload for setting the auto flag of a range controller
+class ViewRangeAutoSetInput(graphene.InputObjectType):
+    """
+    The payload to pin a range controller or release it to follow the data statistics
+    """
+
+    # the viewport
+    viewport = graphene.Int()
+    # the channel that owns the controller
+    channel = graphene.String()
+    # the controller name
+    controller = graphene.String(required=True)
+    # the flag
+    auto = graphene.Boolean(required=True)
+
+
+# end of file

--- a/pkg/gql/controllers/ViewRangeResize.py
+++ b/pkg/gql/controllers/ViewRangeResize.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import graphene
+
+# the request payload
+from .ViewRangeResizeInput import ViewRangeResizeInput
+
+# the result types
+from ..views.View import View
+from .RangeController import RangeController
+
+
+# resize a range controller
+class ViewRangeResize(graphene.Mutation):
+    """
+    Set the display bounds of a range controller by hand; the bounds must leave the picks in
+    place, so the rendered pixels never change, and the edit pins the controller
+    """
+
+    # inputs
+    class Arguments:
+        # the request payload
+        input = ViewRangeResizeInput(required=True)
+
+    # the result is the view, whose session token is unchanged since no pixels moved
+    view = graphene.Field(View)
+    # and the resized range controller
+    controller = graphene.Field(RangeController)
+
+    # the mutator
+    @staticmethod
+    def mutate(root, info, input):
+        """
+        Resize the controller named in {input}
+        """
+        # unpack the payload
+        viewport = input["viewport"]
+        channelName = input["channel"]
+        controllerName = input["controller"]
+        # grab the store
+        store = info.context["store"]
+        # ask it to resize the controller; a refused extent surfaces as a failed mutation
+        view, controller = store.vizResizeController(
+            viewport=viewport,
+            channel=channelName,
+            name=controllerName,
+            min=input["min"],
+            max=input["max"],
+        )
+        # build the resolution context
+        context = {
+            "view": view,
+            "controller": {
+                "controller": controller,
+            },
+        }
+        # and use the result to resolve the mutation
+        return context
+
+
+# end of file

--- a/pkg/gql/controllers/ViewRangeResizeInput.py
+++ b/pkg/gql/controllers/ViewRangeResizeInput.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import graphene
+
+
+# the request payload for resizing a range controller
+class ViewRangeResizeInput(graphene.InputObjectType):
+    """
+    The payload to set the display bounds of a range controller by hand
+    """
+
+    # the viewport
+    viewport = graphene.Int()
+    # the channel that owns the controller
+    channel = graphene.String()
+    # the controller name
+    controller = graphene.String(required=True)
+    # the new display bounds
+    min = graphene.Float(required=True)
+    max = graphene.Float(required=True)
+
+
+# end of file

--- a/pkg/gql/controllers/ViewValueAutoSet.py
+++ b/pkg/gql/controllers/ViewValueAutoSet.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import graphene
+
+# the request payload
+from .ViewValueAutoSetInput import ViewValueAutoSetInput
+
+# the result types
+from ..views.View import View
+from .ValueController import ValueController
+
+
+# set the auto flag of a value controller
+class ViewValueAutoSet(graphene.Mutation):
+    """
+    Pin a value controller, or release it to follow the data statistics; a released controller
+    stretches its display bounds to accommodate the statistics accumulated so far, but its picks
+    never move, so the rendered pixels are unchanged
+    """
+
+    # inputs
+    class Arguments:
+        # the request payload
+        input = ViewValueAutoSetInput(required=True)
+
+    # the result is the view, whose session token is unchanged since no pixels moved
+    view = graphene.Field(View)
+    # and the adjusted value controller
+    controller = graphene.Field(ValueController)
+
+    # the mutator
+    @staticmethod
+    def mutate(root, info, input):
+        """
+        Set the auto flag of the controller named in {input}
+        """
+        # unpack the payload
+        viewport = input["viewport"]
+        channelName = input["channel"]
+        controllerName = input["controller"]
+        # grab the store
+        store = info.context["store"]
+        # ask it to adjust the controller
+        view, controller = store.vizSetControllerAuto(
+            viewport=viewport,
+            channel=channelName,
+            name=controllerName,
+            auto=input["auto"],
+        )
+        # build the resolution context
+        context = {
+            "view": view,
+            "controller": {
+                "controller": controller,
+            },
+        }
+        # and use the result to resolve the mutation
+        return context
+
+
+# end of file

--- a/pkg/gql/controllers/ViewValueAutoSetInput.py
+++ b/pkg/gql/controllers/ViewValueAutoSetInput.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import graphene
+
+
+# the request payload for setting the auto flag of a value controller
+class ViewValueAutoSetInput(graphene.InputObjectType):
+    """
+    The payload to pin a value controller or release it to follow the data statistics
+    """
+
+    # the viewport
+    viewport = graphene.Int()
+    # the channel that owns the controller
+    channel = graphene.String()
+    # the controller name
+    controller = graphene.String(required=True)
+    # the flag
+    auto = graphene.Boolean(required=True)
+
+
+# end of file

--- a/pkg/gql/controllers/ViewValueResize.py
+++ b/pkg/gql/controllers/ViewValueResize.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import graphene
+
+# the request payload
+from .ViewValueResizeInput import ViewValueResizeInput
+
+# the result types
+from ..views.View import View
+from .ValueController import ValueController
+
+
+# resize a value controller
+class ViewValueResize(graphene.Mutation):
+    """
+    Set the display bounds of a value controller by hand; the bounds must leave the picks in
+    place, so the rendered pixels never change, and the edit pins the controller
+    """
+
+    # inputs
+    class Arguments:
+        # the request payload
+        input = ViewValueResizeInput(required=True)
+
+    # the result is the view, whose session token is unchanged since no pixels moved
+    view = graphene.Field(View)
+    # and the resized value controller
+    controller = graphene.Field(ValueController)
+
+    # the mutator
+    @staticmethod
+    def mutate(root, info, input):
+        """
+        Resize the controller named in {input}
+        """
+        # unpack the payload
+        viewport = input["viewport"]
+        channelName = input["channel"]
+        controllerName = input["controller"]
+        # grab the store
+        store = info.context["store"]
+        # ask it to resize the controller; a refused extent surfaces as a failed mutation
+        view, controller = store.vizResizeController(
+            viewport=viewport,
+            channel=channelName,
+            name=controllerName,
+            min=input["min"],
+            max=input["max"],
+        )
+        # build the resolution context
+        context = {
+            "view": view,
+            "controller": {
+                "controller": controller,
+            },
+        }
+        # and use the result to resolve the mutation
+        return context
+
+
+# end of file

--- a/pkg/gql/controllers/ViewValueResizeInput.py
+++ b/pkg/gql/controllers/ViewValueResizeInput.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# externals
+import graphene
+
+
+# the request payload for resizing a value controller
+class ViewValueResizeInput(graphene.InputObjectType):
+    """
+    The payload to set the display bounds of a value controller by hand
+    """
+
+    # the viewport
+    viewport = graphene.Int()
+    # the channel that owns the controller
+    channel = graphene.String()
+    # the controller name
+    controller = graphene.String(required=True)
+    # the new display bounds
+    min = graphene.Float(required=True)
+    max = graphene.Float(required=True)
+
+
+# end of file

--- a/pkg/ux/Store.py
+++ b/pkg/ux/Store.py
@@ -818,6 +818,29 @@ class Store(qed.shells.command, family="qed.cli.ux"):
         # and delegate
         return port.vizUpdateController(**kwds)
 
+    def vizResizeController(self, viewport, **kwds):
+        """
+        Set the display bounds of a viz pipeline controller by hand
+        """
+        # get the {viewport} configuration
+        port = self._viewports[viewport]
+        # and delegate
+        return port.vizResizeController(**kwds)
+
+    def vizSetControllerAuto(self, viewport, auto, **kwds):
+        """
+        Set the {auto} flag of a viz pipeline controller; a released controller catches up
+        with whatever statistics have accumulated for its dataset
+        """
+        # get the {viewport} configuration
+        port = self._viewports[viewport]
+        # look up the accumulated statistics of the dataset on display
+        sample = self.statistics(name=port.view().dataset.pyre_name)
+        # reduce them to the triple the controllers understand, if there are any
+        stats = None if sample is None else (sample.min, sample.mean, sample.max)
+        # and delegate
+        return port.vizSetControllerAuto(auto=auto, stats=stats, **kwds)
+
     def lookAt(self, viewport, row, col):
         """
         Set the source pixel at the center of {viewport}

--- a/pkg/ux/View.py
+++ b/pkg/ux/View.py
@@ -474,13 +474,87 @@ class View(qed.component, family="qed.ux.views.view", implements=qed.protocols.u
         pipeline = self._pipelines[channel]
         # get the controller
         controller = getattr(pipeline, name)
+        # the extent rides along with the picks; collect it here
+        extent = {}
         # go through the configuration
-        for name, value in configuration.items():
-            # and adjust the controller state
-            setattr(controller, name, value)
+        for trait, value in configuration.items():
+            # setting the extent aside
+            if trait in controller.cosmetic:
+                # for after the picks have landed
+                extent[trait] = value
+                # on to the next one
+                continue
+            # and adjusting the picks
+            setattr(controller, trait, value)
+        # if the payload carries an extent
+        if extent:
+            # it must leave the picks in place, since only they shape the rendered pixels
+            if controller.accommodates(**extent):
+                # adopt it; the picks own this payload, so the extent is not a hand edit
+                # and does not pin the controller
+                for trait, value in extent.items():
+                    # one bound at a time
+                    setattr(controller, trait, value)
+            # otherwise
+            else:
+                # make a channel
+                warning = journal.warning("qed.ux.controllers")
+                # complain
+                warning.line(f"while updating '{controller.pyre_name}'")
+                warning.indent()
+                warning.line(f"ignoring the extent {extent}")
+                warning.line(f"it does not accommodate the picks")
+                warning.outdent()
+                # flush
+                warning.log()
         # grab a new session token
         self.session = uuid.uuid1()
         # all done
+        return controller
+
+    def vizResizeController(self, name, channel, min, max):
+        """
+        Set the display bounds of one of my controllers to [{min}, {max}] by hand
+        """
+        # form the name of the pipeline and look it up
+        pipeline = self._pipelines[channel]
+        # get the controller
+        controller = getattr(pipeline, name)
+        # ask it to adopt the extent, which pins it
+        if not controller.resize(min=min, max=max):
+            # if it refused, make a channel
+            error = journal.error("qed.ux.controllers")
+            # complain
+            error.line(f"while resizing '{controller.pyre_name}'")
+            error.indent()
+            error.line(f"the extent [{min}, {max}] does not accommodate the picks")
+            error.line(f"or is not well formed")
+            error.outdent()
+            # flush; the error is fatal and reaches the client as a failed mutation
+            error.log()
+            # bail, in case the channel has been muted
+            return controller
+        # the rendered pixels are unchanged, so the session token stays put
+        return controller
+
+    def vizSetControllerAuto(self, name, channel, auto, stats=None):
+        """
+        Set the {auto} flag of one of my controllers; a released controller catches up with
+        {stats}, the accumulated statistics of my dataset, if any
+        """
+        # form the name of the pipeline and look it up
+        pipeline = self._pipelines[channel]
+        # get the controller
+        controller = getattr(pipeline, name)
+        # if the flag is being cleared
+        if not auto:
+            # pin the controller
+            controller.pin()
+        # otherwise
+        else:
+            # release it and let it catch up with the data
+            controller.unpin(stats=stats)
+        # the picks are untouched either way, so the session token stays put
         return controller
 
     def zoomSetLevel(self, horizontal, vertical):

--- a/pkg/ux/Viewport.py
+++ b/pkg/ux/Viewport.py
@@ -248,6 +248,28 @@ class Viewport(
         # and hand off the pair
         return view, controller
 
+    def vizResizeController(self, **kwds):
+        """
+        Set the display bounds of a controller of my active visualization pipeline
+        """
+        # get my active view
+        view = self._view
+        # resize the controller
+        controller = view.vizResizeController(**kwds)
+        # and hand off the pair
+        return view, controller
+
+    def vizSetControllerAuto(self, **kwds):
+        """
+        Set the {auto} flag of a controller of my active visualization pipeline
+        """
+        # get my active view
+        view = self._view
+        # adjust the controller
+        controller = view.vizSetControllerAuto(**kwds)
+        # and hand off the pair
+        return view, controller
+
     def lookAt(self, row, col):
         """
         Set the source pixel that sits at the center of the viewport

--- a/tests/qed.pkg/extent.py
+++ b/tests/qed.pkg/extent.py
@@ -1,0 +1,179 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Check that the store routes controller updates and hand-set display bounds correctly: a drag
+payload moves the picks and lets its extent ride along only when it accommodates them, while a
+resize moves only the bounds, never the picks or the session token, and refuses to encroach
+"""
+
+# support
+import qed
+import journal
+
+# the refusals below are reported on channels that would otherwise break the silence
+journal.warning("qed.ux.controllers").device = journal.trash()
+journal.error("qed.ux.controllers").device = journal.trash()
+
+# load the app so the configuration in this directory is processed
+app = qed.shells.qed(name="qed.app")
+# build its dispatcher, which assembles the store with the local {d16} reader
+ux = qed.ux.dispatcher(plexus=app, docroot=qed.filesystem.local(root="."), pfs=app.pfs)
+# initiate first contact with the sources, the way the server does when it is ready
+ux.store.open()
+# get the view in the only viewport
+view = ux.store._viewports[0].view()
+# and the name of the complex pipeline of the fixture
+channel = view.pipeline(channel="d16.data.complex").pyre_name
+# whose amplitude controller is a range, configured to (-1, -0.5, 0.5, 1)
+amplitude = getattr(view.pipeline(channel="d16.data.complex"), "amplitude")
+# and whose saturation controller is a value, configured to (0.2, 0.4, 0.6)
+saturation = getattr(view.pipeline(channel="d16.data.complex"), "saturation")
+
+# remember the session token
+session = view.session
+# a drag payload with a consistent extent
+_, controller = ux.store.vizUpdateController(
+    viewport=0,
+    channel=channel,
+    name="amplitude",
+    configuration={"min": -2.0, "low": -0.75, "high": 0.75, "max": 2.0},
+)
+# lands both the picks and the extent
+assert controller is amplitude
+assert (amplitude.min, amplitude.low, amplitude.high, amplitude.max) == (
+    -2.0,
+    -0.75,
+    0.75,
+    2.0,
+)
+# and rolls the session, since the pixels moved
+assert view.session != session
+
+# remember the session token
+session = view.session
+# a drag payload whose extent encroaches on its own picks
+ux.store.vizUpdateController(
+    viewport=0,
+    channel=channel,
+    name="amplitude",
+    configuration={"min": 0.0, "low": -0.5, "high": 0.5, "max": 2.0},
+)
+# moves the picks
+assert (amplitude.low, amplitude.high) == (-0.5, 0.5)
+# but leaves the extent alone
+assert (amplitude.min, amplitude.max) == (-2.0, 2.0)
+# and still rolls the session
+assert view.session != session
+
+# remember the session token
+session = view.session
+# a hand-set extent that accommodates the picks
+_, controller = ux.store.vizResizeController(
+    viewport=0, channel=channel, name="amplitude", min=-0.5, max=1.0
+)
+# moves only the bounds
+assert controller is amplitude
+assert (amplitude.min, amplitude.low, amplitude.high, amplitude.max) == (
+    -0.5,
+    -0.5,
+    0.5,
+    1.0,
+)
+# leaves the session token alone, since no pixels moved
+assert view.session == session
+# and pins the controller
+assert amplitude.auto is False
+
+# a hand-set extent that encroaches on the picks
+try:
+    # is refused
+    ux.store.vizResizeController(
+        viewport=0, channel=channel, name="amplitude", min=0.0, max=1.0
+    )
+# loudly
+except journal.ApplicationError:
+    # as expected
+    pass
+# otherwise
+else:
+    # something is wrong
+    assert False, "an encroaching extent was accepted"
+# and everything stays put
+assert (amplitude.min, amplitude.low, amplitude.high, amplitude.max) == (
+    -0.5,
+    -0.5,
+    0.5,
+    1.0,
+)
+assert view.session == session
+
+# a value controller behaves the same way; an extent that leaves the pick outside
+try:
+    # is refused
+    ux.store.vizResizeController(
+        viewport=0, channel=channel, name="saturation", min=0.5, max=0.6
+    )
+# loudly
+except journal.ApplicationError:
+    # as expected
+    pass
+# otherwise
+else:
+    # something is wrong
+    assert False, "an extent that excludes the pick was accepted"
+# and the controller is untouched
+assert (saturation.min, saturation.value, saturation.max) == (0.2, 0.4, 0.6)
+# while one that reaches the pick exactly is adopted
+_, controller = ux.store.vizResizeController(
+    viewport=0, channel=channel, name="saturation", min=0.4, max=1.0
+)
+assert controller is saturation
+assert (saturation.min, saturation.value, saturation.max) == (0.4, 0.4, 1.0)
+assert view.session == session
+
+# the hand edits pinned both controllers
+assert amplitude.auto is False
+assert saturation.auto is False
+# releasing one with no statistics on record flips the flag and leaves the bounds alone
+_, controller = ux.store.vizSetControllerAuto(
+    viewport=0, channel=channel, name="saturation", auto=True
+)
+assert controller is saturation
+assert saturation.auto is True
+assert (saturation.min, saturation.value, saturation.max) == (0.4, 0.4, 1.0)
+# pinning it again is just as quiet
+ux.store.vizSetControllerAuto(
+    viewport=0, channel=channel, name="saturation", auto=False
+)
+assert saturation.auto is False
+
+# seed the accumulated statistics of the dataset on display, the way rendered tiles would
+sample = qed.ux.sample()
+# with a record that reaches well past the amplitude bounds: count, low, mean, m2, high; the
+# amplitude controller works in log scale, so the record is in linear units and its top lands
+# on the decade above 4000
+sample.merge(record=(1000, 1.0, 100.0, 0.0, 4000.0))
+# and file it under the dataset
+ux.store._statistics[view.dataset.pyre_name] = sample
+# releasing the amplitude controller now catches up with the data right away
+_, controller = ux.store.vizSetControllerAuto(
+    viewport=0, channel=channel, name="amplitude", auto=True
+)
+assert controller is amplitude
+assert amplitude.auto is True
+# the top stretches to the decade above the data, in log scale
+assert amplitude.max == 4
+# the bottom already accommodates the data, so it stays put
+assert amplitude.min == -0.5
+# the picks stay put
+assert (amplitude.low, amplitude.high) == (-0.5, 0.5)
+# and so does the session token, since no pixels moved
+assert view.session == session
+
+
+# end of file

--- a/tests/qed.pkg/identity.py
+++ b/tests/qed.pkg/identity.py
@@ -71,5 +71,18 @@ assert one != tweaked
 restored = build()
 assert one == restored
 
+# the display bounds are presentation only, so moving them is the same work
+minimum = pipeline.amplitude.min
+pipeline.amplitude.min = minimum - 1.0
+reframed = build()
+pipeline.amplitude.min = minimum
+assert one == reframed
+# and so is pinning the controller, or releasing it
+auto = pipeline.amplitude.auto
+pipeline.amplitude.auto = not auto
+flipped = build()
+pipeline.amplitude.auto = auto
+assert one == flipped
+
 
 # end of file

--- a/tests/qed.pkg/resize.py
+++ b/tests/qed.pkg/resize.py
@@ -1,0 +1,114 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Check that controllers adopt hand-set display bounds only when the bounds leave the picks in
+place, and that a hand-set extent pins the controller against automatic adjustments
+"""
+
+# support
+import qed
+
+# a linear range controller with a known configuration
+linear = qed.controllers.linearRange(name="resize_linear")
+# spread out
+linear.min, linear.low, linear.high, linear.max = -10.0, -1.0, 1.0, 10.0
+# and marked clean, the way view registration does
+linear.dirty = False
+
+# an inverted extent is refused
+assert linear.resize(min=5.0, max=-5.0) is False
+# so is a degenerate one
+assert linear.resize(min=0.0, max=0.0) is False
+# an extent that encroaches on the low pick
+assert linear.resize(min=-0.5, max=10.0) is False
+# or on the high pick
+assert linear.resize(min=-10.0, max=0.5) is False
+# each refusal leaves everything alone
+assert (linear.min, linear.low, linear.high, linear.max) == (-10.0, -1.0, 1.0, 10.0)
+# including the pin and the dirty flag
+assert linear.auto is True
+assert linear.dirty is False
+
+# an extent that fits snugly around the picks is accepted
+assert linear.resize(min=-1.0, max=1.0) is True
+# the bounds move
+assert (linear.min, linear.max) == (-1.0, 1.0)
+# the picks do not
+assert (linear.low, linear.high) == (-1.0, 1.0)
+# the controller is now pinned
+assert linear.auto is False
+# and dirty, since the edit is worth persisting
+assert linear.dirty is True
+
+# once pinned, statistics can no longer stretch the bounds
+assert linear.widen(stats=(-100.0, 0.0, 100.0)) is False
+assert (linear.min, linear.max) == (-1.0, 1.0)
+# nor can a fresh sample retune it
+linear.autotune(stats=(-100.0, 0.0, 100.0))
+assert (linear.min, linear.low, linear.high, linear.max) == (-1.0, -1.0, 1.0, 1.0)
+
+# a log range controller, in log scale
+log = qed.controllers.logRange(name="resize_log")
+# with a known configuration
+log.min, log.low, log.high, log.max = -7.0, -6.0, 3.0, 4.0
+# an extent that squeezes past the high pick is refused
+assert log.resize(min=-7.0, max=2.0) is False
+assert (log.min, log.max) == (-7.0, 4.0)
+# a wider one is adopted and pins the controller
+assert log.resize(min=-8.0, max=8.0) is True
+assert (log.min, log.max) == (-8.0, 8.0)
+assert log.auto is False
+# so an escaping sample no longer moves it
+assert log.widen(stats=(1e-12, 1.0, 1e12)) is False
+assert (log.min, log.max) == (-8.0, 8.0)
+
+# a value controller
+value = qed.controllers.value(name="resize_value")
+# with a known configuration
+value.min, value.value, value.max = 0.0, 0.5, 1.0
+# an extent that leaves the pick outside is refused, from either side
+assert value.resize(min=0.6, max=1.0) is False
+assert value.resize(min=0.0, max=0.4) is False
+assert (value.min, value.value, value.max) == (0.0, 0.5, 1.0)
+# an extent that just reaches the pick is fine
+assert value.resize(min=0.5, max=2.0) is True
+assert (value.min, value.value, value.max) == (0.5, 0.5, 2.0)
+# and pins the controller
+assert value.auto is False
+
+# a pinned controller can be released
+value.unpin()
+# which lets statistics move it again
+assert value.auto is True
+# but a value controller is not scaled by the data, so statistics never stretch it
+bounds = (value.min, value.max)
+assert value.unpin(stats=(-1.0, 0.5, 3.0)) is False
+assert (value.min, value.max) == bounds
+# a pin is a pin, with or without an edit
+value.pin()
+assert value.auto is False
+
+# releasing a range controller with statistics on offer stretches the bounds right away
+assert linear.unpin(stats=(-100.0, 0.0, 100.0)) is True
+# to accommodate the data, with the usual breathing room
+assert linear.auto is True
+assert linear.min < -100.0 and linear.max > 100.0
+# without touching the picks
+assert (linear.low, linear.high) == (-1.0, 1.0)
+# and a release with nothing to catch up on leaves the bounds alone
+bounds = (linear.min, linear.max)
+assert linear.unpin() is False
+assert (linear.min, linear.max) == bounds
+
+# the checks are available without committing to a move
+assert value.accommodates(min=0.0, max=1.0) is True
+assert value.accommodates(min=0.6, max=1.0) is False
+assert value.accommodates(min=1.0, max=1.0) is False
+
+
+# end of file

--- a/tests/qed.ux.playwright/api/contract.spec.ts
+++ b/tests/qed.ux.playwright/api/contract.spec.ts
@@ -71,6 +71,51 @@ test.describe.serial("the window.qed contract", () => {
         await page.evaluate(slot => window.qed.range.reset(slot), slot)
     })
 
+    test("a range controller adopts hand-set bounds that enclose its picks and refuses ones that do not", async ({ page }) => {
+        // the amplitude channel (the setup default) carries a range controller
+        const range = (await page.evaluate(() => window.qed.controllers())).find(c => c.kind === "range")
+        test.skip(!range, "the active channel exposes no range controller")
+        const { slot, min, max } = range!
+        // park the picks well inside the extent
+        const quarter = (max - min) / 4
+        const picks = { min, low: min + quarter, high: max - quarter, max }
+        await page.evaluate(([slot, picks]) => window.qed.range.update(slot, picks), [slot, picks] as const)
+        // a wider extent is adopted
+        const wider = { min: min - quarter, max: max + quarter }
+        const adopted = await page.evaluate(
+            ([slot, bounds]) => window.qed.range.resize(slot, bounds),
+            [slot, wider] as const,
+        ) as { viewRangeResize: { controller: { min: number, max: number } } }
+        expect(adopted.viewRangeResize.controller.min).toBeCloseTo(wider.min, 3)
+        expect(adopted.viewRangeResize.controller.max).toBeCloseTo(wider.max, 3)
+        // an extent that encroaches on the low pick is refused by the server
+        const encroaching = { min: picks.low + quarter / 2, max }
+        await expect(page.evaluate(
+            ([slot, bounds]) => window.qed.range.resize(slot, bounds),
+            [slot, encroaching] as const,
+        )).rejects.toThrow()
+        // and the bounds stay where the adopted edit put them
+        const after = (await page.evaluate(() => window.qed.controllers())).find(c => c.slot === slot)!
+        expect(after.min).toBeCloseTo(wider.min, 3)
+        expect(after.max).toBeCloseTo(wider.max, 3)
+        // the hand edit pinned the controller
+        expect(after.auto).toBe(false)
+        // releasing it flips the flag in the payload
+        const released = await page.evaluate(
+            ([slot]) => window.qed.range.setAuto(slot, true),
+            [slot] as const,
+        ) as { viewRangeAutoSet: { controller: { auto: boolean, low: number, high: number } } }
+        expect(released.viewRangeAutoSet.controller.auto).toBe(true)
+        // and in the model, with the picks untouched
+        const model = (await page.evaluate(() => window.qed.controllers())).find(c => c.slot === slot)!
+        expect(model.auto).toBe(true)
+        // pinning it again flips it back
+        await page.evaluate(([slot]) => window.qed.range.setAuto(slot, false), [slot] as const)
+        expect((await page.evaluate(() => window.qed.controllers())).find(c => c.slot === slot)!.auto).toBe(false)
+        // restore
+        await page.evaluate(slot => window.qed.range.reset(slot), slot)
+    })
+
     test("a value controller round-trips its marker through the server", async ({ page }) => {
         // the phase channel carries value controllers (brightness/saturation)
         await page.evaluate(() => window.qed.setChannel("phase"))

--- a/tests/qed.ux.playwright/behavior/controller-extent.spec.ts
+++ b/tests/qed.ux.playwright/behavior/controller-extent.spec.ts
@@ -1,0 +1,110 @@
+// -*- web -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// support
+import { test, expect } from "@playwright/test"
+import type { Page } from "@playwright/test"
+
+
+// the display bounds of a colour-stretch controller are editable by hand: a double click on an
+// end label of the slider opens a text field over it that owns its contents and talks to the
+// server only on commit, so typing a number digit by digit never sends a partial value. a
+// committed extent pins the controller, and the lock button on the header releases it. the server
+// refuses an extent that encroaches on the picks; the field shows the refusal and closes on escape
+
+// the end label of {slot} that edits the {end} of its extent
+const endLabel = (page: Page, slot: string, end: "min" | "max") =>
+    page.locator(`[data-qed-control="${slot}"] [data-pyre-widget-part="bound"][data-pyre-bound="${end}"]`)
+
+test.describe.serial("a controller's display bounds are editable by hand", () => {
+    test("typing a new min commits on enter, pins the controller, and the lock releases it", async ({ page }) => {
+        await page.goto("/controls", { waitUntil: "load" })
+        await page.waitForFunction(() => Boolean(window.qed))
+
+        // the range controller of the active channel
+        const range = (await page.evaluate(() => window.qed.controllers()))
+            .find(controller => controller.kind === "range")
+        test.skip(!range, "the active channel exposes no range controller")
+        const { slot, min, max } = range!
+        const quarter = (max - min) / 4
+
+        // a double click on the low end label opens the editor over it
+        await endLabel(page, slot, "min").dblclick()
+        const field = page.getByRole("textbox", { name: `${slot} min` })
+        await field.waitFor()
+        // seeded with the server value
+        expect(Number(await field.inputValue())).toBeCloseTo(min, 3)
+
+        // type a lower bound, one keystroke at a time, and commit with enter
+        const lower = min - quarter
+        await field.fill("")
+        await field.pressSequentially(String(lower))
+        // nothing has been sent yet
+        expect((await page.evaluate(() => window.qed.controllers())).find(c => c.slot === slot)!.min).toBeCloseTo(min, 3)
+        await field.press("Enter")
+        // the model catches up with the committed value
+        await expect
+            .poll(async () => (await page.evaluate(() => window.qed.controllers())).find(c => c.slot === slot)!.min)
+            .toBeCloseTo(lower, 3)
+        // the edit pinned the controller
+        expect((await page.evaluate(() => window.qed.controllers())).find(c => c.slot === slot)!.auto).toBe(false)
+        // the editor closed on commit, and the label now shows the new bound
+        await expect(field).toHaveCount(0)
+        await expect(endLabel(page, slot, "min")).toHaveText(lower.toFixed(1))
+
+        // the lock on the header reports the pin and releases it on click
+        const lock = page.getByRole("button", { name: `${slot} auto` })
+        await expect(lock).toHaveAttribute("aria-pressed", "false")
+        await lock.click()
+        await expect
+            .poll(async () => (await page.evaluate(() => window.qed.controllers())).find(c => c.slot === slot)!.auto)
+            .toBe(true)
+        await expect(lock).toHaveAttribute("aria-pressed", "true")
+
+        // restore
+        await page.evaluate(slot => window.qed.range.reset(slot), slot)
+    })
+
+    test("an extent that encroaches on the picks is refused and escape reverts the field", async ({ page }) => {
+        await page.goto("/controls", { waitUntil: "load" })
+        await page.waitForFunction(() => Boolean(window.qed))
+
+        // the range controller of the active channel
+        const range = (await page.evaluate(() => window.qed.controllers()))
+            .find(controller => controller.kind === "range")
+        test.skip(!range, "the active channel exposes no range controller")
+        const { slot, min, max } = range!
+        // park the picks well inside the extent
+        const quarter = (max - min) / 4
+        await page.evaluate(
+            ([slot, picks]) => window.qed.range.update(slot, picks),
+            [slot, { min, low: min + quarter, high: max - quarter, max }] as const,
+        )
+
+        // a double click on the high end label opens the editor over it
+        await endLabel(page, slot, "max").dblclick()
+        const field = page.getByRole("textbox", { name: `${slot} max` })
+        await field.waitFor()
+        // an upper bound below the high pick
+        await field.fill(String(max - 2 * quarter))
+        // is flagged before it is ever sent
+        await expect(field).toHaveAttribute("aria-invalid", "true")
+        // and enter does not commit it
+        await field.press("Enter")
+        expect((await page.evaluate(() => window.qed.controllers())).find(c => c.slot === slot)!.max).toBeCloseTo(max, 3)
+        // escape gives up: the editor closes and the label still shows the server value
+        await field.press("Escape")
+        await expect(field).toHaveCount(0)
+        await expect(endLabel(page, slot, "max")).toHaveText(max.toFixed(1))
+
+        // restore
+        await page.evaluate(slot => window.qed.range.reset(slot), slot)
+    })
+})
+
+
+/* end of file */

--- a/tests/qed.ux.playwright/behavior/controller-extent.spec.ts
+++ b/tests/qed.ux.playwright/behavior/controller-extent.spec.ts
@@ -16,6 +16,10 @@ import type { Page } from "@playwright/test"
 // committed extent pins the controller, and the lock button on the header releases it. the server
 // refuses an extent that encroaches on the picks; the field shows the refusal and closes on escape
 
+// the marker label of {slot} that edits the pick named {name}
+const pickLabel = (page: Page, slot: string, name: string) =>
+    page.locator(`[data-qed-control="${slot}"] [data-pyre-widget-part="pick"][data-pyre-pick="${name}"]`)
+
 // the end label of {slot} that edits the {end} of its extent
 const endLabel = (page: Page, slot: string, end: "min" | "max") =>
     page.locator(`[data-qed-control="${slot}"] [data-pyre-widget-part="bound"][data-pyre-bound="${end}"]`)
@@ -103,6 +107,59 @@ test.describe.serial("a controller's display bounds are editable by hand", () =>
 
         // restore
         await page.evaluate(slot => window.qed.range.reset(slot), slot)
+    })
+
+    test("typing a pick into a marker label reaches the server without pinning the controller", async ({ page, context }) => {
+        const driver = page
+        const observer = await context.newPage()
+        for (const client of [driver, observer]) {
+            await client.goto("/controls", { waitUntil: "load" })
+            await client.waitForFunction(() => Boolean(window.qed))
+        }
+
+        // the range controller of the active channel
+        const range = (await driver.evaluate(() => window.qed.controllers()))
+            .find(controller => controller.kind === "range")
+        test.skip(!range, "the active channel exposes no range controller")
+        const { slot, min, max, auto } = range!
+        const quarter = (max - min) / 4
+        // park the picks at known places
+        await driver.evaluate(
+            ([slot, picks]) => window.qed.range.update(slot, picks),
+            [slot, { min, low: min + quarter, high: max - quarter, max }] as const,
+        )
+
+        // a double click on the low marker label opens the editor over it
+        await pickLabel(driver, slot, `${slot} low`).dblclick()
+        const field = driver.getByRole("textbox", { name: `${slot} low value` })
+        await field.waitFor()
+        // seeded with the pick
+        expect(Number(await field.inputValue())).toBeCloseTo(min + quarter, 3)
+        // a pick below the lower limit is flagged before it is sent
+        await field.fill(String(min - quarter))
+        await expect(field).toHaveAttribute("aria-invalid", "true")
+        // a pick inside the limits is not
+        const low = min + quarter / 2
+        await field.fill(String(low))
+        await expect(field).toHaveAttribute("aria-invalid", "false")
+        // commit
+        await field.press("Enter")
+        await expect(field).toHaveCount(0)
+        // the driver's thumb moves
+        await expect.poll(async () =>
+            Number(await driver.getByRole("slider", { name: `${slot} low` }).getAttribute("aria-valuenow"))
+        ).toBeCloseTo(low, 3)
+        // and so does the observer's, which proves the pick reached the server
+        await expect.poll(async () =>
+            Number(await observer.getByRole("slider", { name: `${slot} low` }).getAttribute("aria-valuenow")),
+            { timeout: 15_000 },
+        ).toBeCloseTo(low, 3)
+        // a typed pick is not a hand edit of the bounds, so the flag is untouched
+        expect((await driver.evaluate(() => window.qed.controllers())).find(c => c.slot === slot)!.auto).toBe(auto)
+
+        // restore
+        await driver.evaluate(slot => window.qed.range.reset(slot), slot)
+        await observer.close()
     })
 })
 

--- a/ux/client/automation/qed.js
+++ b/ux/client/automation/qed.js
@@ -22,6 +22,10 @@ import { useUpdateRangeControllerMutation as updateRangeControllerMutation } fro
 import { useResetRangeControllerMutation as resetRangeControllerMutation } from '~/views/viz/controls/viz/useResetRangeController'
 import { useUpdateValueControllerMutation as updateValueControllerMutation } from '~/views/viz/controls/viz/useUpdateValueController'
 import { useResetValueControllerMutation as resetValueControllerMutation } from '~/views/viz/controls/viz/useResetValueController'
+import { useResizeRangeControllerMutation as resizeRangeControllerMutation } from '~/views/viz/controls/viz/useResizeRangeController'
+import { useResizeValueControllerMutation as resizeValueControllerMutation } from '~/views/viz/controls/viz/useResizeValueController'
+import { useAutoRangeControllerMutation as autoRangeControllerMutation } from '~/views/viz/controls/viz/useAutoRangeController'
+import { useAutoValueControllerMutation as autoValueControllerMutation } from '~/views/viz/controls/viz/useAutoValueController'
 import { useAnchorAddMutation as anchorAddMutation } from '~/views/viz/measure/useAnchorAdd'
 import { useAnchorPlaceMutation as anchorPlaceMutation } from '~/views/viz/measure/useAnchorPlace'
 import { useAnchorSplitMutation as anchorSplitMutation } from '~/views/viz/measure/useAnchorSplit'
@@ -105,7 +109,7 @@ const readersQuery = graphql`
 const controllersQuery = graphql`
     query qedControllersQuery {
         qed {
-            views { channel { controllers { __typename slot min max } } }
+            views { channel { controllers { __typename slot auto min max } } }
         }
     }
 `
@@ -172,12 +176,13 @@ export const makeQED = () => ({
     },
 
     // the colour-stretch controllers on {viewport}'s channel: each one's kind (range|value), slot,
-    // and bounds, so a driver picks one by kind and feeds it to {range}/{value}
+    // whether it follows the data statistics ({auto}) or is pinned, and bounds, so a driver picks
+    // one by kind and feeds it to {range}/{value}
     controllers: async (viewport = getActiveViewport()) => {
         const { qed } = await read(controllersQuery)
         return (qed.views[viewport]?.channel?.controllers ?? []).map(controller => ({
             kind: controller.__typename.replace(/Controller$/, "").toLowerCase(),
-            slot: controller.slot, min: controller.min, max: controller.max,
+            slot: controller.slot, auto: controller.auto, min: controller.min, max: controller.max,
         }))
     },
 
@@ -305,6 +310,16 @@ export const makeQED = () => ({
         reset: async (controller, channel, viewport = getActiveViewport()) =>
             command(resetRangeControllerMutation,
                 { viewport, channel: channel ?? await channelOf(viewport), controller }),
+        // set the display bounds {min,max} by hand; they must leave {low,high} in place, so the
+        // pixels never change, and the edit pins the controller against statistics
+        resize: async (controller, { min, max }, channel, viewport = getActiveViewport()) =>
+            command(resizeRangeControllerMutation,
+                { viewport, channel: channel ?? await channelOf(viewport), controller, min, max }),
+        // pin the controller ({auto} false) or release it to follow the data statistics ({auto}
+        // true); a released controller stretches its bounds to the statistics accumulated so far
+        setAuto: async (controller, auto, channel, viewport = getActiveViewport()) =>
+            command(autoRangeControllerMutation,
+                { viewport, channel: channel ?? await channelOf(viewport), controller, auto }),
     },
 
     // the colour-stretch value controller of a {channel}; the bounds are {min,value,max}
@@ -315,6 +330,16 @@ export const makeQED = () => ({
         reset: async (controller, channel, viewport = getActiveViewport()) =>
             command(resetValueControllerMutation,
                 { viewport, channel: channel ?? await channelOf(viewport), controller }),
+        // set the display bounds {min,max} by hand; they must leave {value} in place, so the
+        // pixels never change, and the edit pins the controller against statistics
+        resize: async (controller, { min, max }, channel, viewport = getActiveViewport()) =>
+            command(resizeValueControllerMutation,
+                { viewport, channel: channel ?? await channelOf(viewport), controller, min, max }),
+        // pin the controller ({auto} false) or release it to follow the data statistics ({auto}
+        // true); a released controller stretches its bounds to the statistics accumulated so far
+        setAuto: async (controller, auto, channel, viewport = getActiveViewport()) =>
+            command(autoValueControllerMutation,
+                { viewport, channel: channel ?? await channelOf(viewport), controller, auto }),
     },
 })
 

--- a/ux/client/shapes/locked/index.js
+++ b/ux/client/shapes/locked/index.js
@@ -6,24 +6,32 @@
 
 // externals
 import React from 'react'
+
 // locals
 import styles from './styles'
 
 
-// the eye lid
-const locked = `
-M 150 500 L 150 900 L 850 900 L 850 500 Z
-M 250 500 A 250 400 0 0 1 750 500
+// a closed padlock; the geometry follows the locked icon of the feather set (MIT), drawn at 80% of the box
+// the rounded body
+const body = `
+M 266.7 466.7 L 733.3 466.7 Q 800.0 466.7 800.0 533.3 L 800.0 766.7 Q 800.0 833.3 733.3 833.3 L 266.7 833.3 Q 200.0 833.3 200.0 766.7 L 200.0 533.3 Q 200.0 466.7 266.7 466.7 Z
+`
+// the shackle
+const shackle = `
+M 333.3 466.7 L 333.3 333.3 A 166.7 166.7 0 0 1 666.7 333.3 L 666.7 466.7
 `
 
-// render the shape
+
 export const Locked = ({ style }) => {
     // mix my paint
     const ico = { ...styles.icon, ...style?.icon }
 
     // paint me
     return (
-        <path style={ico} d={locked} />
+        <g>
+            <path style={ico} d={body} />
+            <path style={ico} d={shackle} />
+        </g>
     )
 }
 

--- a/ux/client/shapes/locked/styles.js
+++ b/ux/client/shapes/locked/styles.js
@@ -23,6 +23,8 @@ export default {
         // stroke
         stroke: ink,
         strokeWidth: 1,
+        strokeLinecap: "round",
+        strokeLinejoin: "round",
         // fill
         fill: "none",
     },

--- a/ux/client/shapes/unlocked/index.js
+++ b/ux/client/shapes/unlocked/index.js
@@ -6,24 +6,32 @@
 
 // externals
 import React from 'react'
+
 // locals
 import styles from './styles'
 
 
-// the eye lid
-const unlocked = `
-M 150 500 L 150 900 L 850 900 L 850 500 Z
-M 450 500 A 250 400 0 0 1 950 500
+// an open padlock; the geometry follows the unlocked icon of the feather set (MIT), drawn at 80% of the box
+// the rounded body
+const body = `
+M 266.7 466.7 L 733.3 466.7 Q 800.0 466.7 800.0 533.3 L 800.0 766.7 Q 800.0 833.3 733.3 833.3 L 266.7 833.3 Q 200.0 833.3 200.0 766.7 L 200.0 533.3 Q 200.0 466.7 266.7 466.7 Z
+`
+// the shackle
+const shackle = `
+M 333.3 466.7 L 333.3 333.3 A 166.7 166.7 0 0 1 663.3 300.0
 `
 
-// render the shape
+
 export const Unlocked = ({ style }) => {
     // mix my paint
     const ico = { ...styles.icon, ...style?.icon }
 
     // paint me
     return (
-        <path style={ico} d={unlocked} />
+        <g>
+            <path style={ico} d={body} />
+            <path style={ico} d={shackle} />
+        </g>
     )
 }
 

--- a/ux/client/shapes/unlocked/styles.js
+++ b/ux/client/shapes/unlocked/styles.js
@@ -23,6 +23,8 @@ export default {
         // stroke
         stroke: ink,
         strokeWidth: 1,
+        strokeLinecap: "round",
+        strokeLinejoin: "round",
         // fill
         fill: "none",
     },

--- a/ux/client/views/viz/controls/viz/auto.js
+++ b/ux/client/views/viz/controls/viz/auto.js
@@ -1,0 +1,56 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// externals
+import React from 'react'
+
+// project
+// shapes
+import { Locked, Unlocked } from '~/shapes'
+// widgets
+import { Badge } from '~/widgets'
+
+// styles
+import styles from './styles'
+
+
+// pin a controller, or release it to follow the data statistics
+export const Auto = ({ slot, auto, setAuto }) => {
+    // build the handler
+    const click = evt => {
+        // stop this event from bubbling up
+        evt.stopPropagation()
+        // and quash any side effects
+        evt.preventDefault()
+        // flip the flag
+        setAuto(!auto)
+        // all done
+        return
+    }
+    // assemble the controllers to hand my {badge}
+    const behaviors = {
+        onClick: click,
+    }
+
+    // a released controller shows an open lock; a pinned one, a closed lock
+    const Icon = auto ? Unlocked : Locked
+    // the tooltip says what a click does
+    const title = auto ? "pin the bounds where they are" : "release the bounds to follow the data"
+
+    // mix my paint
+    const paint = styles.auto
+    // and render; the badge is a toggle whose pressed state is the flag
+    return (
+        <Badge size={24} state="enabled" behaviors={behaviors} style={paint}
+            title={title} aria-label={`${slot} auto`} aria-pressed={auto}
+        >
+            <Icon />
+        </Badge>
+    )
+}
+
+
+// end of file

--- a/ux/client/views/viz/controls/viz/range.js
+++ b/ux/client/views/viz/controls/viz/range.js
@@ -44,6 +44,9 @@ export const RangeController = ({ channel, configuration }) => {
     // true while the user is dragging THIS control; server updates are throttled, so the store
     // trails the pointer and we must not let an in-flight echo of our own edit yank the thumb back
     const interacting = React.useRef(false)
+    // true while a pointer button is down anywhere; only then is an update a drag, as opposed to
+    // a pick typed into the slider, which is a single deliberate commit
+    const pressed = React.useRef(false)
 
     // adopt server-side values that arrive while we are not dragging: a reset, or -- the point of
     // live sync -- a change another client made that the server pushed to us over the event stream
@@ -66,10 +69,13 @@ export const RangeController = ({ channel, configuration }) => {
     // a drag ends when the pointer is released anywhere; clear the flag so the next server value
     // is reconciled. listen in the capture phase so a child that stops propagation cannot hide it
     React.useEffect(() => {
-        const release = () => { interacting.current = false }
+        const press = () => { pressed.current = true }
+        const release = () => { pressed.current = false; interacting.current = false }
+        window.addEventListener("pointerdown", press, true)
         window.addEventListener("pointerup", release, true)
         window.addEventListener("pointercancel", release, true)
         return () => {
+            window.removeEventListener("pointerdown", press, true)
             window.removeEventListener("pointerup", release, true)
             window.removeEventListener("pointercancel", release, true)
         }
@@ -89,8 +95,9 @@ export const RangeController = ({ channel, configuration }) => {
     // and passes it as an argument a function that expects the current range and returns
     // the updated value
     const set = callback => {
-        // we are driving this control; suppress server reconciliation until the drag ends
-        interacting.current = true
+        // if a pointer is driving this control, suppress server reconciliation until the drag
+        // ends; a typed pick has no drag to protect, so the server's echo is welcome right away
+        interacting.current = pressed.current
         // get the updated values
         const [newLow, newHigh] = callback([range.low, range.high])
         // make a new range
@@ -146,6 +153,8 @@ export const RangeController = ({ channel, configuration }) => {
             envelope: [range.low, range.high],
             resize: setExtentByHand,
         },
+        // the marker labels edit the picks on a double click
+        editable: true,
         direction: "row", labels: "bottom", arrows: "top", markers: true,
         height: 100, width: 250,
     }

--- a/ux/client/views/viz/controls/viz/range.js
+++ b/ux/client/views/viz/controls/viz/range.js
@@ -20,7 +20,10 @@ import { theme } from "~/palette"
 import { useViewports } from '~/views/viz'
 import { useResetRangeController } from './useResetRangeController'
 import { useUpdateRangeController } from './useUpdateRangeController'
+import { useResizeRangeController } from './useResizeRangeController'
+import { useAutoRangeController } from './useAutoRangeController'
 // components
+import { Auto } from './auto'
 import { Reset } from './reset'
 import { Save } from './save'
 
@@ -29,7 +32,7 @@ import { Save } from './save'
 export const RangeController = ({ channel, configuration }) => {
     // unpack the controller configuration
     const {
-        slot, dirty, min, low, high, max,
+        slot, dirty, auto, min, low, high, max,
     } = useFragment(rangeVizGetControllerStateFragment, configuration)
     // get the active viewport
     const { activeViewport } = useViewports()
@@ -76,6 +79,10 @@ export const RangeController = ({ channel, configuration }) => {
     const { reset: defaults } = useResetRangeController({ viewport: activeViewport, channel })
     // build the update handler
     const { update } = useUpdateRangeController({ viewport: activeViewport, channel })
+    // build the resize handler, for hand edits of the display bounds
+    const { resize } = useResizeRangeController({ viewport: activeViewport, channel })
+    // and the pin/release handler
+    const { setAuto } = useAutoRangeController({ viewport: activeViewport, channel })
 
     // the handler that sets the controller state
     // this is built in the style of {react} state updates: the controller invokes this
@@ -106,6 +113,21 @@ export const RangeController = ({ channel, configuration }) => {
     const save = () => {
         console.log(`viz.range: saving`)
     }
+    // the handler that sets the display bounds by hand; the server refuses an extent that
+    // encroaches on the picks, so the field simply snaps back to the bounds on record
+    const setExtentByHand = bounds => {
+        // send it
+        resize({ controller: slot, extent: bounds })
+        // all done
+        return
+    }
+    // the handler that pins the controller or releases it to follow the data
+    const setAutoFlag = flag => {
+        // send it
+        setAuto({ controller: slot, auto: flag })
+        // all done
+        return
+    }
 
     // set up the tick marks
     const major = [min, (max + min) / 2, max]
@@ -117,6 +139,13 @@ export const RangeController = ({ channel, configuration }) => {
         // by assistive tech and drivers alike
         names: [`${slot} low`, `${slot} high`],
         min, max, major,
+        // the end labels edit the extent on a double click; the bounds may never encroach on
+        // the picks, and an accepted extent goes to the server
+        extent: {
+            names: [`${slot} min`, `${slot} max`],
+            envelope: [range.low, range.high],
+            resize: setExtentByHand,
+        },
         direction: "row", labels: "bottom", arrows: "top", markers: true,
         height: 100, width: 250,
     }
@@ -127,6 +156,7 @@ export const RangeController = ({ channel, configuration }) => {
             <Header>
                 <Title>{slot}</Title>
                 <Spacer />
+                <Auto slot={slot} auto={auto} setAuto={setAutoFlag} />
                 <Save save={save} enabled={false} />
                 <Reset reset={reset} enabled={dirty} />
             </Header>
@@ -174,6 +204,7 @@ const rangeVizGetControllerStateFragment = graphql`
     fragment rangeVizGetControllerStateFragment on Controller {
         slot
         dirty
+        auto
         min
         max
         ... on RangeController {

--- a/ux/client/views/viz/controls/viz/styles.js
+++ b/ux/client/views/viz/controls/viz/styles.js
@@ -189,8 +189,11 @@ const save = {
 
 
 // publish
+// the pin/release toggle looks like the reset button
+const auto = reset
+
 export default {
-    reset, save,
+    reset, save, auto,
 }
 
 

--- a/ux/client/views/viz/controls/viz/useAutoRangeController.js
+++ b/ux/client/views/viz/controls/viz/useAutoRangeController.js
@@ -1,0 +1,69 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// externals
+import { graphql, useMutation } from 'react-relay/hooks'
+
+
+// pin a range controller, or release it to follow the data statistics
+export const useAutoRangeController = ({ viewport, channel }) => {
+    // flipping the flag mutates the server side store
+    const [commit, pending] = useMutation(useAutoRangeControllerMutation)
+
+    // make the handler
+    const setAuto = ({ controller, auto }) => {
+        // if there is a pending operation
+        if (pending) {
+            // nothing to do
+            return
+        }
+        // otherwise, send the mutation to the server; the payload carries the adjusted bounds,
+        // which the relay store folds into the controller fragment
+        commit({
+            // the payload
+            variables: {
+                input: { viewport, channel, controller, auto },
+            },
+            // on failure, report
+            onError: errors => {
+                // show me
+                console.log(`viz.controls.viz.useAutoRangeController:`)
+                console.group()
+                console.log(`viewport ${viewport}:`)
+                console.log(`ERROR while setting the auto flag of ${controller}`)
+                console.log(`for channel ${channel}`)
+                console.log(errors)
+                console.groupEnd()
+            },
+        })
+        // all done
+        return
+    }
+
+    // all done
+    return { setAuto }
+}
+
+
+// the mutation that sets the auto flag
+export const useAutoRangeControllerMutation = graphql`
+mutation useAutoRangeControllerMutation($input: ViewRangeAutoSetInput!) {
+    viewRangeAutoSet(input: $input) {
+        view {
+            session
+        }
+        controller {
+            id
+            dirty
+            auto
+            min
+            max
+        }
+    }
+}`
+
+
+// end of file

--- a/ux/client/views/viz/controls/viz/useAutoValueController.js
+++ b/ux/client/views/viz/controls/viz/useAutoValueController.js
@@ -1,0 +1,69 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// externals
+import { graphql, useMutation } from 'react-relay/hooks'
+
+
+// pin a value controller, or release it to follow the data statistics
+export const useAutoValueController = ({ viewport, channel }) => {
+    // flipping the flag mutates the server side store
+    const [commit, pending] = useMutation(useAutoValueControllerMutation)
+
+    // make the handler
+    const setAuto = ({ controller, auto }) => {
+        // if there is a pending operation
+        if (pending) {
+            // nothing to do
+            return
+        }
+        // otherwise, send the mutation to the server; the payload carries the adjusted bounds,
+        // which the relay store folds into the controller fragment
+        commit({
+            // the payload
+            variables: {
+                input: { viewport, channel, controller, auto },
+            },
+            // on failure, report
+            onError: errors => {
+                // show me
+                console.log(`viz.controls.viz.useAutoValueController:`)
+                console.group()
+                console.log(`viewport ${viewport}:`)
+                console.log(`ERROR while setting the auto flag of ${controller}`)
+                console.log(`for channel ${channel}`)
+                console.log(errors)
+                console.groupEnd()
+            },
+        })
+        // all done
+        return
+    }
+
+    // all done
+    return { setAuto }
+}
+
+
+// the mutation that sets the auto flag
+export const useAutoValueControllerMutation = graphql`
+mutation useAutoValueControllerMutation($input: ViewValueAutoSetInput!) {
+    viewValueAutoSet(input: $input) {
+        view {
+            session
+        }
+        controller {
+            id
+            dirty
+            auto
+            min
+            max
+        }
+    }
+}`
+
+
+// end of file

--- a/ux/client/views/viz/controls/viz/useResetRangeController.js
+++ b/ux/client/views/viz/controls/viz/useResetRangeController.js
@@ -73,6 +73,7 @@ mutation useResetRangeControllerMutation($input: ViewRangeResetInput!) {
         controller {
             id
             dirty
+            auto
             min
             low
             high

--- a/ux/client/views/viz/controls/viz/useResetValueController.js
+++ b/ux/client/views/viz/controls/viz/useResetValueController.js
@@ -73,6 +73,7 @@ mutation useResetValueControllerMutation($input: ViewValueResetInput!) {
         controller {
             id
             dirty
+            auto
             min
             value
             max

--- a/ux/client/views/viz/controls/viz/useResizeRangeController.js
+++ b/ux/client/views/viz/controls/viz/useResizeRangeController.js
@@ -1,0 +1,68 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// externals
+import { graphql, useMutation } from 'react-relay/hooks'
+
+
+// send hand-set display bounds of a range controller to the server side store
+export const useResizeRangeController = ({ viewport, channel }) => {
+    // resizing the controller mutates the server side store
+    const [commit] = useMutation(useResizeRangeControllerMutation)
+
+    // a hand edit is a single deliberate commit, not a drag storm, so there is nothing to coalesce;
+    // the server refuses an extent that encroaches on the picks, and the refusal lands in {onError}
+    const resize = ({ controller, extent, onError = null }) => {
+        // commit the mutation
+        commit({
+            // the payload
+            variables: {
+                input: { viewport, channel, controller, ...extent },
+            },
+            // on failure, report and let the caller cope
+            onError: errors => {
+                // show me
+                console.log(`viz.controls.viz.useResizeRangeController:`)
+                console.group()
+                console.log(`viewport ${viewport}:`)
+                console.log(`ERROR while resizing ${controller}`)
+                console.log(`for channel ${channel}`)
+                console.log(errors)
+                console.groupEnd()
+                // let the caller know
+                if (onError) {
+                    onError(errors)
+                }
+            },
+        })
+        // all done
+        return
+    }
+
+    // all done
+    return { resize }
+}
+
+
+// the mutation that sets the controller display bounds
+export const useResizeRangeControllerMutation = graphql`
+mutation useResizeRangeControllerMutation($input: ViewRangeResizeInput!) {
+    viewRangeResize(input: $input) {
+        view {
+            session
+        }
+        controller {
+            id
+            dirty
+            auto
+            min
+            max
+        }
+    }
+}`
+
+
+// end of file

--- a/ux/client/views/viz/controls/viz/useResizeValueController.js
+++ b/ux/client/views/viz/controls/viz/useResizeValueController.js
@@ -1,0 +1,68 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// externals
+import { graphql, useMutation } from 'react-relay/hooks'
+
+
+// send hand-set display bounds of a value controller to the server side store
+export const useResizeValueController = ({ viewport, channel }) => {
+    // resizing the controller mutates the server side store
+    const [commit] = useMutation(useResizeValueControllerMutation)
+
+    // a hand edit is a single deliberate commit, not a drag storm, so there is nothing to coalesce;
+    // the server refuses an extent that encroaches on the picks, and the refusal lands in {onError}
+    const resize = ({ controller, extent, onError = null }) => {
+        // commit the mutation
+        commit({
+            // the payload
+            variables: {
+                input: { viewport, channel, controller, ...extent },
+            },
+            // on failure, report and let the caller cope
+            onError: errors => {
+                // show me
+                console.log(`viz.controls.viz.useResizeValueController:`)
+                console.group()
+                console.log(`viewport ${viewport}:`)
+                console.log(`ERROR while resizing ${controller}`)
+                console.log(`for channel ${channel}`)
+                console.log(errors)
+                console.groupEnd()
+                // let the caller know
+                if (onError) {
+                    onError(errors)
+                }
+            },
+        })
+        // all done
+        return
+    }
+
+    // all done
+    return { resize }
+}
+
+
+// the mutation that sets the controller display bounds
+export const useResizeValueControllerMutation = graphql`
+mutation useResizeValueControllerMutation($input: ViewValueResizeInput!) {
+    viewValueResize(input: $input) {
+        view {
+            session
+        }
+        controller {
+            id
+            dirty
+            auto
+            min
+            max
+        }
+    }
+}`
+
+
+// end of file

--- a/ux/client/views/viz/controls/viz/useUpdateRangeController.js
+++ b/ux/client/views/viz/controls/viz/useUpdateRangeController.js
@@ -93,6 +93,7 @@ mutation useUpdateRangeControllerMutation($input: ViewRangeUpdateInput!) {
         controller {
             id
             dirty
+            auto
             min
             low
             high

--- a/ux/client/views/viz/controls/viz/useUpdateValueController.js
+++ b/ux/client/views/viz/controls/viz/useUpdateValueController.js
@@ -93,6 +93,7 @@ mutation useUpdateValueControllerMutation($input: ViewValueUpdateInput!) {
         controller {
             id
             dirty
+            auto
             min
             value
             max

--- a/ux/client/views/viz/controls/viz/value.js
+++ b/ux/client/views/viz/controls/viz/value.js
@@ -20,7 +20,10 @@ import { theme } from "~/palette"
 import { useViewports } from '~/views/viz'
 import { useResetValueController } from './useResetValueController'
 import { useUpdateValueController } from './useUpdateValueController'
+import { useResizeValueController } from './useResizeValueController'
+import { useAutoValueController } from './useAutoValueController'
 // components
+import { Auto } from './auto'
 import { Reset } from './reset'
 import { Save } from './save'
 
@@ -29,7 +32,7 @@ import { Save } from './save'
 export const ValueController = ({ channel, configuration }) => {
     // unpack the controller configuration
     const {
-        slot, dirty, min, value, max,
+        slot, dirty, auto, min, value, max,
     } = useFragment(valueVizGetControllerStateFragment, configuration)
     // get the active viewport
     const { activeViewport } = useViewports()
@@ -76,6 +79,10 @@ export const ValueController = ({ channel, configuration }) => {
     const { reset: defaults } = useResetValueController({ viewport: activeViewport, channel })
     // build the update handler
     const { update } = useUpdateValueController({ viewport: activeViewport, channel })
+    // build the resize handler, for hand edits of the display bounds
+    const { resize } = useResizeValueController({ viewport: activeViewport, channel })
+    // and the pin/release handler
+    const { setAuto } = useAutoValueController({ viewport: activeViewport, channel })
 
     // the handler that sets the controller state
     // this is built in the style of {react} state updates: the controller invokes this
@@ -102,6 +109,21 @@ export const ValueController = ({ channel, configuration }) => {
     const save = () => {
         console.log(`viz.value: saving`)
     }
+    // the handler that sets the display bounds by hand; the server refuses an extent that
+    // encroaches on the picks, so the field simply snaps back to the bounds on record
+    const setExtentByHand = bounds => {
+        // send it
+        resize({ controller: slot, extent: bounds })
+        // all done
+        return
+    }
+    // the handler that pins the controller or releases it to follow the data
+    const setAutoFlag = flag => {
+        // send it
+        setAuto({ controller: slot, auto: flag })
+        // all done
+        return
+    }
 
     // set up the tick marks
     const major = [min, (min + max) / 2, max]
@@ -112,6 +134,13 @@ export const ValueController = ({ channel, configuration }) => {
         // name the single thumb after the server controller {slot}, so it is uniquely addressable
         label: slot,
         min, max, major,
+        // the end labels edit the extent on a double click; the bounds may never encroach on
+        // the picks, and an accepted extent goes to the server
+        extent: {
+            names: [`${slot} min`, `${slot} max`],
+            envelope: [marker, marker],
+            resize: setExtentByHand,
+        },
         direction: "row", labels: "bottom", arrows: "top", markers: true,
         height: 100, width: 250,
     }
@@ -122,6 +151,7 @@ export const ValueController = ({ channel, configuration }) => {
             <Header>
                 <Title>{slot}</Title>
                 <Spacer />
+                <Auto slot={slot} auto={auto} setAuto={setAutoFlag} />
                 <Save save={save} enabled={false} />
                 <Reset reset={reset} enabled={dirty} />
             </Header>
@@ -169,6 +199,7 @@ const valueVizGetControllerStateFragment = graphql`
     fragment valueVizGetControllerStateFragment on Controller {
         slot
         dirty
+        auto
         min
         max
         ... on ValueController {

--- a/ux/client/views/viz/controls/viz/value.js
+++ b/ux/client/views/viz/controls/viz/value.js
@@ -44,6 +44,9 @@ export const ValueController = ({ channel, configuration }) => {
     // true while the user is dragging THIS control; server updates are throttled, so the store
     // trails the pointer and we must not let an in-flight echo of our own edit yank the marker back
     const interacting = React.useRef(false)
+    // true while a pointer button is down anywhere; only then is an update a drag, as opposed to
+    // a pick typed into the slider, which is a single deliberate commit
+    const pressed = React.useRef(false)
 
     // adopt server-side values that arrive while we are not dragging: a reset, or -- the point of
     // live sync -- a change another client made that the server pushed to us over the event stream
@@ -66,10 +69,13 @@ export const ValueController = ({ channel, configuration }) => {
     // a drag ends when the pointer is released anywhere; clear the flag so the next server value
     // is reconciled. listen in the capture phase so a child that stops propagation cannot hide it
     React.useEffect(() => {
-        const release = () => { interacting.current = false }
+        const press = () => { pressed.current = true }
+        const release = () => { pressed.current = false; interacting.current = false }
+        window.addEventListener("pointerdown", press, true)
         window.addEventListener("pointerup", release, true)
         window.addEventListener("pointercancel", release, true)
         return () => {
+            window.removeEventListener("pointerdown", press, true)
             window.removeEventListener("pointerup", release, true)
             window.removeEventListener("pointercancel", release, true)
         }
@@ -89,8 +95,9 @@ export const ValueController = ({ channel, configuration }) => {
     // and passes it as an argument a function that expects the current value and returns
     // the updated value
     const set = value => {
-        // we are driving this control; suppress server reconciliation until the drag ends
-        interacting.current = true
+        // if a pointer is driving this control, suppress server reconciliation until the drag
+        // ends; a typed pick has no drag to protect, so the server's echo is welcome right away
+        interacting.current = pressed.current
         // store it
         setMarker(value)
         // attempt to update the server side store
@@ -141,6 +148,8 @@ export const ValueController = ({ channel, configuration }) => {
             envelope: [marker, marker],
             resize: setExtentByHand,
         },
+        // the marker labels edit the picks on a double click
+        editable: true,
         direction: "row", labels: "bottom", arrows: "top", markers: true,
         height: 100, width: 250,
     }

--- a/ux/client/widgets/slider/context.js
+++ b/ux/client/widgets/slider/context.js
@@ -33,6 +33,8 @@ export const Provider = ({ config, children }) => {
     // {envelope} of the picks that the extent may never encroach on, and the {resize} callback
     // that receives an accepted {min, max}
     const { extent = null } = config
+    // whether the marker labels edit the picks on a double click
+    const { editable = false } = config
 
     // my unit cell, in intrinsic coordinates
     const cell = 10
@@ -213,6 +215,8 @@ export const Provider = ({ config, children }) => {
         tickPrecision, markerPrecision,
         // the hand-editable extent, if any
         extent,
+        // whether the picks are hand-editable
+        editable,
 
         // my unit cell
         cell,
@@ -276,6 +280,8 @@ export const Context = React.createContext(
         tickPrecision: null, markerPrecision: null,
         // the hand-editable extent
         extent: null,
+        // whether the picks are hand-editable
+        editable: null,
 
         // my unit cell
         cell: null,

--- a/ux/client/widgets/slider/context.js
+++ b/ux/client/widgets/slider/context.js
@@ -29,6 +29,10 @@ export const Provider = ({ config, children }) => {
     const { min, max, major = [], minor = [] } = config
     // the label display precision
     const { tickPrecision = 1, markerPrecision = 1 } = config
+    // the optional hand-editable extent: accessible {names} for the two end labels, the
+    // {envelope} of the picks that the extent may never encroach on, and the {resize} callback
+    // that receives an accepted {min, max}
+    const { extent = null } = config
 
     // my unit cell, in intrinsic coordinates
     const cell = 10
@@ -207,6 +211,8 @@ export const Provider = ({ config, children }) => {
         min, max, major, minor,
         // the display precision of labels
         tickPrecision, markerPrecision,
+        // the hand-editable extent, if any
+        extent,
 
         // my unit cell
         cell,
@@ -268,6 +274,8 @@ export const Context = React.createContext(
         min: null, max: null, major: null, minor: null,
         // the display precision of labels
         tickPrecision: null, markerPrecision: null,
+        // the hand-editable extent
+        extent: null,
 
         // my unit cell
         cell: null,

--- a/ux/client/widgets/slider/editor.js
+++ b/ux/client/widgets/slider/editor.js
@@ -1,0 +1,191 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// externals
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+// project
+// colors
+import { theme } from "~/palette"
+
+
+// a text field that takes the place of an end label while its value is being edited by hand; it
+// is portalled to the document body and pinned over {rect}, the label's rectangle on the screen,
+// so it sits on top of the label regardless of how the slider is transformed. it owns its
+// contents and talks to nobody until the user commits with {Enter} or by leaving the field;
+// {Escape} gives up, and the arrow keys step the bound, committing at once since each step is a
+// complete number; either way, {close} takes the field down when it is done
+export const Editor = ({ name, end, value, step, check, commit, rect, fontSize, close }) => {
+    // the text under edit, seeded with the value on record
+    const [text, setText] = React.useState(format(value))
+    // what the text means, if anything
+    const trimmed = text.trim()
+    const parsed = trimmed === "" ? NaN : Number(trimmed)
+    // whether the contents can be committed
+    const valid = Number.isFinite(parsed) && check(parsed)
+    // a handle on the field, for the initial focus
+    const field = React.useRef(null)
+
+    // send the text to the server, if it is acceptable, and report whether it went
+    const apply = () => {
+        // refuse anything that cannot be committed
+        if (!valid) {
+            // and say so
+            return false
+        }
+        // a value that differs from the one on record goes out
+        if (parsed !== value) {
+            // send it
+            commit(parsed)
+        }
+        // and report success
+        return true
+    }
+    // nudge the bound by {direction} steps, committing at once
+    const nudge = direction => {
+        // start from the text under edit, when it means something, else from the value on record
+        const base = Number.isFinite(parsed) ? parsed : value
+        // form the candidate, rounded to the step to keep the digits tidy
+        const candidate = Math.round((base + direction * step) / step) * step
+        // refuse a candidate that encroaches on the picks
+        if (!check(candidate)) {
+            // by leaving things alone
+            return
+        }
+        // send it
+        commit(candidate)
+        // and show it
+        setText(format(candidate))
+        // all done
+        return
+    }
+
+    // take the focus and select the contents as soon as the field appears, so typing replaces them
+    React.useEffect(() => {
+        // get the field
+        const input = field.current
+        // if it is there
+        if (input) {
+            // focus and select
+            input.focus()
+            input.select()
+        }
+        // all done
+        return
+    }, [])
+    // the field is pinned to a spot on the screen, so a scroll or a resize would leave it
+    // floating over the wrong place; give up instead
+    React.useEffect(() => {
+        // install
+        window.addEventListener("scroll", close, true)
+        window.addEventListener("resize", close)
+        // and clean up
+        return () => {
+            window.removeEventListener("scroll", close, true)
+            window.removeEventListener("resize", close)
+        }
+    }, [close])
+
+    // leaving the field commits when possible; either way, the editor goes away
+    const blur = () => {
+        // attempt to commit
+        apply()
+        // and close
+        close()
+        // all done
+        return
+    }
+    // track the typing without talking to the server
+    const change = evt => {
+        // record the text
+        setText(evt.target.value)
+        // all done
+        return
+    }
+    // the keys that commit, give up, or step
+    const keydown = evt => {
+        // commit
+        if (evt.key === "Enter") {
+            // quash the default
+            evt.preventDefault()
+            // an acceptable value goes out and the editor closes; an unacceptable one stays in
+            // the field, painted invalid
+            if (apply()) {
+                // done here
+                close()
+            }
+            // all done
+            return
+        }
+        // give up
+        if (evt.key === "Escape") {
+            // quash the default
+            evt.preventDefault()
+            // and close without committing
+            close()
+            // all done
+            return
+        }
+        // step
+        if (evt.key === "ArrowUp" || evt.key === "ArrowDown") {
+            // quash the default
+            evt.preventDefault()
+            // and nudge in the right direction
+            nudge(evt.key === "ArrowUp" ? 1 : -1)
+            // all done
+            return
+        }
+        // everything else is typing
+        return
+    }
+    // keep the pointer events of the field away from whatever lies under it
+    const swallow = evt => evt.stopPropagation()
+
+    // the field is centered where the label is, with room for a number longer than the label
+    const width = Math.max(rect.width, 9 * fontSize * 0.6)
+    const height = Math.max(rect.height, 1.4 * fontSize)
+    // mix my paint
+    const paint = {
+        // pin it over the label
+        position: "fixed",
+        left: rect.left + rect.width / 2 - width / 2,
+        top: rect.top + rect.height / 2 - height / 2,
+        width, height,
+        boxSizing: "border-box",
+        zIndex: 10,
+        // and dress it like the label
+        margin: 0,
+        padding: 0,
+        fontFamily: "inconsolata",
+        fontSize,
+        lineHeight: 1,
+        textAlign: "center",
+        color: valid ? theme.page.highlight : theme.page.danger,
+        backgroundColor: theme.page.shaded,
+        border: "none",
+        borderBottom: `1px solid ${valid ? theme.page.highlight : theme.page.danger}`,
+        outline: "none",
+    }
+    // and render, outside the slider so the field is neither transformed nor hidden with the
+    // decorative scale
+    return ReactDOM.createPortal(
+        <input ref={field} type="text" inputMode="decimal" spellCheck={false} autoComplete="off"
+            aria-label={name} aria-invalid={!valid} title={`type a new ${end} and press enter`}
+            value={text} style={paint}
+            onBlur={blur} onChange={change} onKeyDown={keydown}
+            onClick={swallow} onDoubleClick={swallow} onMouseDown={swallow}
+        />,
+        document.body,
+    )
+}
+
+
+// render a bound compactly, with enough digits to round trip the typical controller value
+const format = value => String(Number(value.toPrecision(6)))
+
+
+// end of file

--- a/ux/client/widgets/slider/editor.js
+++ b/ux/client/widgets/slider/editor.js
@@ -13,8 +13,8 @@ import ReactDOM from 'react-dom'
 import { theme } from "~/palette"
 
 
-// a text field that takes the place of an end label while its value is being edited by hand; it
-// is portalled to the document body and pinned over {rect}, the label's rectangle on the screen,
+// a text field that takes the place of a label while its value is being edited by hand; it is
+// rendered through a portal to the document body and pinned over {rect}, the label's rectangle,
 // so it sits on top of the label regardless of how the slider is transformed. it owns its
 // contents and talks to nobody until the user commits with {Enter} or by leaving the field;
 // {Escape} gives up, and the arrow keys step the bound, committing at once since each step is a

--- a/ux/client/widgets/slider/hitbox.js
+++ b/ux/client/widgets/slider/hitbox.js
@@ -1,0 +1,38 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// externals
+import React from 'react'
+import styled from 'styled-components'
+
+
+// an invisible rectangle behind a label that catches the pointer over the label's whole box;
+// browsers differ on how they hit test text, and some only count the glyphs themselves, so a
+// click between two characters would otherwise fall through to whatever lies underneath. the
+// label is centered on ({x}, {y}) with its baseline at {y}, {text} is what it shows, and
+// {fontSize} is its size in intrinsic units
+export const Hitbox = ({ x, y, text, fontSize }) => {
+    // a monospace glyph advances about half an em; add half an em of slack on each side
+    const width = (0.55 * text.length + 1) * fontSize
+    // the box covers the ascenders and a bit of descender
+    const height = 1.2 * fontSize
+    // render
+    return (
+        <Box x={x - width / 2} y={y - 0.9 * fontSize} width={width} height={height} />
+    )
+}
+
+
+// styling
+const Box = styled.rect`
+    fill: none;
+    stroke: none;
+    pointer-events: all;
+    cursor: text;
+`
+
+
+// end of file

--- a/ux/client/widgets/slider/label.js
+++ b/ux/client/widgets/slider/label.js
@@ -15,21 +15,33 @@ import { theme } from "~/palette"
 // local
 // hooks
 import { useConfig } from './useConfig'
-import { useMine } from './useMine'
-// components
-import { Editor } from './editor'
+import { useEditor } from './useEditor'
 
 
 // render a single label
 export const Label = ({ tick, value = null, setValue = null }) => {
     // unpack the geometry
     const { enabled, arrows, labels, labelPosition, tickPrecision, min, max, extent } = useConfig()
-    // and the scale, to size the editor's font like mine
-    const { ils } = useMine()
-    // a handle on my text node, to measure where i am on the screen
-    const node = React.useRef(null)
-    // the rectangle the editor is pinned over while my value is being edited; {null} otherwise
-    const [editing, setEditing] = React.useState(null)
+
+    // an end label of a slider with a hand-editable extent doubles as its editor
+    const end = extent === null ? null : (tick === min ? "min" : (tick === max ? "max" : null))
+    // unpack the extent configuration, if any
+    const { names = [], envelope = [null, null], resize = null } = extent ?? {}
+    // and the span of the picks
+    const [lowest, highest] = envelope
+    // the low end may move anywhere below the lowest pick, as long as the extent stays sane;
+    // similarly for the high end
+    const check = end === "min"
+        ? candidate => candidate < max && candidate <= lowest
+        : candidate => candidate > min && candidate >= highest
+    // committing one end keeps the other where it is
+    const commit = end === "min"
+        ? candidate => resize({ min: candidate, max })
+        : candidate => resize({ min, max: candidate })
+    // set up the editor
+    const { node, editing, open, editor } = useEditor({
+        name: names[end === "min" ? 0 : 1], end, value: tick, check, commit, fontSize,
+    })
 
     // check whether my value is the currently chosen one
     const selected = tick === value
@@ -39,8 +51,6 @@ export const Label = ({ tick, value = null, setValue = null }) => {
         return null
     }
 
-    // an end label of a slider with a hand-editable extent doubles as its editor
-    const end = extent === null ? null : (tick === min ? "min" : (tick === max ? "max" : null))
     // pick an implementation based on my state
     const Label = enabled ? (selected ? Selected : Enabled) : Disabled
 
@@ -66,63 +76,19 @@ export const Label = ({ tick, value = null, setValue = null }) => {
     }
     // when i am an editable end
     if (end !== null && enabled) {
-        // on double click, measure myself and open the editor over me
-        behaviors["onDoubleClick"] = evt => {
-            // suppress the placemat listener
-            evt.stopPropagation()
-            // and quash any side effects, e.g. text selection
-            evt.preventDefault()
-            // measure
-            const rect = node.current.getBoundingClientRect()
-            // and open the editor
-            setEditing({
-                left: rect.left, top: rect.top, width: rect.width, height: rect.height,
-            })
-            // all done
-            return
-        }
+        // on double click, open the editor over me
+        behaviors["onDoubleClick"] = open
         // tag me so drivers can find the affordance
         behaviors["data-pyre-widget"] = "slider"
         behaviors["data-pyre-widget-part"] = "bound"
         behaviors["data-pyre-bound"] = end
     }
 
-    // the editor, if open
-    let editor = null
-    // when it is
-    if (editing !== null) {
-        // unpack the extent configuration
-        const { names, envelope, resize } = extent
-        // and the span of the picks
-        const [lowest, highest] = envelope
-        // a keyboard step is one unit in the digit below the leading digit of the span, so
-        // that stepping produces round numbers at the scale of the slider
-        const span = max - min
-        const step = span > 0 ? Math.pow(10, Math.floor(Math.log10(span)) - 1) : 1
-        // the low end may move anywhere below the lowest pick, as long as the extent stays sane;
-        // similarly for the high end
-        const check = end === "min"
-            ? candidate => candidate < max && candidate <= lowest
-            : candidate => candidate > min && candidate >= highest
-        // committing one end keeps the other where it is
-        const commit = end === "min"
-            ? candidate => resize({ min: candidate, max })
-            : candidate => resize({ min, max: candidate })
-        // the editor closes by clearing the rectangle
-        const close = () => setEditing(null)
-        // build it, with a font as big as mine on the screen
-        editor = (
-            <Editor name={names[end === "min" ? 0 : 1]} end={end} value={tick} step={step}
-                check={check} commit={commit} rect={editing} fontSize={fontSize * ils} close={close}
-            />
-        )
-    }
-
     // render; while the editor is up, the label goes invisible so it does not show through
     return (
         <>
             <Label ref={node} {...labelPosition(tick)} {...behaviors}
-                visibility={editing === null ? "visible" : "hidden"}
+                visibility={editing ? "hidden" : "visible"}
             >
                 {tick.toFixed(tickPrecision)}
             </Label>

--- a/ux/client/widgets/slider/label.js
+++ b/ux/client/widgets/slider/label.js
@@ -15,12 +15,21 @@ import { theme } from "~/palette"
 // local
 // hooks
 import { useConfig } from './useConfig'
+import { useMine } from './useMine'
+// components
+import { Editor } from './editor'
 
 
 // render a single label
 export const Label = ({ tick, value = null, setValue = null }) => {
     // unpack the geometry
-    const { enabled, arrows, labels, labelPosition, tickPrecision } = useConfig()
+    const { enabled, arrows, labels, labelPosition, tickPrecision, min, max, extent } = useConfig()
+    // and the scale, to size the editor's font like mine
+    const { ils } = useMine()
+    // a handle on my text node, to measure where i am on the screen
+    const node = React.useRef(null)
+    // the rectangle the editor is pinned over while my value is being edited; {null} otherwise
+    const [editing, setEditing] = React.useState(null)
 
     // check whether my value is the currently chosen one
     const selected = tick === value
@@ -30,40 +39,111 @@ export const Label = ({ tick, value = null, setValue = null }) => {
         return null
     }
 
+    // an end label of a slider with a hand-editable extent doubles as its editor
+    const end = extent === null ? null : (tick === min ? "min" : (tick === max ? "max" : null))
     // pick an implementation based on my state
     const Label = enabled ? (selected ? Selected : Enabled) : Disabled
 
     // set up my behaviors
     const behaviors = {}
-    // when have a way to notify the client, am enabled, but not selected
+    // when i have a way to notify the client, am enabled, but not selected
     if (setValue != null && enabled && !selected) {
-        // on click, set the value
+        // on click, set the value; an editable end label gives up this shortcut, since a double
+        // click would trip it on the way to the editor, and the thumb can be dragged to the end
         behaviors["onClick"] = evt => {
             // suppress the placemat listener
             evt.stopPropagation()
+            // if i am an editable end
+            if (end !== null) {
+                // leave the value alone
+                return
+            }
             // set the value
             setValue(tick)
             // all done
             return
         }
     }
+    // when i am an editable end
+    if (end !== null && enabled) {
+        // on double click, measure myself and open the editor over me
+        behaviors["onDoubleClick"] = evt => {
+            // suppress the placemat listener
+            evt.stopPropagation()
+            // and quash any side effects, e.g. text selection
+            evt.preventDefault()
+            // measure
+            const rect = node.current.getBoundingClientRect()
+            // and open the editor
+            setEditing({
+                left: rect.left, top: rect.top, width: rect.width, height: rect.height,
+            })
+            // all done
+            return
+        }
+        // tag me so drivers can find the affordance
+        behaviors["data-pyre-widget"] = "slider"
+        behaviors["data-pyre-widget-part"] = "bound"
+        behaviors["data-pyre-bound"] = end
+    }
 
-    // render
+    // the editor, if open
+    let editor = null
+    // when it is
+    if (editing !== null) {
+        // unpack the extent configuration
+        const { names, envelope, resize } = extent
+        // and the span of the picks
+        const [lowest, highest] = envelope
+        // a keyboard step is one unit in the digit below the leading digit of the span, so
+        // that stepping produces round numbers at the scale of the slider
+        const span = max - min
+        const step = span > 0 ? Math.pow(10, Math.floor(Math.log10(span)) - 1) : 1
+        // the low end may move anywhere below the lowest pick, as long as the extent stays sane;
+        // similarly for the high end
+        const check = end === "min"
+            ? candidate => candidate < max && candidate <= lowest
+            : candidate => candidate > min && candidate >= highest
+        // committing one end keeps the other where it is
+        const commit = end === "min"
+            ? candidate => resize({ min: candidate, max })
+            : candidate => resize({ min, max: candidate })
+        // the editor closes by clearing the rectangle
+        const close = () => setEditing(null)
+        // build it, with a font as big as mine on the screen
+        editor = (
+            <Editor name={names[end === "min" ? 0 : 1]} end={end} value={tick} step={step}
+                check={check} commit={commit} rect={editing} fontSize={fontSize * ils} close={close}
+            />
+        )
+    }
+
+    // render; while the editor is up, the label goes invisible so it does not show through
     return (
-        <Label {...labelPosition(tick)} {...behaviors} >
-            {tick.toFixed(tickPrecision)}
-        </Label>
+        <>
+            <Label ref={node} {...labelPosition(tick)} {...behaviors}
+                visibility={editing === null ? "visible" : "hidden"}
+            >
+                {tick.toFixed(tickPrecision)}
+            </Label>
+            {editor}
+        </>
     )
 }
+
+
+// the font size of a label, in intrinsic units
+const fontSize = 32
 
 
 // styling
 // the base
 const Base = styled.text`
     font-family: inconsolata;
-    font-size: 32px;
+    font-size: ${fontSize}px;
     text-anchor: middle;
     cursor: default;
+    user-select: none;
 `
 
 
@@ -76,6 +156,10 @@ const Enabled = styled(Base)`
     & {
         fill: ${props => theme.page.normal};
         cursor: pointer;
+    }
+
+    &[data-pyre-widget-part="bound"] {
+        cursor: text;
     }
 
     &:hover {

--- a/ux/client/widgets/slider/label.js
+++ b/ux/client/widgets/slider/label.js
@@ -16,6 +16,8 @@ import { theme } from "~/palette"
 // hooks
 import { useConfig } from './useConfig'
 import { useEditor } from './useEditor'
+// components
+import { Hitbox } from './hitbox'
 
 
 // render a single label
@@ -84,16 +86,33 @@ export const Label = ({ tick, value = null, setValue = null }) => {
         behaviors["data-pyre-bound"] = end
     }
 
-    // render; while the editor is up, the label goes invisible so it does not show through
+    // what i show
+    const text = tick.toFixed(tickPrecision)
+    // and where
+    const position = labelPosition(tick)
+
+    // an editable end gets a hit box behind it, so a double click anywhere on it opens the
+    // editor; the behaviors go on the group so both the box and the text respond
+    if (end !== null && enabled) {
+        // render; while the editor is up, the label goes invisible so it does not show through
+        return (
+            <>
+                <g {...behaviors}>
+                    <Hitbox x={position.x} y={position.y} text={text} fontSize={fontSize} />
+                    <Label ref={node} {...position} visibility={editing ? "hidden" : "visible"}>
+                        {text}
+                    </Label>
+                </g>
+                {editor}
+            </>
+        )
+    }
+
+    // render
     return (
-        <>
-            <Label ref={node} {...labelPosition(tick)} {...behaviors}
-                visibility={editing ? "hidden" : "visible"}
-            >
-                {tick.toFixed(tickPrecision)}
-            </Label>
-            {editor}
-        </>
+        <Label ref={node} {...position} {...behaviors}>
+            {text}
+        </Label>
     )
 }
 
@@ -124,7 +143,7 @@ const Enabled = styled(Base)`
         cursor: pointer;
     }
 
-    &[data-pyre-widget-part="bound"] {
+    [data-pyre-widget-part="bound"] > & {
         cursor: text;
     }
 

--- a/ux/client/widgets/slider/markerLabel.js
+++ b/ux/client/widgets/slider/markerLabel.js
@@ -15,19 +15,27 @@ import { theme } from "~/palette"
 // local
 // hooks
 import { useConfig } from './useConfig'
+import { useEditor } from './useEditor'
 
 
-// render a single label at the marker position
-export const MarkerLabel = ({ value }) => {
+// render the label of a marker; when the slider is {editable}, a double click on the label
+// opens an editor over it that lets the user type the pick, with {check} accepting a candidate
+// and {commit} sending an accepted one
+export const MarkerLabel = ({ value, name = null, check = null, commit = null }) => {
     // unpack the geometry
-    const { enabled, markers, markerLabelPosition, markerPrecision } = useConfig()
+    const { enabled, markers, markerLabelPosition, markerPrecision, editable } = useConfig()
+    // i can be edited when the client asked for it and told me how
+    const active = editable && enabled && name !== null && check !== null && commit !== null
+    // set up the editor
+    const { node, editing, open, editor } = useEditor({
+        name: `${name} value`, end: "value", value: value ?? 0, check, commit, fontSize,
+    })
 
     // if the client does not want the value label
     if (!markers) {
         // bail
         return null
     }
-
     // if there is no value to show, there is nothing to label
     if (value == null) {
         // so render nothing
@@ -36,23 +44,44 @@ export const MarkerLabel = ({ value }) => {
 
     // pick an implementation based on my state
     const Label = enabled ? Enabled : Disabled
+    // set up my behaviors
+    const behaviors = {}
+    // when i can be edited
+    if (active) {
+        // on double click, open the editor over me
+        behaviors["onDoubleClick"] = open
+        // tag me so drivers can find the affordance
+        behaviors["data-pyre-widget"] = "slider"
+        behaviors["data-pyre-widget-part"] = "pick"
+        behaviors["data-pyre-pick"] = name
+    }
 
-    // render
+    // render; while the editor is up, the label goes invisible so it does not show through
     return (
-        <Label {...markerLabelPosition(value)} >
-            {value.toFixed(markerPrecision)}
-        </Label>
+        <>
+            <Label ref={node} {...markerLabelPosition(value)} {...behaviors}
+                visibility={editing ? "hidden" : "visible"}
+            >
+                {value.toFixed(markerPrecision)}
+            </Label>
+            {editor}
+        </>
     )
 }
+
+
+// the font size of a marker label, in intrinsic units
+const fontSize = 28
 
 
 // styling
 // the base
 const Base = styled.text`
     font-family: inconsolata;
-    font-size: 28px;
+    font-size: ${fontSize}px;
     text-anchor: middle;
     cursor: default;
+    user-select: none;
 `
 
 
@@ -62,7 +91,17 @@ const Disabled = styled(Base)`
 
 
 const Enabled = styled(Base)`
-    fill: ${props => theme.page.normal};
+    & {
+        fill: ${props => theme.page.normal};
+    }
+
+    &[data-pyre-widget-part="pick"] {
+        cursor: text;
+    }
+
+    &[data-pyre-widget-part="pick"]:hover {
+        fill: ${props => theme.page.highlight};
+    }
 `
 
 

--- a/ux/client/widgets/slider/markerLabel.js
+++ b/ux/client/widgets/slider/markerLabel.js
@@ -16,6 +16,8 @@ import { theme } from "~/palette"
 // hooks
 import { useConfig } from './useConfig'
 import { useEditor } from './useEditor'
+// components
+import { Hitbox } from './hitbox'
 
 
 // render the label of a marker; when the slider is {editable}, a double click on the label
@@ -56,16 +58,33 @@ export const MarkerLabel = ({ value, name = null, check = null, commit = null })
         behaviors["data-pyre-pick"] = name
     }
 
-    // render; while the editor is up, the label goes invisible so it does not show through
+    // what i show
+    const text = value.toFixed(markerPrecision)
+    // and where
+    const position = markerLabelPosition(value)
+
+    // an editable label gets a hit box behind it, so a double click anywhere on it opens the
+    // editor; the behaviors go on the group so both the box and the text respond
+    if (active) {
+        // render; while the editor is up, the label goes invisible so it does not show through
+        return (
+            <>
+                <g {...behaviors}>
+                    <Hitbox x={position.x} y={position.y} text={text} fontSize={fontSize} />
+                    <Label ref={node} {...position} visibility={editing ? "hidden" : "visible"}>
+                        {text}
+                    </Label>
+                </g>
+                {editor}
+            </>
+        )
+    }
+
+    // render
     return (
-        <>
-            <Label ref={node} {...markerLabelPosition(value)} {...behaviors}
-                visibility={editing ? "hidden" : "visible"}
-            >
-                {value.toFixed(markerPrecision)}
-            </Label>
-            {editor}
-        </>
+        <Label ref={node} {...position}>
+            {text}
+        </Label>
     )
 }
 
@@ -95,11 +114,11 @@ const Enabled = styled(Base)`
         fill: ${props => theme.page.normal};
     }
 
-    &[data-pyre-widget-part="pick"] {
+    [data-pyre-widget-part="pick"] > & {
         cursor: text;
     }
 
-    &[data-pyre-widget-part="pick"]:hover {
+    [data-pyre-widget-part="pick"]:hover > & {
         fill: ${props => theme.page.highlight};
     }
 `

--- a/ux/client/widgets/slider/range.js
+++ b/ux/client/widgets/slider/range.js
@@ -37,7 +37,13 @@ export const Range = ({ value, setValue, ...config }) => {
 // render the controller
 const Controller = ({ value, setValue }) => {
     // the client names the two thumbs (e.g. "linear low" / "linear high"); fall back to nothing
-    const { names = [] } = useConfig()
+    const { names = [], min, max } = useConfig()
+    // a typed low pick may go anywhere between the lower limit and the high pick, and a typed
+    // high pick anywhere between the low pick and the upper limit; the other pick stays put
+    const checkLow = candidate => candidate >= min && candidate <= value[1]
+    const commitLow = candidate => setValue(old => [candidate, old[1]])
+    const checkHigh = candidate => candidate >= value[0] && candidate <= max
+    const commitHigh = candidate => setValue(old => [old[0], candidate])
     // render; the axis, ticks, and tick labels are a decorative scale that duplicates the
     // accessible thumbs (role=slider, aria-valuenow), so they are hidden from assistive tech
     return (
@@ -50,9 +56,9 @@ const Controller = ({ value, setValue }) => {
             </g>
             <Interval value={value} />
             <Marker id={0} value={value[0]} name={names[0]} />
-            <MarkerLabel value={value[0]} />
+            <MarkerLabel value={value[0]} name={names[0]} check={checkLow} commit={commitLow} />
             <Marker id={1} value={value[1]} name={names[1]} />
-            <MarkerLabel value={value[1]} />
+            <MarkerLabel value={value[1]} name={names[1]} check={checkHigh} commit={commitHigh} />
         </Rangemat>
     )
 }

--- a/ux/client/widgets/slider/slider.js
+++ b/ux/client/widgets/slider/slider.js
@@ -10,6 +10,8 @@ import React from 'react'
 // locals
 // context
 import { Provider } from './context'
+// hooks
+import { useConfig } from './useConfig'
 // components
 import { Axis } from './axis'
 import { Labels } from './labels'
@@ -33,6 +35,12 @@ export const Slider = ({ value, setValue, ...config }) => {
 
 // lay out the control
 const Controller = ({ value, setValue }) => {
+    // the client names the thumb; the limits bound a typed pick
+    const { label = null, min, max } = useConfig()
+    // a typed pick may go anywhere between the limits
+    const check = candidate => candidate >= min && candidate <= max
+    // and goes straight to the client
+    const commit = candidate => setValue(candidate)
     // render; the axis, ticks, and tick labels are a decorative scale that duplicates the
     // accessible thumb (role=slider, aria-valuenow), so they are hidden from assistive tech --
     // they stay clickable for mouse users. the {Marker} thumb stays in the accessible tree.
@@ -45,7 +53,7 @@ const Controller = ({ value, setValue }) => {
                 <Labels value={value} setValue={setValue} />
             </g>
             <Marker value={value} />
-            <MarkerLabel value={value} />
+            <MarkerLabel value={value} name={label} check={check} commit={commit} />
         </Simplemat>
     )
 }

--- a/ux/client/widgets/slider/useConfig.js
+++ b/ux/client/widgets/slider/useConfig.js
@@ -19,7 +19,7 @@ export const useConfig = () => {
     const {
         enabled, label, names, direction,
         arrows, labels, markers,
-        min, max, major, minor, tickPrecision, markerPrecision, extent,
+        min, max, major, minor, tickPrecision, markerPrecision, extent, editable,
         intervalPosition,
         labelPosition, majorPosition, minorPosition, marker, markerPosition, markerLabelPosition,
     } = React.useContext(Context)
@@ -28,7 +28,7 @@ export const useConfig = () => {
     return {
         enabled, label, names, direction,
         arrows, labels, markers,
-        min, max, major, minor, tickPrecision, markerPrecision, extent,
+        min, max, major, minor, tickPrecision, markerPrecision, extent, editable,
         intervalPosition, labelPosition, majorPosition, minorPosition,
         marker, markerPosition, markerLabelPosition,
     }

--- a/ux/client/widgets/slider/useConfig.js
+++ b/ux/client/widgets/slider/useConfig.js
@@ -19,7 +19,7 @@ export const useConfig = () => {
     const {
         enabled, label, names, direction,
         arrows, labels, markers,
-        min, max, major, minor, tickPrecision, markerPrecision,
+        min, max, major, minor, tickPrecision, markerPrecision, extent,
         intervalPosition,
         labelPosition, majorPosition, minorPosition, marker, markerPosition, markerLabelPosition,
     } = React.useContext(Context)
@@ -28,7 +28,7 @@ export const useConfig = () => {
     return {
         enabled, label, names, direction,
         arrows, labels, markers,
-        min, max, major, minor, tickPrecision, markerPrecision,
+        min, max, major, minor, tickPrecision, markerPrecision, extent,
         intervalPosition, labelPosition, majorPosition, minorPosition,
         marker, markerPosition, markerLabelPosition,
     }

--- a/ux/client/widgets/slider/useEditor.js
+++ b/ux/client/widgets/slider/useEditor.js
@@ -1,0 +1,65 @@
+// -*- web -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// externals
+import React from 'react'
+
+// locals
+// hooks
+import { useConfig } from './useConfig'
+import { useMine } from './useMine'
+// components
+import { Editor } from './editor'
+
+
+// the machinery shared by the labels that double as editors of the number they show: {name} is
+// the accessible name of the field, {end} says what it edits for the tooltip, {value} seeds it,
+// {check} accepts a candidate, {commit} sends an accepted one, and {fontSize} is the size of the
+// label in intrinsic units, so the field can match it on the screen
+export const useEditor = ({ name, end, value, check, commit, fontSize }) => {
+    // the limits set the scale of a keyboard step
+    const { min, max } = useConfig()
+    // and the slider scale sets the size of the font on the screen
+    const { ils } = useMine()
+    // a handle on the label's text node, to measure where it is on the screen
+    const node = React.useRef(null)
+    // the rectangle the editor is pinned over while it is up; {null} otherwise
+    const [rect, setRect] = React.useState(null)
+
+    // measure the label and open the editor over it
+    const open = evt => {
+        // suppress the placemat listener
+        evt.stopPropagation()
+        // and quash any side effects, e.g. text selection
+        evt.preventDefault()
+        // measure
+        const box = node.current.getBoundingClientRect()
+        // and open
+        setRect({ left: box.left, top: box.top, width: box.width, height: box.height })
+        // all done
+        return
+    }
+    // close the editor by dropping the rectangle; stable, since the editor listens with it
+    const close = React.useCallback(() => setRect(null), [])
+
+    // a keyboard step is one unit in the digit below the leading digit of the span, so that
+    // stepping produces round numbers at the scale of the slider
+    const span = max - min
+    const step = span > 0 ? Math.pow(10, Math.floor(Math.log10(span)) - 1) : 1
+
+    // the editor, when it is up, with a font as big as the label on the screen
+    const editor = rect === null ? null : (
+        <Editor name={name} end={end} value={value} step={step}
+            check={check} commit={commit} rect={rect} fontSize={fontSize * ils} close={close}
+        />
+    )
+
+    // hand back the handle, the state, the opener, and the element
+    return { node, editing: rect !== null, open, editor }
+}
+
+
+// end of file

--- a/ux/client/widgets/slider/useMine.js
+++ b/ux/client/widgets/slider/useMine.js
@@ -17,11 +17,11 @@ import { Context } from "./context"
 export const useMine = () => {
     // pull what i need from {context}
     const {
-        bboxMine, mainMine, crossMine,
+        bboxMine, mainMine, crossMine, ils,
     } = React.useContext(Context)
 
     // and publish it
-    return { bboxMine, mainMine, crossMine, }
+    return { bboxMine, mainMine, crossMine, ils }
 }
 
 


### PR DESCRIPTION
The viz controllers can now be set by typing numbers. A double click on either end label of a slider opens a numeric field in its place for the display bounds, the `min` and `max` that frame the slider. A double click on a marker label opens the same field for the pick under it, `low` or `high` for a range and `value` for a value controller. An accepted edit of the bounds pins the controller so that accumulated statistics no longer move them, and a lock on the controller header releases it again. Editing the bounds never moves the picks, so the rendered pixels are unchanged and no tiles are refetched; editing a pick goes through the same path a drag does.

Closes #15. Closes #14.

## Controllers

`Controller.resize(min, max)` adopts hand-set bounds. It refuses an inverted or degenerate extent and one that would encroach on the picks; a refusal leaves the controller untouched. An accepted extent clears `auto`, so neither `autotune` nor `widen` can move the bounds afterwards. `accommodates(min, max)` exposes the check on its own.

`auto` joins `min` and `max` in the controller's `cosmetic` set, so pinning or releasing a controller leaves tile identities alone: it changes what statistics may do later, not the pixels, and must not defeat the tile cache. `tests/qed.pkg/identity.py` checks this for the bounds and the flag.

`pin()` clears `auto`. `unpin(stats)` sets it and, when statistics are supplied, widens the bounds to them at once, because a dataset that has already been surveyed in full will never send another report. Each flavour reports the envelope of its picks: `low` and `high` for the two range kinds, the single `value` for the value controller. Statistics never scale a value controller, so releasing one only flips the flag.

## Store

`View.vizResizeController` applies a hand edit and reports a refusal on the `qed.ux.controllers` error channel, which reaches the browser as a failed mutation. `View.vizSetControllerAuto` pins or releases a controller; `Store.vizSetControllerAuto` looks up the statistics accumulated for the dataset on display and hands them along. Neither path rolls the session token.

`View.vizUpdateController`, the drag path, still carries the extent along with the picks. The picks always land; the extent lands only if it accommodates them, and is otherwise ignored with a warning. The drag path never pins.

## GraphQL

The `Controller` interface and both concrete types expose `auto`. Four mutations are added, following the existing per-kind pattern:

- `viewRangeResize` and `viewValueResize`, with input `{viewport, channel, controller, min, max}`
- `viewRangeAutoSet` and `viewValueAutoSet`, with input `{viewport, channel, controller, auto}`

Every controller mutation payload now returns `auto`, so a reset or an update refreshes the lock.

## Client

The editor lives in the slider widget. The slider takes an `extent` option carrying the accessible names of the two ends, the envelope of the picks, and a resize callback. The end labels open the editor on a double click and are tagged `data-pyre-widget-part="bound"` with `data-pyre-bound="min|max"`. On the value slider the end labels give up their click-to-jump, since a double click would trip it on the way to the editor; the middle label keeps it, and the range slider had none.

Each editable label sits in a group with an invisible hit rectangle behind it, because browsers differ on how they hit test SVG text: WebKit counts only the glyphs, so a double click between two characters would otherwise fall through to the placemat. The editor is a plain `<input>` rendered through a portal to the document body and pinned over the label's measured rectangle, with its font sized from the slider's own scale. The label is hidden underneath while the field is up. The field owns its contents and sends nothing while the user types: Enter commits and closes, Escape closes without committing, blur commits when it can and closes either way, and the arrow keys step the bound by one unit in the digit below the span's leading digit, committing at once since each step is a complete number. The same enclosure rule the server enforces runs client side first, and a field that cannot be committed is painted in the palette's danger colour with `aria-invalid`. A window scroll or resize closes the editor so it cannot be left floating over the wrong spot.

The marker labels above the thumbs open the same editor for the picks when the slider is configured `editable`, which the viz controllers are and the zoom slider is not. A typed low pick is accepted anywhere between the lower limit and the high pick, a typed high pick between the low pick and the upper limit, and a typed value between the two limits. The commit goes through the slider's `setValue`, so the controller sends it the way it sends a drag, with one difference: the controller suppresses reconciliation with the server only while a pointer button is down, so a typed pick, which has no drag to protect, adopts the server's echo at once. The editing machinery shared by the two kinds of label lives in `useEditor.js`.

The lock on the controller header, `viz/controls/viz/auto.js`, is a toggle whose `aria-pressed` reflects the flag: an open lock means the controller follows the data, a closed one means it is pinned. The `Locked` and `Unlocked` shapes are redrawn after the Feather icon set (MIT) at 80% of the shape box; they had no other users.

## Automation surface

`controllers()` reports `auto`. `range.resize`, `value.resize`, `range.setAuto`, and `value.setAuto` are added; `doc/automation-surface.md` documents them.

The editor was exercised under Chromium by the suite and under WebKit 26.4 by hand: opening on a double click, typing a bound, committing with Enter, and the value reaching the server.

## Tests

- `tests/qed.pkg/resize.py`: the resize rules per flavour, pinning, releasing with and without statistics.
- `tests/qed.pkg/extent.py`: the store paths against the local fixture, including the refusals, the session token staying put, and a release catching up with seeded statistics.
- `api/contract.spec.ts`: the facade round trip for resize, refusal, pin, and release.
- `behavior/controller-extent.spec.ts`: a bound typed one keystroke at a time reaches the server only on Enter, pins the controller, and the lock releases it; an encroaching bound is flagged before it is sent and Escape closes the editor with the server value intact; a pick typed into a marker label is flagged outside the limits, moves the thumb on a second client once committed, and leaves the flag alone.
