### PR TITLE
qed.controllers: an all-zero raster can be displayed

### DIFF
--- a/doc/statistics.md
+++ b/doc/statistics.md
@@ -175,7 +175,12 @@ These are the rules the current code enforces, and that any change must preserve
    line-interleaved bands. `autotune(stats=None)` is a no-op — in `Controller.autotune` for
    every leaf controller, and in the three isce2 unwrapped channels that index before
    delegating — so a dataset nobody has measured keeps its configured values instead of
-   raising. Any new shape-sensitive autotuner must carry the same guard.
+   raising. Any new shape-sensitive autotuner must carry the same guard. A sample with no
+   spread — a raster that is all zeros, or all one value — is real data, not fill, and the
+   autotuners cope with it quietly: a log range keeps its configured values, since there is
+   nothing positive to take a log of, and a linear range pretends the data spans a unit
+   interval around its value, since a range with no width cannot render. The probe warns
+   once, on `qed.readers.statistics`, that the range is a guess. This is issue #81.
 5. **`GDALBand.render` takes its range from the controller.** It used to read `self.stats`
    on every tile, which silently ignored the client's settings; it now reads `low` and
    `high` off the channel's `range` controller, which is what the worker installs the

--- a/pkg/controllers/LinearRange.py
+++ b/pkg/controllers/LinearRange.py
@@ -53,6 +53,15 @@ class LinearRange(Controller, family="qed.controllers.linearrange"):
         low, mean, high = stats
         # compute the spread
         spread = high - low
+        # a sample with no spread, e.g. one taken from a raster that is all zeros, would
+        # collapse the picks onto each other and the bounds onto the picks, and a range with
+        # no width cannot render; pretend the data spans a unit interval around its value
+        if spread <= 0:
+            # a unit wide
+            spread = 1.0
+            # centered on the value
+            low = mean - spread / 2
+            high = mean + spread / 2
 
         # set the initial guess for the low value
         self.low = low

--- a/pkg/controllers/LogRange.py
+++ b/pkg/controllers/LogRange.py
@@ -55,9 +55,15 @@ class LogRange(Controller, family="qed.controllers.logrange"):
 
         # unpack the stats
         low, mean, high = stats
-        # if low is too small
-        if low / high < 1e-3:
-            # adjust it
+        # a sample with nothing positive in it, e.g. one taken from a raster that is all
+        # zeros, has nothing to teach a log scale; the configured values stay in place, and
+        # the accumulated statistics will widen the bounds if a tile ever finds something
+        if high <= 0:
+            # so leave things alone
+            return
+        # protect the low end from zeros and excessive dynamic range
+        if low <= 0 or low / high < 1e-3:
+            # by clipping it
             low = high / 1e3
 
         # we want to be conservative, as this logic is only supposed to make sure that

--- a/pkg/readers/probes.py
+++ b/pkg/readers/probes.py
@@ -74,7 +74,23 @@ def probe(dataset, stops: int = 4) -> tuple:
         # linear channel cannot render without one
         return 0.0, 0.5, 1.0
 
-    # otherwise, report what the windows found
+    # a raster whose every sampled cell holds the same value, e.g. one that is all zeros,
+    # has data but no spread; the controllers cope, but the user should know the range is a
+    # guess, just as for a raster that holds nothing at all
+    if low == high:
+        # make a channel
+        channel = journal.warning("qed.readers.statistics")
+        # complain
+        channel.line(f"found no spread in '{dataset.pyre_name}'")
+        channel.line(
+            f"sampled {len(origins)} windows of {span} across an extent of {shape}"
+        )
+        channel.line(f"and every cell that held data held {low}")
+        channel.line(f"the display range is a guess until a tile finds something else")
+        # flush
+        channel.log()
+
+    # report what the windows found
     return low, total / cells, high
 
 

--- a/tests/qed.pkg/constant.py
+++ b/tests/qed.pkg/constant.py
@@ -1,0 +1,81 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Check that a raster whose every cell holds the same value, e.g. one that is all zeros, tunes
+its controllers to a range that can render, instead of dividing by zero or collapsing the
+picks onto each other; this is issue #81
+"""
+
+# externals
+import tempfile
+
+# support
+import journal
+import pyre
+import qed
+
+# the probe reports the lack of spread on a channel that would otherwise break the silence
+journal.warning("qed.readers.statistics").device = journal.trash()
+
+# a constant sample, the shape the probe hands out
+zeros = (0.0, 0.0, 0.0)
+
+# a log range controller has nothing to learn from it
+log = qed.controllers.logRange(name="constant_log")
+# remember its configured values
+configured = (log.min, log.low, log.high, log.max)
+# tuning does not raise
+log.autotune(stats=zeros)
+# and leaves the configuration alone
+assert (log.min, log.low, log.high, log.max) == configured
+# a sample with a zero floor but a positive ceiling is fine: the floor gets clipped
+log.autotune(stats=(0.0, 0.5, 2.0))
+assert log.min < log.low < log.high < log.max
+
+# a linear range controller pretends the data spans a unit interval around the value
+linear = qed.controllers.linearRange(name="constant_linear")
+# tuning does not raise
+linear.autotune(stats=zeros)
+# the picks are distinct and bracket the value
+assert linear.low < 0.0 < linear.high
+assert linear.high - linear.low == 1.0
+# and the bounds enclose the picks with room to move
+assert linear.min < linear.low and linear.high < linear.max
+# the same holds away from zero
+linear.autotune(stats=(3.0, 3.0, 3.0))
+assert linear.low < 3.0 < linear.high
+assert linear.min < linear.low and linear.high < linear.max
+
+# an all-zero raster, the way a user would meet one: a 65x65 complex file of nothing
+scratch = pyre.primitives.path(tempfile.mkdtemp(prefix="qed_constant_"))
+# the fixture
+fixture = scratch / "zeros.dat"
+# c16 cells are sixteen bytes each
+fixture.open(mode="wb").write(bytes(65 * 65 * 16))
+# open it
+dataset = qed.readers.native.datasets.mmap(
+    name="zeros", uri=f"file:{fixture}", cell="c16", shape=(65, 65)
+)
+# measure it, the way the blocking open path does; this used to divide by zero
+stats = dataset.measure()
+# the probe reports what it found
+assert stats == zeros
+# and every channel can render a tile of it
+for name in dataset.channels:
+    # get the pipeline
+    pipeline = dataset.channel(name=name)
+    # render
+    tile = dataset.render(channel=pipeline, zoom=(0, 0), origin=(0, 0), shape=(64, 64))
+    # and check that a bitmap came back
+    assert len(bytes(memoryview(tile))) > 0
+# clean up
+fixture.unlink()
+scratch.rmdir()
+
+
+# end of file


### PR DESCRIPTION
A raster whose every cell holds the same value, an all-zero image being the common case, can now be opened and displayed. The seed statistics of such a raster are a triple with no spread, and the autotuners used to divide by zero on it, which since the staging work has meant the source ends first contact in the `failed` standing rather than crashing the server.

Closes #81.

## Controllers

`LogRange._autotune` returns without touching the configuration when the sample has nothing positive in it, since there is nothing to take a log of; this mirrors the guard `_widen` already had. A zero floor under a positive ceiling is clipped before the ratio, as `_widen` already did, instead of being divided.

`LinearRange._autotune` treats a sample with no spread as a unit interval centred on its value. Without this the picks collapsed onto each other and the bounds onto the picks, and the normalizer in the C++ pipelines divides by the width of the pick range with no guard, so the collapsed range would have rendered NaN pixels rather than an image.

Neither controller reports anything. The accumulated statistics widen the bounds as usual once a tile finds data with spread, which covers the case the issue raises of a presumed-zero image that holds values the seed did not see.

## Probe

`qed.readers.probe` warns once, on `qed.readers.statistics`, when every sampled cell holds the same value, alongside its existing warning for a raster that holds nothing but fill. The two cases are distinct: fill is the absence of data and the probe invents a range for it, while a constant raster is data, and the probe reports it as measured. The readers that seed themselves without the probe, GDAL and isce2, feed the same guarded autotuners, so they are covered for the failure; only the warning is probe-specific.

## Documentation

Invariant 4 of `doc/statistics.md` records the rule for samples with no spread.

## Tests

`tests/qed.pkg/constant.py` tunes both controller flavours against constant samples, then synthesizes a 65 by 65 all-zero complex file, opens it as a memory-mapped dataset, measures it the way the blocking open path does, and renders a tile from every channel.
