### PR TITLE
a missing extension is named rather than tripped over

### DIFF
--- a/pkg/exceptions.py
+++ b/pkg/exceptions.py
@@ -15,4 +15,26 @@ class QEDError(PyreError):
     """
 
 
+# raised when a computation needs the extension and it is not there
+class ExtensionError(QEDError):
+    """
+    Exception raised when the qed extension is needed and is not available
+
+    The message is complete on its own, since it may travel back from a crew member as the
+    reason a data product could not be staged
+    """
+
+    # public data
+    description = "the qed extension is not available: {0.reason}"
+
+    # metamethods
+    def __init__(self, reason, **kwds):
+        # chain up
+        super().__init__(**kwds)
+        # save the reason
+        self.reason = reason
+        # all done
+        return
+
+
 # end of file

--- a/pkg/ext/__init__.py
+++ b/pkg/ext/__init__.py
@@ -20,9 +20,29 @@ try:
     # pull the extension module
     from . import qed as libqed
 # if this fails
-except ImportError:
+except ImportError as error:
     # indicate the bindings are not accessible
     libqed = None
+    # remember why, for whoever has to explain a failure downstream: a server without its
+    # extension declines to come up, and a product without it cannot read its cells, and both
+    # quote this
+    libqed_error = str(error)
+    # leave a note for the curious; not a warning, since a command line panel that never
+    # renders, e.g. the one that generates the schema while the extension is still being built,
+    # must be able to carry on quietly
+    import journal
+
+    # make a channel
+    channel = journal.debug("qed.ext")
+    # complain
+    channel.line("the qed extension could not be imported")
+    channel.line(f"{error}")
+    # flush
+    channel.log()
+# if it succeeds
+else:
+    # there is no failure to explain
+    libqed_error = None
 
 # check whether
 try:

--- a/pkg/nexus/Server.py
+++ b/pkg/nexus/Server.py
@@ -54,6 +54,20 @@ class Server(http, family="qed.nexus.servers.http"):
         """
         Register with the nexus and wire my fleet into the shared event loop
         """
+        # the extension, whose absence the package only warns about
+        from .. import ext
+
+        # a server that cannot render must not come up and serve a catalog it will fail on
+        if ext.libqed is None:
+            # make a channel
+            channel = journal.error("qed.nexus.server")
+            # complain, quoting the loader
+            channel.line("the qed extension is not available, so no dataset can be rendered")
+            channel.line(f"{ext.libqed_error}")
+            # flush; the channel is fatal unless the user has said otherwise
+            channel.log()
+            # in which case, decline to activate
+            return
         # chain up to grab a port and build the event hub
         super().activate(app=app, dispatcher=dispatcher)
         # hold on to the application; it is the only thing in reach of everything the

--- a/pkg/readers/nisar/products/Product.py
+++ b/pkg/readers/nisar/products/Product.py
@@ -66,6 +66,14 @@ class Product(
         if cell is None:
             # there is no kernel either; whoever needs one must decode first
             return None
+        # the kernels live in the extension; its absence must be named rather than tripped
+        # over, since an attribute error raised here would be reported as the absence of
+        # this very property
+        if qed.libqed is None:
+            # complain, quoting the loader
+            raise qed.exceptions.ExtensionError(
+                reason=f"{qed.ext.libqed_error}; the cells of '{self.pyre_name}' cannot be read"
+            )
         # otherwise, hand back the set that matches
         return getattr(qed.libqed.nisar.cells, cell, None)
 

--- a/tests/qed.pkg/extension.py
+++ b/tests/qed.pkg/extension.py
@@ -1,0 +1,86 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Check that a missing extension is named rather than tripped over: the kernels of a product
+raise an error whose message quotes the loader, and the server declines to come up
+"""
+
+# externals
+import os
+
+# support
+import journal
+import qed
+
+# the error is one of ours
+assert issubclass(qed.exceptions.ExtensionError, qed.exceptions.QEDError)
+
+# the NISAR fixture; part of the shared test data tree
+product = os.path.join(os.path.dirname(__file__), "..", "data", "nisar", "gslc.h5")
+# if it has not been generated
+if not os.path.exists(product):
+    # there is nothing more to check
+    raise SystemExit(0)
+
+# a reader over it
+reader = qed.readers.nisar.gslc(name="ext_gslc", uri=product)
+# make first contact
+reader.open()
+# and grab a dataset
+dataset, *_ = reader.datasets
+# with the extension in place, the kernels are there
+assert dataset.kernels is not None
+
+# take the extension away, the way a failed import leaves things: the package and its
+# extension module both point at nothing, and the reason is on record
+libqed, reason = qed.libqed, qed.ext.libqed_error
+qed.libqed = qed.ext.libqed = None
+qed.ext.libqed_error = "undefined symbol: planted"
+# carefully
+try:
+    # the kernels name the condition, quoting the loader and naming the product
+    try:
+        # ask
+        dataset.kernels
+    # the answer is an error of ours, not the absence of the property
+    except qed.exceptions.ExtensionError as error:
+        # with a message complete on its own
+        assert "undefined symbol: planted" in str(error)
+        assert "ext_gslc" in str(error)
+    # anything else is a failure
+    else:
+        # complain
+        assert False, "a missing extension went unnoticed"
+
+    # the server declines to come up; its error channel is fatal by default
+    server = qed.nexus.server(name="ext_server")
+    # attempt to
+    try:
+        # activate it; the refusal comes before any port is bound
+        server.activate(app=None, dispatcher=None)
+    # the refusal is an application error
+    except journal.ApplicationError:
+        # as expected
+        pass
+    # anything else is a failure
+    else:
+        # complain
+        assert False, "a server without its extension came up"
+    # and nothing was built
+    assert server.fleet is None
+# whatever happens
+finally:
+    # restore the extension
+    qed.libqed = qed.ext.libqed = libqed
+    qed.ext.libqed_error = reason
+
+# with the extension back, the kernels are there again
+assert dataset.kernels is not None
+
+
+# end of file


### PR DESCRIPTION
A missing extension is named rather than tripped over.

## The failure this addresses

When the compiled module fails to import, the package sets `libqed` to `None` and says nothing. The first use is the `kernels` property of a product, on a crew member during the survey; it reaches into `None`, raises an attribute error, and pyre's component lookup reports that as the property being absent. Staging then fails with "no attribute `kernels`", a message that says nothing about the cause. In the case that prompted this, the extension had been linked without `libpyre-h5`, and the loader's message named the missing symbol.

## The change

- `pkg/ext/__init__.py` keeps the loader's message in `libqed_error` when the import fails, and leaves a note on the `qed.ext` debug channel. It is a note rather than a warning because command line panels that never render, such as the one that generates the schema during a build while the extension does not yet exist, carry on quietly.
- `qed.exceptions.ExtensionError`, derived from `QEDError`, names the condition. The `kernels` property of a product raises it, quoting the loader and naming the product, with a message complete on its own, since it travels back from the crew as the reason a product could not be staged. Deriving from `QEDError` rather than an attribute error is what keeps the component lookup from masking it. A cell type the extension has no kernels for still yields `None`, which the pyramid relies on for encoded products.
- The server declines to activate without the extension: a fatal error on `qed.nexus.server`, raised before any port is bound, quoting the loader. A server that cannot render must not come up and serve a catalog it will fail on.

## Tests

`extension` plants a missing extension, the way a failed import leaves things, and checks that the kernels raise the new error with the loader's message and the product's name, that the server refuses to activate, and that both recover when the extension is restored.
